### PR TITLE
Default parser to babylon

### DIFF
--- a/.changeset/sour-starfishes-laugh.md
+++ b/.changeset/sour-starfishes-laugh.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": minor
+---
+
+Default parser to babylon

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -60,3 +60,5 @@ const transformer = async (file: FileInfo, api: API) => {
 };
 
 export default transformer;
+
+export const parser = "babylon";


### PR DESCRIPTION
### Issue

Refs:
* https://github.com/facebook/jscodeshift/issues/488
* https://github.com/facebook/jscodeshift/issues/500

### Description

The jscodeshift a parser parameter defaults to `babel5compat`, which is has a significantly reduced feature set from ts, babylon, etc. The upstream project is meaning to switch default parser to babylon.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
