### PR TITLE
chore: drop support for Node.js 12.x

### DIFF
--- a/.changeset/large-seals-rush.md
+++ b/.changeset/large-seals-rush.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": minor
+---
+
+Drop support for Node.js 12.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@tsconfig/node14": "1.0.3",
     "@types/jest": "27.4.1",
     "@types/jscodeshift": "0.11.5",
-    "@types/node": "16.11.26",
+    "@types/node": "14.18.33",
     "@typescript-eslint/eslint-plugin": "5.43.0",
     "@typescript-eslint/parser": "5.43.0",
     "eslint": "8.27.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "4.8.4"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "packageManager": "yarn@3.3.0",
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "2.21.0",
-    "@tsconfig/node12": "1.0.2",
+    "@tsconfig/node14": "1.0.3",
     "@types/jest": "27.4.1",
     "@types/jscodeshift": "0.11.5",
     "@types/node": "16.11.26",

--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -1,4 +1,6 @@
 import { readdirSync, readFileSync } from "fs";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: Could not find a declaration file for module 'jscodeshift/dist/testUtils'
 import { runInlineTest } from "jscodeshift/dist/testUtils";
 import { join } from "path";
 

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -17,7 +17,7 @@ export default function transformer(file: FileInfo, api: API) {
   const j = api.jscodeshift;
   const source = j(file.source);
 
-  const v2DefaultModuleName = getV2DefaultModuleName(j, source);
+  const v2DefaultModuleName = getV2DefaultModuleName(j, source) as string;
   const v2ServiceModuleNames = getV2ServiceModuleNames(j, source);
   if (!v2DefaultModuleName && v2ServiceModuleNames.length === 0) {
     return source.toSource();

--- a/src/transforms/v2-to-v3/utils/addV3ClientImport.ts
+++ b/src/transforms/v2-to-v3/utils/addV3ClientImport.ts
@@ -17,8 +17,8 @@ export const addV3ClientImport = (
   if (existingImports.size()) {
     existingImports.forEach((nodePath) => {
       // Append to existing import if specifier not present.
-      if (!nodePath.value.specifiers.find((specifier) => specifier.local.name === v3ClientName)) {
-        nodePath.value.specifiers.push(j.importSpecifier(j.identifier(v3ClientName)));
+      if (!nodePath.value.specifiers?.find((specifier) => specifier.local?.name === v3ClientName)) {
+        nodePath.value.specifiers?.push(j.importSpecifier(j.identifier(v3ClientName)));
       }
     });
     return;

--- a/src/transforms/v2-to-v3/utils/config/CLIENT_NAMES_MAP.ts
+++ b/src/transforms/v2-to-v3/utils/config/CLIENT_NAMES_MAP.ts
@@ -1,6 +1,6 @@
 import { CLIENT_NAMES } from "./CLIENT_NAMES";
 
-export const CLIENT_NAMES_MAP = {
+export const CLIENT_NAMES_MAP: Record<string, string> = {
   ...CLIENT_NAMES.reduce((acc, name) => ({ ...acc, [name]: name }), {}),
   AugmentedAIRuntime: "SageMakerA2IRuntime",
   CUR: "CostAndUsageReportService",

--- a/src/transforms/v2-to-v3/utils/config/CLIENT_PACKAGE_NAMES_MAP.ts
+++ b/src/transforms/v2-to-v3/utils/config/CLIENT_PACKAGE_NAMES_MAP.ts
@@ -1,6 +1,6 @@
 import { CLIENT_NAMES } from "./CLIENT_NAMES";
 
-export const CLIENT_PACKAGE_NAMES_MAP = {
+export const CLIENT_PACKAGE_NAMES_MAP: Record<string, string> = {
   ...CLIENT_NAMES.reduce(
     (acc, name) => ({
       ...acc,

--- a/src/transforms/v2-to-v3/utils/getImportIdentifierName.ts
+++ b/src/transforms/v2-to-v3/utils/getImportIdentifierName.ts
@@ -9,4 +9,4 @@ export const getImportIdentifierName = (
     .find(j.ImportDeclaration, {
       source: { value: literalValue },
     })
-    .nodes()[0]?.specifiers[0]?.local.name;
+    .nodes()[0]?.specifiers?.[0]?.local?.name;

--- a/src/transforms/v2-to-v3/utils/getV2ServiceModuleNames.ts
+++ b/src/transforms/v2-to-v3/utils/getV2ServiceModuleNames.ts
@@ -9,6 +9,6 @@ import { getV2ServiceModulePath } from "./getV2ServiceModulePath";
 export const getV2ServiceModuleNames = (j: JSCodeshift, source: Collection<unknown>): string[] =>
   CLIENT_NAMES.map((clientName) =>
     containsRequire(j, source)
-      ? getRequireIdentifierName(j, source, getV2ServiceModulePath(clientName))
-      : getImportIdentifierName(j, source, getV2ServiceModulePath(clientName))
+      ? (getRequireIdentifierName(j, source, getV2ServiceModulePath(clientName)) as string)
+      : (getImportIdentifierName(j, source, getV2ServiceModulePath(clientName)) as string)
   ).filter((v2ServiceModuleName) => v2ServiceModuleName !== undefined);

--- a/src/transforms/v2-to-v3/utils/removeImportIdentifierName.ts
+++ b/src/transforms/v2-to-v3/utils/removeImportIdentifierName.ts
@@ -17,11 +17,11 @@ export const removeImportIdentifierName = (
     })
     .forEach((declarationPath) => {
       // Remove default import from ImportDeclaration.
-      declarationPath.value.specifiers = declarationPath.value.specifiers.filter(
-        (specifier) => specifier.local.name !== identifierName
+      declarationPath.value.specifiers = declarationPath.value.specifiers?.filter(
+        (specifier) => specifier.local?.name !== identifierName
       );
       // Remove ImportDeclaration if there are no other imports.
-      if (declarationPath.value.specifiers.length === 0) {
+      if (declarationPath.value.specifiers?.length === 0) {
         j(declarationPath).remove();
       }
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,10 +1228,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node12@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@tsconfig/node12@npm:1.0.2"
-  checksum: 02fdd65c4b19bedcf953d9bcf94548e36d18cb3390cb0738a34b8916f7cd25f48e1498df2ee4610ae57cd6142f688985dd3ccf5897d6e4a67a294726101b0f39
+"@tsconfig/node14@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@tsconfig/node14@npm:1.0.3"
+  checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
   languageName: node
   linkType: hard
 
@@ -1822,7 +1822,7 @@ __metadata:
   resolution: "aws-sdk-js-codemod@workspace:."
   dependencies:
     "@changesets/cli": 2.21.0
-    "@tsconfig/node12": 1.0.2
+    "@tsconfig/node14": 1.0.3
     "@types/jest": 27.4.1
     "@types/jscodeshift": 0.11.5
     "@types/node": 16.11.26

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,10 +1360,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:16.11.26":
-  version: 16.11.26
-  resolution: "@types/node@npm:16.11.26"
-  checksum: 57757caaba3f0d95de82198cb276a1002c49b710108c932a1d02d7c91ff2fa57cfe2dd19fde60853b6dd90b0964b3cf35557981d2628e20aed6a909057aedfe6
+"@types/node@npm:14.18.33":
+  version: 14.18.33
+  resolution: "@types/node@npm:14.18.33"
+  checksum: 4e23f95186d8ae1d38c999bc6b46fe94e790da88744b0a3bfeedcbd0d9ffe2cb0ff39e85f43014f6739e5270292c1a1f6f97a1fc606fd573a0c17fda9a1d42de
   languageName: node
   linkType: hard
 
@@ -1825,7 +1825,7 @@ __metadata:
     "@tsconfig/node14": 1.0.3
     "@types/jest": 27.4.1
     "@types/jscodeshift": 0.11.5
-    "@types/node": 16.11.26
+    "@types/node": 14.18.33
     "@typescript-eslint/eslint-plugin": 5.43.0
     "@typescript-eslint/parser": 5.43.0
     eslint: 8.27.0


### PR DESCRIPTION
* Node.js 12.x was end-of-life on 2022-04-30: https://github.com/nodejs/Release
* jscodeshift dropped support in https://github.com/facebook/jscodeshift/pull/530