### PR TITLE
chore(ci): remove fetch-depth on push action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,10 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
-
       - uses: actions/setup-node@v3
         with:
           cache: "yarn"


### PR DESCRIPTION
### Issue

Refs: https://github.com/changesets/action/pull/177

### Description

The `fetch-depth` configuration is not needed as changesets automatically deepens a shallow clone as necessary

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
