### PR TITLE
fix: remove dotenv

### DIFF
--- a/.changeset/changelog.js
+++ b/.changeset/changelog.js
@@ -1,7 +1,3 @@
-const { config } = require("dotenv");
-
-config();
-
 const REPO = "awslabs/aws-sdk-js-codemod";
 
 const getGithubCommitWithLink = (commit) =>


### PR DESCRIPTION
GH Action is failing with:
```console
error Error: Cannot find module 'dotenv'
```

Action: https://github.com/awslabs/aws-sdk-js-codemod/runs/5687551457