### PR TITLE
fix: exclude outDir in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "resolveJsonModule": true,
     "rootDir": "src"
   },
-  "exclude": ["**/__fixtures__/**", "**/*.spec.ts"]
+  "exclude": ["dist", "**/__fixtures__/**", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/135

Verified that yarn build is successful when run for the second time.