### PR TITLE
fix(typescript): do not emit declaration/types

### DIFF
--- a/.changeset/orange-pigs-joke.md
+++ b/.changeset/orange-pigs-joke.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Skip generation of type definitions

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
     "esModuleInterop": true,
     "outDir": "dist",
     "resolveJsonModule": true,


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/115

### Description

Do not emit declaration/types

### Testing

```console
$> yarn build

$> du -sh dist
368K    dist

$> rm -rf dist 

$> yarn build 

$> du -sh dist
188K    dist
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
