### PR TITLE
test: set jest timeout of 20s for transformer

### DIFF
--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -7,9 +7,10 @@ import { join } from "path";
 
 import transformer from "./transformer";
 
-const inputFileRegex = /(.*).input.[jt]sx?$/;
-
 describe("v2-to-v3", () => {
+  jest.setTimeout(20000);
+
+  const inputFileRegex = /(.*).input.[jt]sx?$/;
   const fixtureDir = join(__dirname, "__fixtures__");
   const testFiles: [string, string][] = readdirSync(fixtureDir)
     .filter((fileName) => inputFileRegex.test(fileName))


### PR DESCRIPTION
### Issue

Refs: https://github.com/awslabs/aws-sdk-js-codemod/issues/190

The jest tests started timing out in local workspace while testing
```console
  ● v2-to-v3 › transforms: new-client-global-import.js

    thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
```

### Description

Sets jest timeout to 20s

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
