### PR TITLE
chore(ci): remove redundnant comments and config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"
-      - name: Install dependencies
-        run: yarn
+      - run: yarn
       - run: yarn lint
       - run: yarn build
       - run: yarn test

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,20 +11,16 @@ jobs:
     needs: call-build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 16.x
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
           cache: "yarn"
 
-      - name: Install Dependencies
-        run: yarn
+      - run: yarn
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
### Issue

N/A

### Description

Removes redundant comments and configuration from workflows:
* Comment `Use Node.js <version>` which is defined in run title.
* Comment `Install dependencies` which yarn does
* Comment `Checkout repo`
* Explicitly setting up node-version to 16 which is default in `actions/setup-node@v3`

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
