### PR TITLE
Replace named imports for Request/Response types

### DIFF
--- a/.changeset/shy-mice-wonder.md
+++ b/.changeset/shy-mice-wonder.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Replace named imports for Request/Response types

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-import.input.ts
@@ -1,9 +1,13 @@
 import AWS from "aws-sdk";
 
-const client = new AWS.DynamoDB({ region: "us-west-2" });
-
+const ddbClient = new AWS.DynamoDB({ region: "us-west-2" });
 const listTablesInput: AWS.DynamoDB.ListTablesInput = { Limit: 10 };
-const listTablesOutput: AWS.DynamoDB.ListTablesOutput = await client
+const listTablesOutput: AWS.DynamoDB.ListTablesOutput = await ddbClient
   .listTables(listTablesInput)
   .promise();
 
+const stsClient = new AWS.STS({ region: "us-west-2" });
+const getCallerIdentityInput: AWS.STS.GetCallerIdentityRequest = {};
+const getCallerIdentityOutput: AWS.STS.GetCallerIdentityResponse = await stsClient
+  .getCallerIdentity(getCallerIdentityInput)
+  .promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-import.output.ts
@@ -1,7 +1,12 @@
 import { DynamoDB, ListTablesCommandInput, ListTablesCommandOutput } from "@aws-sdk/client-dynamodb";
+import { STS, GetCallerIdentityCommandInput, GetCallerIdentityCommandOutput } from "@aws-sdk/client-sts";
 
-const client = new DynamoDB({ region: "us-west-2" });
-
+const ddbClient = new DynamoDB({ region: "us-west-2" });
 const listTablesInput: ListTablesCommandInput = { Limit: 10 };
-const listTablesOutput: ListTablesCommandOutput = await client
+const listTablesOutput: ListTablesCommandOutput = await ddbClient
   .listTables(listTablesInput);
+
+const stsClient = new STS({ region: "us-west-2" });
+const getCallerIdentityInput: GetCallerIdentityCommandInput = {};
+const getCallerIdentityOutput: GetCallerIdentityCommandOutput = await stsClient
+  .getCallerIdentity(getCallerIdentityInput);

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-require.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-require.input.ts
@@ -1,9 +1,13 @@
 const AWS = require("aws-sdk");
 
-const client = new AWS.DynamoDB({ region: "us-west-2" });
-
+const ddbClient = new AWS.DynamoDB({ region: "us-west-2" });
 const listTablesInput: AWS.DynamoDB.ListTablesInput = { Limit: 10 };
-const listTablesOutput: AWS.DynamoDB.ListTablesOutput = await client
+const listTablesOutput: AWS.DynamoDB.ListTablesOutput = await ddbClient
   .listTables(listTablesInput)
   .promise();
 
+const stsClient = new AWS.STS({ region: "us-west-2" });
+const getCallerIdentityInput: AWS.STS.GetCallerIdentityRequest = {};
+const getCallerIdentityOutput: AWS.STS.GetCallerIdentityResponse = await stsClient
+  .getCallerIdentity(getCallerIdentityInput)
+  .promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-require.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-require.output.ts
@@ -4,8 +4,18 @@ const {
   ListTablesCommandOutput
 } = require("@aws-sdk/client-dynamodb");
 
-const client = new DynamoDB({ region: "us-west-2" });
+const {
+  STS,
+  GetCallerIdentityCommandInput,
+  GetCallerIdentityCommandOutput
+} = require("@aws-sdk/client-sts");
 
+const ddbClient = new DynamoDB({ region: "us-west-2" });
 const listTablesInput: ListTablesCommandInput = { Limit: 10 };
-const listTablesOutput: ListTablesCommandOutput = await client
+const listTablesOutput: ListTablesCommandOutput = await ddbClient
   .listTables(listTablesInput);
+
+const stsClient = new STS({ region: "us-west-2" });
+const getCallerIdentityInput: GetCallerIdentityCommandInput = {};
+const getCallerIdentityOutput: GetCallerIdentityCommandOutput = await stsClient
+  .getCallerIdentity(getCallerIdentityInput);

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-import-named.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-import-named.input.ts
@@ -1,8 +1,14 @@
 import DynamoDB, { ListTablesInput, ListTablesOutput } from "aws-sdk/clients/dynamodb";
+import STS, { GetCallerIdentityRequest, GetCallerIdentityResponse } from "aws-sdk/clients/sts";
 
-const client = new DynamoDB({ region: "us-west-2" });
-
+const ddbClient = new DynamoDB({ region: "us-west-2" });
 const listTablesInput: ListTablesInput = { Limit: 10 };
-const listTablesOutput: ListTablesOutput = await client
+const listTablesOutput: ListTablesOutput = await ddbClient
   .listTables(listTablesInput)
+  .promise();
+
+const stsClient = new STS({ region: "us-west-2" });
+const getCallerIdentityInput: GetCallerIdentityRequest = {};
+const getCallerIdentityOutput: GetCallerIdentityResponse = await stsClient
+  .getCallerIdentity(getCallerIdentityInput)
   .promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-import-named.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-import-named.output.ts
@@ -1,7 +1,12 @@
 import { DynamoDB, ListTablesCommandInput, ListTablesCommandOutput } from "@aws-sdk/client-dynamodb";
+import { STS, GetCallerIdentityCommandInput, GetCallerIdentityCommandOutput } from "@aws-sdk/client-sts";
 
-const client = new DynamoDB({ region: "us-west-2" });
-
+const ddbClient = new DynamoDB({ region: "us-west-2" });
 const listTablesInput: ListTablesCommandInput = { Limit: 10 };
-const listTablesOutput: ListTablesCommandOutput = await client
+const listTablesOutput: ListTablesCommandOutput = await ddbClient
   .listTables(listTablesInput);
+
+const stsClient = new STS({ region: "us-west-2" });
+const getCallerIdentityInput: GetCallerIdentityCommandInput = {};
+const getCallerIdentityOutput: GetCallerIdentityCommandOutput = await stsClient
+  .getCallerIdentity(getCallerIdentityInput);

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-import.input.ts
@@ -1,8 +1,14 @@
 import DynamoDB from "aws-sdk/clients/dynamodb";
+import STS from "aws-sdk/clients/sts";
 
-const client = new DynamoDB({ region: "us-west-2" });
-
+const ddbClient = new DynamoDB({ region: "us-west-2" });
 const listTablesInput: DynamoDB.ListTablesInput = { Limit: 10 };
-const listTablesOutput: DynamoDB.ListTablesOutput = await client
+const listTablesOutput: DynamoDB.ListTablesOutput = await ddbClient
   .listTables(listTablesInput)
+  .promise();
+
+const stsClient = new STS({ region: "us-west-2" });
+const getCallerIdentityInput: STS.GetCallerIdentityRequest = {};
+const getCallerIdentityOutput: STS.GetCallerIdentityResponse = await stsClient
+  .getCallerIdentity(getCallerIdentityInput)
   .promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-import.output.ts
@@ -1,7 +1,12 @@
 import { DynamoDB, ListTablesCommandInput, ListTablesCommandOutput } from "@aws-sdk/client-dynamodb";
+import { STS, GetCallerIdentityCommandInput, GetCallerIdentityCommandOutput } from "@aws-sdk/client-sts";
 
-const client = new DynamoDB({ region: "us-west-2" });
-
+const ddbClient = new DynamoDB({ region: "us-west-2" });
 const listTablesInput: ListTablesCommandInput = { Limit: 10 };
-const listTablesOutput: ListTablesCommandOutput = await client
+const listTablesOutput: ListTablesCommandOutput = await ddbClient
   .listTables(listTablesInput);
+
+const stsClient = new STS({ region: "us-west-2" });
+const getCallerIdentityInput: GetCallerIdentityCommandInput = {};
+const getCallerIdentityOutput: GetCallerIdentityCommandOutput = await stsClient
+  .getCallerIdentity(getCallerIdentityInput);

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-require.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-require.input.ts
@@ -1,8 +1,14 @@
 const DynamoDB = require("aws-sdk/clients/dynamodb");
+const STS = require("aws-sdk/clients/sts");
 
-const client = new DynamoDB({ region: "us-west-2" });
-
+const ddbClient = new DynamoDB({ region: "us-west-2" });
 const listTablesInput: DynamoDB.ListTablesInput = { Limit: 10 };
-const listTablesOutput: DynamoDB.ListTablesOutput = await client
+const listTablesOutput: DynamoDB.ListTablesOutput = await ddbClient
   .listTables(listTablesInput)
+  .promise();
+
+const stsClient = new STS({ region: "us-west-2" });
+const getCallerIdentityInput: STS.GetCallerIdentityRequest = {};
+const getCallerIdentityOutput: STS.GetCallerIdentityResponse = await stsClient
+  .getCallerIdentity(getCallerIdentityInput)
   .promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-require.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-require.output.ts
@@ -3,9 +3,18 @@ const {
   ListTablesCommandInput,
   ListTablesCommandOutput
 } = require("@aws-sdk/client-dynamodb");
+const {
+  STS,
+  GetCallerIdentityCommandInput,
+  GetCallerIdentityCommandOutput
+} = require("@aws-sdk/client-sts");
 
-const client = new DynamoDB({ region: "us-west-2" });
-
+const ddbClient = new DynamoDB({ region: "us-west-2" });
 const listTablesInput: ListTablesCommandInput = { Limit: 10 };
-const listTablesOutput: ListTablesCommandOutput = await client
+const listTablesOutput: ListTablesCommandOutput = await ddbClient
   .listTables(listTablesInput);
+
+const stsClient = new STS({ region: "us-west-2" });
+const getCallerIdentityInput: GetCallerIdentityCommandInput = {};
+const getCallerIdentityOutput: GetCallerIdentityCommandOutput = await stsClient
+  .getCallerIdentity(getCallerIdentityInput);

--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -37,7 +37,7 @@ describe("v2-to-v3", () => {
     return { input, outputCode };
   };
 
-  it.concurrent.each(getTestFileMetadata(fixtureDir))(
+  it.concurrent.skip.each(getTestFileMetadata(fixtureDir))(
     `transforms: %s.%s`,
     async (filePrefix, fileExtension) => {
       const { input, outputCode } = await getTestMetadata(fixtureDir, filePrefix, fileExtension);
@@ -45,7 +45,7 @@ describe("v2-to-v3", () => {
     }
   );
 
-  describe.each(fixtureSubDirs)("%s", (subDir) => {
+  describe.each(["api-input-output-type"])("%s", (subDir) => {
     const subDirPath = join(fixtureDir, subDir);
     it.concurrent.each(getTestFileMetadata(subDirPath))(
       `transforms: %s.%s`,

--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -37,7 +37,7 @@ describe("v2-to-v3", () => {
     return { input, outputCode };
   };
 
-  it.concurrent.skip.each(getTestFileMetadata(fixtureDir))(
+  it.concurrent.each(getTestFileMetadata(fixtureDir))(
     `transforms: %s.%s`,
     async (filePrefix, fileExtension) => {
       const { input, outputCode } = await getTestMetadata(fixtureDir, filePrefix, fileExtension);
@@ -45,7 +45,7 @@ describe("v2-to-v3", () => {
     }
   );
 
-  describe.each(["api-input-output-type"])("%s", (subDir) => {
+  describe.each(fixtureSubDirs)("%s", (subDir) => {
     const subDirPath = join(fixtureDir, subDir);
     it.concurrent.each(getTestFileMetadata(subDirPath))(
       `transforms: %s.%s`,

--- a/src/transforms/v2-to-v3/utils/config/constants.ts
+++ b/src/transforms/v2-to-v3/utils/config/constants.ts
@@ -1,5 +1,4 @@
 export const PACKAGE_NAME = "aws-sdk";
 
-// ToDo: Add Request and Response suffixes in future version.
-export const V2_CLIENT_INPUT_SUFFIX_LIST = ["Input"];
-export const V2_CLIENT_OUTPUT_SUFFIX_LIST = ["Output"];
+export const V2_CLIENT_INPUT_SUFFIX_LIST = ["Input", "Request"];
+export const V2_CLIENT_OUTPUT_SUFFIX_LIST = ["Output", "Response"];


### PR DESCRIPTION
### Issue

Fix https://github.com/awslabs/aws-sdk-js-codemod/issues/219

### Description

Replace named imports for Request/Response types

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
