### PR TITLE
Update GitHub user to awslabs

### DIFF
--- a/.changeset/clean-spoons-deliver.md
+++ b/.changeset/clean-spoons-deliver.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Update GitHub user to awslabs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ information to effectively respond to your bug report or contribution.
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/trivikr/aws-sdk-js-codemod/issues), or [recently closed](https://github.com/trivikr/aws-sdk-js-codemod/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
+When filing an issue, please check [existing open](https://github.com/awslabs/aws-sdk-js-codemod/issues), or [recently closed](https://github.com/awslabs/aws-sdk-js-codemod/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 - A reproducible test case or series of steps
@@ -40,7 +40,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 ## Finding contributions to work on
 
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/trivikr/aws-sdk-js-codemod/labels/help%20wanted) issues is a great place to start.
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/awslabs/aws-sdk-js-codemod/labels/help%20wanted) issues is a great place to start.
 
 ## Code of Conduct
 
@@ -54,6 +54,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/trivikr/aws-sdk-js-codemod/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/awslabs/aws-sdk-js-codemod/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "v3",
     "migration"
   ],
-  "homepage": "https://github.com/trivikr/aws-sdk-js-codemod",
+  "homepage": "https://github.com/awslabs/aws-sdk-js-codemod",
   "license": "MIT-0",
   "author": "Kamat, Trivikram <trivikr.dev@gmail.com>",
   "files": [
@@ -24,7 +24,7 @@
   "bin": "bin/aws-sdk-js-codemod",
   "repository": {
     "type": "git",
-    "url": "https://github.com/trivikr/aws-sdk-js-codemod.git"
+    "url": "https://github.com/awslabs/aws-sdk-js-codemod.git"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Reason: The `aws-sdk-js-codemod` repo is now in `awslabs` org.