### PR TITLE
chore: remove unused Identifier

### DIFF
--- a/src/transforms/v2-to-v3/utils/getV2ClientIdNamesFromTSTypeRef.ts
+++ b/src/transforms/v2-to-v3/utils/getV2ClientIdNamesFromTSTypeRef.ts
@@ -1,4 +1,4 @@
-import { Collection, Identifier, JSCodeshift } from "jscodeshift";
+import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getMergedArrayWithoutDuplicates } from "./getMergedArrayWithoutDuplicates";
 


### PR DESCRIPTION
This comes under "Unchanged files with check annotations" in PRs.
Example: https://github.com/awslabs/aws-sdk-js-codemod/pull/134

It also comes as a warning when running yarn lint:

```console
$ yarn lint

/Users/trivikr/workspace/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/getV2ClientIdNamesFromTSTypeRef.ts
  1:22  warning  'Identifier' is defined but never used  @typescript-eslint/no-unused-vars

✖ 1 problem (0 errors, 1 warning)
```