### PR TITLE
fix(deps): use exact version for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "jscodeshift": "^0.14.0",
-    "table": "^6.8.0"
+    "jscodeshift": "0.14.0",
+    "table": "6.8.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,11 +2124,11 @@ __metadata:
     eslint: ^8.27.0
     eslint-plugin-simple-import-sort: ^8.0.0
     jest: ^29.3.1
-    jscodeshift: ^0.14.0
+    jscodeshift: 0.14.0
     lint-staged: ^13.0.3
     prettier: 2.5.1
     simple-git-hooks: ^2.8.1
-    table: ^6.8.0
+    table: 6.8.0
     ts-jest: ^29.0.3
     typescript: ~4.8.4
   bin:
@@ -4648,7 +4648,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jscodeshift@npm:^0.14.0":
+"jscodeshift@npm:0.14.0":
   version: 0.14.0
   resolution: "jscodeshift@npm:0.14.0"
   dependencies:
@@ -6535,16 +6535,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"table@npm:^6.8.0":
-  version: 6.8.1
-  resolution: "table@npm:6.8.1"
+"table@npm:6.8.0":
+  version: 6.8.0
+  resolution: "table@npm:6.8.0"
   dependencies:
     ajv: ^8.0.1
     lodash.truncate: ^4.4.2
     slice-ansi: ^4.0.0
     string-width: ^4.2.3
     strip-ansi: ^6.0.1
-  checksum: 08249c7046125d9d0a944a6e96cfe9ec66908d6b8a9db125531be6eb05fa0de047fd5542e9d43b4f987057f00a093b276b8d3e19af162a9c40db2681058fd306
+  checksum: 5b07fe462ee03d2e1fac02cbb578efd2e0b55ac07e3d3db2e950aa9570ade5a4a2b8d3c15e9f25c89e4e50b646bc4269934601ee1eef4ca7968ad31960977690
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/awslabs/aws-sdk-js-codemod/pull/161

### Description

Remove semver range for dependencies. 
This way the consumers will get the exact version of dependencies, which are tested in our CI.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
