### PR TITLE
feat: remove `.promise()` calls from class member clients

### DIFF
--- a/.changeset/lemon-fans-sell.md
+++ b/.changeset/lemon-fans-sell.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove .promise() calls from class member clients

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise-class-member.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise-class-member.input.js
@@ -1,0 +1,18 @@
+import * as AWS from 'aws-sdk';
+
+export class SecretsManager {
+  constructor(client = new AWS.SecretsManager()) {
+    this.client = client;
+  }
+
+  async getSecretValue(secretId) {
+    const response = await this.client
+      .getSecretValue({ SecretId: secretId })
+      .promise();
+    if (response.SecretString) {
+      return response.SecretString;
+    } else {
+      throw new Error(`Unable to get the secret value from ${secretId}`);
+    }
+  }
+}

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise-class-member.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise-class-member.output.js
@@ -1,0 +1,17 @@
+import { SecretsManager } from "@aws-sdk/client-secrets-manager";
+
+export class SecretsManager {
+  constructor(client = new SecretsManager()) {
+    this.client = client;
+  }
+
+  async getSecretValue(secretId) {
+    const response = await this.client
+      .getSecretValue({ SecretId: secretId });
+    if (response.SecretString) {
+      return response.SecretString;
+    } else {
+      throw new Error(`Unable to get the secret value from ${secretId}`);
+    }
+  }
+}

--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -17,13 +17,16 @@ describe("v2-to-v3", () => {
       fileName.split(".").pop() as string,
     ]);
 
-  it.each(testFiles)(`transforms correctly using "%s" data`, (filePrefix, fileExtension) => {
-    const inputPath = join(fixtureDir, [filePrefix, "input", fileExtension].join("."));
-    const outputPath = join(fixtureDir, [filePrefix, "output", fileExtension].join("."));
-    const inputCode = readFileSync(inputPath, "utf8");
-    const outputCode = readFileSync(outputPath, "utf8");
+  it.each([["api-promise-class-member", "js"]])(
+    `transforms correctly using "%s" data`,
+    (filePrefix, fileExtension) => {
+      const inputPath = join(fixtureDir, [filePrefix, "input", fileExtension].join("."));
+      const outputPath = join(fixtureDir, [filePrefix, "output", fileExtension].join("."));
+      const inputCode = readFileSync(inputPath, "utf8");
+      const outputCode = readFileSync(outputPath, "utf8");
 
-    const input = { path: inputPath, source: inputCode };
-    runInlineTest(transformer, null, input, outputCode);
-  });
+      const input = { path: inputPath, source: inputCode };
+      runInlineTest(transformer, null, input, outputCode);
+    }
+  );
 });

--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -17,16 +17,13 @@ describe("v2-to-v3", () => {
       fileName.split(".").pop() as string,
     ]);
 
-  it.each([["api-promise-class-member", "js"]])(
-    `transforms correctly using "%s" data`,
-    (filePrefix, fileExtension) => {
-      const inputPath = join(fixtureDir, [filePrefix, "input", fileExtension].join("."));
-      const outputPath = join(fixtureDir, [filePrefix, "output", fileExtension].join("."));
-      const inputCode = readFileSync(inputPath, "utf8");
-      const outputCode = readFileSync(outputPath, "utf8");
+  it.each(testFiles)(`transforms correctly using "%s" data`, (filePrefix, fileExtension) => {
+    const inputPath = join(fixtureDir, [filePrefix, "input", fileExtension].join("."));
+    const outputPath = join(fixtureDir, [filePrefix, "output", fileExtension].join("."));
+    const inputCode = readFileSync(inputPath, "utf8");
+    const outputCode = readFileSync(outputPath, "utf8");
 
-      const input = { path: inputPath, source: inputCode };
-      runInlineTest(transformer, null, input, outputCode);
-    }
-  );
+    const input = { path: inputPath, source: inputCode };
+    runInlineTest(transformer, null, input, outputCode);
+  });
 });

--- a/src/transforms/v2-to-v3/utils/getV2ClientIdNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/utils/getV2ClientIdNamesFromNewExpr.ts
@@ -1,4 +1,4 @@
-import { Collection, Identifier, JSCodeshift } from "jscodeshift";
+import { Collection, Identifier, JSCodeshift, NewExpression } from "jscodeshift";
 
 import { getMergedArrayWithoutDuplicates } from "./getMergedArrayWithoutDuplicates";
 
@@ -7,38 +7,58 @@ export interface GetV2ClientIdNamesFromNewExprOptions {
   v2DefaultModuleName: string;
 }
 
+const getNamesFromVariableDeclarator = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  newExpression: NewExpression
+) =>
+  source
+    .find(j.VariableDeclarator, {
+      id: { type: "Identifier" },
+      init: newExpression,
+    })
+    .nodes()
+    .map((variableDeclarator) => (variableDeclarator.id as Identifier).name);
+
+const getNamesFromAssignmentPattern = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  newExpression: NewExpression
+) =>
+  source
+    .find(j.AssignmentPattern, {
+      left: { type: "Identifier" },
+      right: newExpression,
+    })
+    .nodes()
+    .map((assignmentPattern) => (assignmentPattern.left as Identifier).name);
+
 export const getV2ClientIdNamesFromNewExpr = (
   j: JSCodeshift,
   source: Collection<unknown>,
   { v2DefaultModuleName, v2ClientName }: GetV2ClientIdNamesFromNewExprOptions
 ): string[] => {
-  const clientIdNamesFromDefaultModule = source
-    .find(j.VariableDeclarator, {
-      id: { type: "Identifier" },
-      init: {
-        type: "NewExpression",
-        callee: {
-          object: { type: "Identifier", name: v2DefaultModuleName },
-          property: { type: "Identifier", name: v2ClientName },
-        },
-      },
-    })
-    .nodes()
-    .map((variableDeclarator) => (variableDeclarator.id as Identifier).name);
+  const defaultNewExpr = {
+    type: "NewExpression",
+    callee: {
+      object: { type: "Identifier", name: v2DefaultModuleName },
+      property: { type: "Identifier", name: v2ClientName },
+    },
+  } as NewExpression;
 
-  const clientIdNamesFromServiceModule = source
-    .find(j.VariableDeclarator, {
-      id: { type: "Identifier" },
-      init: {
-        type: "NewExpression",
-        callee: { type: "Identifier", name: v2ClientName },
-      },
-    })
-    .nodes()
-    .map((variableDeclarator) => (variableDeclarator.id as Identifier).name);
+  const clientNewExpr = {
+    type: "NewExpression",
+    callee: { type: "Identifier", name: v2ClientName },
+  } as NewExpression;
 
-  return getMergedArrayWithoutDuplicates(
-    clientIdNamesFromDefaultModule,
-    clientIdNamesFromServiceModule
-  );
+  const namesFromDefaultModule = [
+    ...getNamesFromVariableDeclarator(j, source, defaultNewExpr),
+    ...getNamesFromAssignmentPattern(j, source, defaultNewExpr),
+  ];
+  const namesFromServiceModule = [
+    ...getNamesFromVariableDeclarator(j, source, clientNewExpr),
+    ...getNamesFromAssignmentPattern(j, source, clientNewExpr),
+  ];
+
+  return getMergedArrayWithoutDuplicates(namesFromDefaultModule, namesFromServiceModule);
 };

--- a/src/transforms/v2-to-v3/utils/getV2ClientIdThisExpressions.ts
+++ b/src/transforms/v2-to-v3/utils/getV2ClientIdThisExpressions.ts
@@ -1,4 +1,4 @@
-import { Collection, Identifier, JSCodeshift, ThisExpression } from "jscodeshift";
+import { Collection, Identifier, JSCodeshift, MemberExpression, ThisExpression } from "jscodeshift";
 
 export interface ThisMemberExpression {
   type: "MemberExpression";
@@ -6,22 +6,28 @@ export interface ThisMemberExpression {
   property: Identifier;
 }
 
+const thisMemberExpression = { type: "MemberExpression", object: { type: "ThisExpression" } };
+
 export const getV2ClientIdThisExpressions = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  v2ClientIdNames: Identifier[]
-): ThisMemberExpression[] => {
-  // ToDo: return MemberExpression based on v2ClientIdNames
-  return [
-    {
-      type: "MemberExpression",
-      object: {
-        type: "ThisExpression",
-      },
-      property: {
-        type: "Identifier",
-        name: "client",
-      },
-    },
-  ];
-};
+  v2ClientIdentifiers: Identifier[]
+): ThisMemberExpression[] =>
+  v2ClientIdentifiers.flatMap((v2ClientIdentifier) =>
+    source
+      .find(j.AssignmentExpression, {
+        left: thisMemberExpression as MemberExpression,
+        right: v2ClientIdentifier,
+      })
+      .nodes()
+      .map(
+        (assignmentExpression) =>
+          ({
+            ...thisMemberExpression,
+            property: {
+              type: "Identifier",
+              name: ((assignmentExpression.left as MemberExpression).property as Identifier).name,
+            },
+          } as ThisMemberExpression)
+      )
+  );

--- a/src/transforms/v2-to-v3/utils/getV2ClientIdThisExpressions.ts
+++ b/src/transforms/v2-to-v3/utils/getV2ClientIdThisExpressions.ts
@@ -1,0 +1,27 @@
+import { Collection, Identifier, JSCodeshift, ThisExpression } from "jscodeshift";
+
+export interface ThisMemberExpression {
+  type: "MemberExpression";
+  object: ThisExpression;
+  property: Identifier;
+}
+
+export const getV2ClientIdThisExpressions = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  v2ClientIdNames: Identifier[]
+): ThisMemberExpression[] => {
+  // ToDo: return MemberExpression based on v2ClientIdNames
+  return [
+    {
+      type: "MemberExpression",
+      object: {
+        type: "ThisExpression",
+      },
+      property: {
+        type: "Identifier",
+        name: "client",
+      },
+    },
+  ];
+};

--- a/src/transforms/v2-to-v3/utils/getV2ClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/utils/getV2ClientIdentifiers.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 import { getMergedArrayWithoutDuplicates } from "./getMergedArrayWithoutDuplicates";
 import { getV2ClientIdNamesFromNewExpr } from "./getV2ClientIdNamesFromNewExpr";
@@ -9,11 +9,11 @@ export interface GetV2ClientIdNamesOptions {
   v2DefaultModuleName: string;
 }
 
-export const getV2ClientIdNames = (
+export const getV2ClientIdentifiers = (
   j: JSCodeshift,
   source: Collection<unknown>,
   { v2DefaultModuleName, v2ClientName }: GetV2ClientIdNamesOptions
-): string[] => {
+): Identifier[] => {
   const v2ClientIdNamesFromNewExpr = getV2ClientIdNamesFromNewExpr(j, source, {
     v2DefaultModuleName,
     v2ClientName,
@@ -24,5 +24,10 @@ export const getV2ClientIdNames = (
     v2ClientName,
   });
 
-  return getMergedArrayWithoutDuplicates(v2ClientIdNamesFromNewExpr, v2ClientIdNamesFromTSTypeRef);
+  const clientIdNames = getMergedArrayWithoutDuplicates(
+    v2ClientIdNamesFromNewExpr,
+    v2ClientIdNamesFromTSTypeRef
+  );
+
+  return clientIdNames.map((clientidName) => ({ type: "Identifier", name: clientidName }));
 };

--- a/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
@@ -13,10 +13,11 @@ export const removePromiseCalls = (
   source: Collection<unknown>,
   { v2DefaultModuleName, v2ClientName }: RemovePromiseCallsOptions
 ): void => {
-  const v2ClientIdNames = getV2ClientIdNames(j, source, {
-    v2DefaultModuleName,
-    v2ClientName,
-  });
+  const v2ClientIdNames = ["client"];
+  // const v2ClientIdNames = getV2ClientIdNames(j, source, {
+  //   v2DefaultModuleName,
+  //   v2ClientName,
+  // });
 
   for (const v2ClientIdName of v2ClientIdNames) {
     source
@@ -28,8 +29,14 @@ export const removePromiseCalls = (
             callee: {
               type: "MemberExpression",
               object: {
-                type: "Identifier",
-                name: v2ClientIdName,
+                type: "MemberExpression",
+                object: {
+                  type: "ThisExpression",
+                },
+                property: {
+                  type: "Identifier",
+                  name: v2ClientIdName,
+                },
               },
             },
           },

--- a/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
@@ -1,6 +1,6 @@
 import { CallExpression, Collection, JSCodeshift, MemberExpression } from "jscodeshift";
 
-import { getV2ClientIdNames } from "./getV2ClientIdNames";
+import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
 
 export interface RemovePromiseCallsOptions {
   v2ClientName: string;
@@ -13,12 +13,12 @@ export const removePromiseCalls = (
   source: Collection<unknown>,
   { v2DefaultModuleName, v2ClientName }: RemovePromiseCallsOptions
 ): void => {
-  const v2ClientIdNames = getV2ClientIdNames(j, source, {
+  const v2ClientIdentifiers = getV2ClientIdentifiers(j, source, {
     v2DefaultModuleName,
     v2ClientName,
   });
 
-  for (const v2ClientIdName of v2ClientIdNames) {
+  for (const v2ClientIdentifier of v2ClientIdentifiers) {
     source
       .find(j.CallExpression, {
         callee: {
@@ -27,10 +27,7 @@ export const removePromiseCalls = (
             type: "CallExpression",
             callee: {
               type: "MemberExpression",
-              object: {
-                type: "Identifier",
-                name: v2ClientIdName,
-              },
+              object: v2ClientIdentifier,
             },
           },
           property: { type: "Identifier", name: "promise" },

--- a/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
@@ -13,11 +13,10 @@ export const removePromiseCalls = (
   source: Collection<unknown>,
   { v2DefaultModuleName, v2ClientName }: RemovePromiseCallsOptions
 ): void => {
-  const v2ClientIdNames = ["client"];
-  // const v2ClientIdNames = getV2ClientIdNames(j, source, {
-  //   v2DefaultModuleName,
-  //   v2ClientName,
-  // });
+  const v2ClientIdNames = getV2ClientIdNames(j, source, {
+    v2DefaultModuleName,
+    v2ClientName,
+  });
 
   for (const v2ClientIdName of v2ClientIdNames) {
     source
@@ -29,14 +28,8 @@ export const removePromiseCalls = (
             callee: {
               type: "MemberExpression",
               object: {
-                type: "MemberExpression",
-                object: {
-                  type: "ThisExpression",
-                },
-                property: {
-                  type: "Identifier",
-                  name: v2ClientIdName,
-                },
+                type: "Identifier",
+                name: v2ClientIdName,
               },
             },
           },

--- a/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
@@ -1,6 +1,7 @@
 import { CallExpression, Collection, JSCodeshift, MemberExpression } from "jscodeshift";
 
 import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
+import { getV2ClientIdThisExpressions } from "./getV2ClientIdThisExpressions";
 
 export interface RemovePromiseCallsOptions {
   v2ClientName: string;
@@ -17,8 +18,9 @@ export const removePromiseCalls = (
     v2DefaultModuleName,
     v2ClientName,
   });
+  const v2ClientIdThisExpressions = getV2ClientIdThisExpressions(j, source, v2ClientIdentifiers);
 
-  for (const v2ClientIdentifier of v2ClientIdentifiers) {
+  for (const v2ClientId of [...v2ClientIdentifiers, ...v2ClientIdThisExpressions]) {
     source
       .find(j.CallExpression, {
         callee: {
@@ -27,7 +29,7 @@ export const removePromiseCalls = (
             type: "CallExpression",
             callee: {
               type: "MemberExpression",
-              object: v2ClientIdentifier,
+              object: v2ClientId,
             },
           },
           property: { type: "Identifier", name: "promise" },


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/182

### Description

Remove `.promise()` calls from client Ids assigned to class member

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
