### PR TITLE
chore(ci): run lint before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: yarn
-      - run: yarn build
       - run: yarn lint
+      - run: yarn build
       - run: yarn test


### PR DESCRIPTION
### Issue

N/A

### Description

Moves lint before build, so that linting errors could be caught earlier

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
