### PR TITLE
chore(deps-dev): add dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/node": "16.11.26",
     "@typescript-eslint/eslint-plugin": "5.14.0",
     "@typescript-eslint/parser": "5.14.0",
+    "dotenv": "16.0.0",
     "eslint": "8.10.0",
     "eslint-plugin-simple-import-sort": "7.0.0",
     "jest": "27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1837,6 +1837,7 @@ __metadata:
     "@types/node": 16.11.26
     "@typescript-eslint/eslint-plugin": 5.14.0
     "@typescript-eslint/parser": 5.14.0
+    dotenv: 16.0.0
     eslint: 8.10.0
     eslint-plugin-simple-import-sort: 7.0.0
     jest: 27.5.1
@@ -2723,6 +2724,13 @@ __metadata:
   dependencies:
     webidl-conversions: ^5.0.0
   checksum: d638e9cb05c52999f1b2eb87c374b03311ea5b1d69c2f875bc92da73e17db60c12142b45c950228642ff7f845c536b65305483350d080df59003a653da80b691
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:16.0.0":
+  version: 16.0.0
+  resolution: "dotenv@npm:16.0.0"
+  checksum: 664cebb51f0a9a1d1b930f51f0271e72e26d62feaecc9dc03df39453dd494b4e724809ca480fb3ec3213382b1ed3f791aaeb83569a137f9329ce58efd4853dbf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
GH Action is failing with:
```console
error Error: Cannot find module 'dotenv'
```

Action: https://github.com/awslabs/aws-sdk-js-codemod/runs/5687551457