### PR TITLE
chore(renovate): enable automerge on lockFileMaintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
+    "automerge": true,
     "schedule": ["before 3am on the first day of the month"]
   }
 }


### PR DESCRIPTION
### Issue

Docs: https://github.com/renovatebot/renovate/blob/84bb830e00134bd32ff2cb5b94411fd6a080b4c4/docs/usage/key-concepts/automerge.md

### Description

Enabled automerge on lockFileMaintenance in renvoate

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
