### PR TITLE
Use for loop for getClientIdNames

### DIFF
--- a/src/transforms/v2-to-v3/utils/get/getV2ClientIdNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientIdNamesFromNewExpr.ts
@@ -51,14 +51,13 @@ export const getV2ClientIdNamesFromNewExpr = (
     callee: { type: "Identifier", name: v2ClientName },
   } as NewExpression;
 
-  const namesFromDefaultModule = [
-    ...getNamesFromVariableDeclarator(j, source, defaultNewExpr),
-    ...getNamesFromAssignmentPattern(j, source, defaultNewExpr),
-  ];
-  const namesFromServiceModule = [
-    ...getNamesFromVariableDeclarator(j, source, clientNewExpr),
-    ...getNamesFromAssignmentPattern(j, source, clientNewExpr),
-  ];
+  const namesFromDefaultModule = [];
+  const namesFromServiceModule = [];
+
+  for (const getNames of [getNamesFromVariableDeclarator, getNamesFromAssignmentPattern]) {
+    namesFromDefaultModule.push(...getNames(j, source, defaultNewExpr));
+    namesFromServiceModule.push(...getNames(j, source, clientNewExpr));
+  }
 
   return getMergedArrayWithoutDuplicates(namesFromDefaultModule, namesFromServiceModule);
 };


### PR DESCRIPTION
### Issue

Refactoring to help with DynamoDB DocumentClient support in https://github.com/awslabs/aws-sdk-js-codemod/pull/50

### Description

Uses a for loop for getClientIdNames

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
