### PR TITLE
test: run transformer tests concurrently

### DIFF
--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -1,4 +1,5 @@
-import { readdirSync, readFileSync } from "fs";
+import { readdirSync } from "fs";
+import { readFile } from "fs/promises";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Could not find a declaration file for module 'jscodeshift/dist/testUtils'
 import { runInlineTest } from "jscodeshift/dist/testUtils";
@@ -17,11 +18,11 @@ describe("v2-to-v3", () => {
       fileName.split(".").pop() as string,
     ]);
 
-  it.each(testFiles)(`transforms correctly using "%s" data`, (filePrefix, fileExtension) => {
+  it.concurrent.each(testFiles)(`transforms: %s.%s`, async (filePrefix, fileExtension) => {
     const inputPath = join(fixtureDir, [filePrefix, "input", fileExtension].join("."));
     const outputPath = join(fixtureDir, [filePrefix, "output", fileExtension].join("."));
-    const inputCode = readFileSync(inputPath, "utf8");
-    const outputCode = readFileSync(outputPath, "utf8");
+    const inputCode = await readFile(inputPath, "utf8");
+    const outputCode = await readFile(outputPath, "utf8");
 
     const input = { path: inputPath, source: inputCode };
     runInlineTest(transformer, null, input, outputCode);


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/191

### Description

Runs transformer tests concurrently

### Testing

The improvements are not noticeable on in GitHub workflow runs with [a 2-core CPU](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), not on local machine with 8-core CPU.

I verified though that tests are run in parallel. I'll merge the changes, as it's may be useful in future as Jest version is updated.

Code:
```ts
// src/transforms/v2-to-v3/transformer.spec.ts

it.concurrent.each(testFiles)(`transforms: %s.%s`, async (filePrefix, fileExtension) => {
  console.log("test start:", filePrefix, Date.now());

  // ...

  console.log("test end: ", filePrefix, Date.now());
}
```

Output:
```console
    test start: api-callback 1671680054826
    test start: api-promise-service-import 1671680054837
    test start: api-promise-service-import 1671680054838
    test start: api-promise 1671680054838
    test start: api-promise 1671680054839
    test end: api-callback 1671680054958
    test start: existing-identifier-import 1671680054959
    test end: api-promise-service-import 1671680055076
...
```

#### Before

Local:
```console
$ yarn test
 PASS  src/cli.spec.ts
aws-sdk-js-codemod: 0.6.4

 PASS  src/transforms/v2-to-v3/utils/isTypeScriptFile.spec.ts
 PASS  src/transforms/v2-to-v3/utils/getV3ClientName.spec.ts
 PASS  src/transforms/v2-to-v3/utils/getV3ClientPackageName.spec.ts
 PASS  src/transforms/v2-to-v3/transformer.spec.ts (16.842 s)

Test Suites: 5 passed, 5 total
Tests:       630 passed, 630 total
Snapshots:   0 total
Time:        17.011 s, estimated 18 s
Ran all test suites.
```

Times taken to run tests in [example workflow run](https://github.com/awslabs/aws-sdk-js-codemod/actions/runs/3751954140):
* 14.x: 41s
* 16.x: 42s
* 18.x: 40s

#### After

Local:
```console
$ yarn test
 PASS  src/transforms/v2-to-v3/utils/getV3ClientPackageName.spec.ts
 PASS  src/transforms/v2-to-v3/utils/isTypeScriptFile.spec.ts
 PASS  src/transforms/v2-to-v3/utils/getV3ClientName.spec.ts
 PASS  src/cli.spec.ts
aws-sdk-js-codemod: 0.6.4

 PASS  src/transforms/v2-to-v3/transformer.spec.ts (17.004 s)

Test Suites: 5 passed, 5 total
Tests:       630 passed, 630 total
Snapshots:   0 total
Time:        17.153 s
Ran all test suites.
```

Example workflow run: 

Times taken to run tests in [example workflow run](https://github.com/awslabs/aws-sdk-js-codemod/actions/runs/3754760092):
* 14.x: 40s
* 16.x: 45s
* 18.x: 40s

### Additional context

Jest https://jestjs.io/docs/api#testconcurrenteachtablename-fn-timeout

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
