### PR TITLE
chore(deps-dev): bump prettier to v2.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-simple-import-sort": "^8.0.0",
     "jest": "^29.3.1",
     "lint-staged": "^13.0.3",
-    "prettier": "2.5.1",
+    "prettier": "2.7.1",
     "simple-git-hooks": "^2.8.1",
     "ts-jest": "^29.0.3",
     "typescript": "~4.8.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2126,7 +2126,7 @@ __metadata:
     jest: ^29.3.1
     jscodeshift: 0.14.0
     lint-staged: ^13.0.3
-    prettier: 2.5.1
+    prettier: 2.7.1
     simple-git-hooks: ^2.8.1
     table: 6.8.0
     ts-jest: ^29.0.3
@@ -5676,16 +5676,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.5.1":
-  version: 2.5.1
-  resolution: "prettier@npm:2.5.1"
-  bin:
-    prettier: bin-prettier.js
-  checksum: 21b9408476ea1c544b0e45d51ceb94a84789ff92095abb710942d780c862d0daebdb29972d47f6b4d0f7ebbfb0ffbf56cc2cfa3e3e9d1cca54864af185b15b66
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^2.7.1":
+"prettier@npm:2.7.1, prettier@npm:^2.7.1":
   version: 2.7.1
   resolution: "prettier@npm:2.7.1"
   bin:


### PR DESCRIPTION
### Issue

N/A

### Description

Bumps prettier to v2.7.1

### Testing

Verified that no additional files were formatted:
```console
$ yarn prettier --write **/*.{ts,json,md}
...
CHANGELOG.md 96ms
CODE_OF_CONDUCT.md 5ms
CONTRIBUTING.md 25ms
README.md 10ms
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
