### PR TITLE
chore(deps): remove dependency on table

### DIFF
--- a/.changeset/red-jars-smile.md
+++ b/.changeset/red-jars-smile.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove dependency 'table'

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "jscodeshift": "0.14.0",
-    "table": "6.8.0"
+    "jscodeshift": "0.14.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.21.0",

--- a/src/utils/getHelpParagraph.ts
+++ b/src/utils/getHelpParagraph.ts
@@ -1,23 +1,17 @@
-import { getBorderCharacters, table } from "table";
-
 import { AwsSdkJsCodemodTransform } from "../transforms";
+import { getTransformDescription } from "./getTransformDescription";
+
+const separator = "-".repeat(95);
 
 export const getHelpParagraph = (transforms: AwsSdkJsCodemodTransform[]) =>
-  `----------------------------------------------------------------------------------------------------
+  `${separator}
 aws-sdk-js-codemod is a lightweight wrapper over jscodeshift.
 It processes --help, --version and --transform options before passing them downstream.
 
 You can provide names of the custom transforms instead of a local path or url:
 
-${table(
-  transforms.map(({ name, description }) => [name, description]),
-  {
-    border: getBorderCharacters("void"),
-    columns: [
-      { width: 12, alignment: "right" },
-      { width: 88, wrapWord: true },
-    ],
-  }
-)}Example: aws-sdk-js-codemod -t v2-to-v3 example.js
+${transforms.map((transform) => getTransformDescription(transform).join("\n"))}
 
-----------------------------------------------------------------------------------------------------\n\n`;
+Example: aws-sdk-js-codemod -t v2-to-v3 example.js
+
+${separator}\n\n`;

--- a/src/utils/getTransformDescription.ts
+++ b/src/utils/getTransformDescription.ts
@@ -1,0 +1,46 @@
+import { AwsSdkJsCodemodTransform } from "../transforms";
+
+const getWrappedBlocks = (sentence: string, blockLength: number): string[] => {
+  const words = sentence.split(" ");
+  const blocks = [];
+  let currentBlock = "";
+
+  // iterate over the words and add them to blocks
+  for (const word of words) {
+    // if the current block plus the next word is longer than the block length,
+    // add the current block to the list of blocks and start a new block
+    if (currentBlock.length + word.length > blockLength) {
+      blocks.push(currentBlock);
+      currentBlock = "";
+    }
+
+    // add the word to the current block
+    currentBlock += word + " ";
+  }
+
+  // add the final block to the list of blocks
+  blocks.push(currentBlock);
+
+  return blocks;
+};
+
+export const getTransformDescription = (transform: AwsSdkJsCodemodTransform): string[] => {
+  const descriptionArr: string[] = [];
+
+  const columnLength = 15;
+  const borderLength = 2;
+
+  descriptionArr[0] =
+    " ".repeat(columnLength - borderLength - transform.name.length) +
+    transform.name +
+    " ".repeat(borderLength);
+
+  const wrappedBlocks = getWrappedBlocks(transform.description, 80);
+
+  descriptionArr[0] += wrappedBlocks[0];
+  for (let i = 1; i < wrappedBlocks.length; i++) {
+    descriptionArr.push(" ".repeat(columnLength) + wrappedBlocks[i]);
+  }
+
+  return descriptionArr;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1685,18 +1685,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.1":
-  version: 8.11.2
-  resolution: "ajv@npm:8.11.2"
-  dependencies:
-    fast-deep-equal: ^3.1.1
-    json-schema-traverse: ^1.0.0
-    require-from-string: ^2.0.2
-    uri-js: ^4.2.2
-  checksum: 53435bf79ee7d1eabba8085962dba4c08d08593334b304db7772887f0b7beebc1b3d957432f7437ed4b60e53b5d966a57b439869890209c50fed610459999e3e
-  languageName: node
-  linkType: hard
-
 "ansi-colors@npm:^4.1.1, ansi-colors@npm:^4.1.3":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
@@ -1871,7 +1859,6 @@ __metadata:
     lint-staged: ^13.0.3
     prettier: 2.7.1
     simple-git-hooks: ^2.8.1
-    table: 6.8.0
     ts-jest: ^29.0.3
     typescript: ~4.8.4
   bin:
@@ -4387,13 +4374,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema-traverse@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "json-schema-traverse@npm:1.0.0"
-  checksum: 02f2f466cdb0362558b2f1fd5e15cce82ef55d60cd7f8fa828cf35ba74330f8d767fcae5c5c2adb7851fa811766c694b9405810879bc4e1ddd78a7c0e03658ad
-  languageName: node
-  linkType: hard
-
 "json-stable-stringify-without-jsonify@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
@@ -4576,13 +4556,6 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.startcase@npm:4.4.0"
   checksum: c03a4a784aca653845fe09d0ef67c902b6e49288dc45f542a4ab345a9c406a6dc194c774423fa313ee7b06283950301c1221dd2a1d8ecb2dac8dfbb9ed5606b5
-  languageName: node
-  linkType: hard
-
-"lodash.truncate@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "lodash.truncate@npm:4.4.2"
-  checksum: b463d8a382cfb5f0e71c504dcb6f807a7bd379ff1ea216669aa42c52fc28c54e404bfbd96791aa09e6df0de2c1d7b8f1b7f4b1a61f324d38fe98bc535aeee4f5
   languageName: node
   linkType: hard
 
@@ -5526,13 +5499,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"require-from-string@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "require-from-string@npm:2.0.2"
-  checksum: a03ef6895445f33a4015300c426699bc66b2b044ba7b670aa238610381b56d3f07c686251740d575e22f4c87531ba662d06937508f0f3c0f1ddc04db3130560b
-  languageName: node
-  linkType: hard
-
 "require-main-filename@npm:^2.0.0":
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
@@ -6154,19 +6120,6 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 53b1e247e68e05db7b3808b99b892bd36fb096e6fba213a06da7fab22045e97597db425c724f2bbd6c99a3c295e1e73f3e4de78592289f38431049e1277ca0ae
-  languageName: node
-  linkType: hard
-
-"table@npm:6.8.0":
-  version: 6.8.0
-  resolution: "table@npm:6.8.0"
-  dependencies:
-    ajv: ^8.0.1
-    lodash.truncate: ^4.4.2
-    slice-ansi: ^4.0.0
-    string-width: ^4.2.3
-    strip-ansi: ^6.0.1
-  checksum: 5b07fe462ee03d2e1fac02cbb578efd2e0b55ac07e3d3db2e950aa9570ade5a4a2b8d3c15e9f25c89e4e50b646bc4269934601ee1eef4ca7968ad31960977690
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

N/A

### Description

Removes the dependency on table and reduces the publish size of the module

### Testing

Verified that transforms are printed in help

```console
$ yarn build

$ ./bin/aws-sdk-js-codemod --help
-----------------------------------------------------------------------------------------------
aws-sdk-js-codemod is a lightweight wrapper over jscodeshift.
It processes --help, --version and --transform options before passing them downstream.

You can provide names of the custom transforms instead of a local path or url:

     v2-to-v3  Converts AWS SDK for JavaScript APIs in a Javascript/TypeScript codebase from 
               version 2 (v2) to version 3 (v3). 

Example: aws-sdk-js-codemod -t v2-to-v3 example.js

-----------------------------------------------------------------------------------------------
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
