### PR TITLE
chore(renovate): disable updates which are not vulnerabilities

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":dependencyDashboard"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "enabled": false
+    }
+  ],
   "vulnerabilityAlerts": {
     "enabled": true
   },


### PR DESCRIPTION
### Issue

Refs: 
* https://github.com/renovatebot/config-help/issues/138#issuecomment-452974332
* https://github.com/aws-samples/aws-sdk-js-notes-app/blob/main/.github/renovate.json

### Description

Disables updates which are not vulnerabilities. This will avoid posting PRs like:
* https://github.com/awslabs/aws-sdk-js-codemod/pull/129
* https://github.com/awslabs/aws-sdk-js-codemod/pull/130
* https://github.com/awslabs/aws-sdk-js-codemod/pull/137
* https://github.com/awslabs/aws-sdk-js-codemod/pull/138

### Testing

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
