### PR TITLE
fix: use require for custom changelog script

### DIFF
--- a/.changeset/brown-worms-bake.md
+++ b/.changeset/brown-worms-bake.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Use require for custom changelog script

--- a/.changeset/changelog.js
+++ b/.changeset/changelog.js
@@ -1,4 +1,4 @@
-import { config } from "dotenv";
+const { config } = require("dotenv");
 
 config();
 
@@ -31,4 +31,4 @@ const getReleaseLine = (changeset, _type) => {
   }`;
 };
 
-export { getReleaseLine, getDependencyReleaseLine };
+module.exports = { getReleaseLine, getDependencyReleaseLine };

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.7.0/schema.json",
-  "changelog": "./changelog.mjs",
+  "changelog": "./changelog.js",
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
Action fails with error:
```console
error Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/.changeset/changelog.mjs not supported.
```

GH Action: https://github.com/awslabs/aws-sdk-js-codemod/runs/5687489707