### PR TITLE
Use filter with isV2ClientInputOutputType in replaceTSTypeReference

### DIFF
--- a/src/transforms/v2-to-v3/utils/replace/replaceTSTypeReference.ts
+++ b/src/transforms/v2-to-v3/utils/replace/replaceTSTypeReference.ts
@@ -16,26 +16,10 @@ export interface ReplaceTypeReferenceOptions {
   v2DefaultModuleName: string;
 }
 
-const getV3ClientTypeFromRightIdentifier = (
-  j: JSCodeshift,
-  v2ClientType: ASTPath<TSTypeReference>
-) => {
-  const v3ClientType = getV3ClientTypeName(
-    ((v2ClientType.node.typeName as TSQualifiedName).right as Identifier).name
-  );
-  if (!v3ClientType) {
-    return v2ClientType.node;
-  }
-  return j.tsTypeReference(j.identifier(v3ClientType));
-};
+const getRightIdentifierName = (node: TSTypeReference) =>
+  ((node.typeName as TSQualifiedName).right as Identifier).name;
 
-const getV3ClientTypeFromIdentifier = (j: JSCodeshift, v2ClientType: ASTPath<TSTypeReference>) => {
-  const v3ClientType = getV3ClientTypeName((v2ClientType.node.typeName as Identifier).name);
-  if (!v3ClientType) {
-    return v2ClientType.node;
-  }
-  return j.tsTypeReference(j.identifier(v3ClientType));
-};
+const getIdentifierName = (node: TSTypeReference) => (node.typeName as Identifier).name;
 
 // Replace v2 client type reference with v3 client type reference.
 export const replaceTSTypeReference = (
@@ -67,7 +51,8 @@ export const replaceTSTypeReference = (
         right: { type: "Identifier" },
       },
     })
-    .replaceWith((v2ClientType) => getV3ClientTypeFromRightIdentifier(j, v2ClientType));
+    .filter((v2ClientType) => isV2ClientInputOutputType(getRightIdentifierName(v2ClientType.node)))
+    .replaceWith((v2ClientType) => getV3ClientTypeName(getRightIdentifierName(v2ClientType.node)));
 
   // Replace type reference to client created with client module.
   source
@@ -76,20 +61,19 @@ export const replaceTSTypeReference = (
         left: { type: "Identifier", name: v2ClientName },
       },
     })
-    .replaceWith((v2ClientType) => getV3ClientTypeFromRightIdentifier(j, v2ClientType));
+    .filter((v2ClientType) => isV2ClientInputOutputType(getRightIdentifierName(v2ClientType.node)))
+    .replaceWith((v2ClientType) => getV3ClientTypeName(getRightIdentifierName(v2ClientType.node)));
 
   // Replace type reference to client input/output import with named imports.
-  const v2ClientTypeNames = getV2ClientTypeNames(j, source, {
-    v2ClientName,
-    v2DefaultModuleName,
-  });
+  const v2ClientTypeNames = getV2ClientTypeNames(j, source, { v2ClientName, v2DefaultModuleName });
   for (const v2ClientTypeName of v2ClientTypeNames) {
     if (isV2ClientInputOutputType(v2ClientTypeName)) {
       source
         .find(j.TSTypeReference, {
           typeName: { type: "Identifier", name: v2ClientTypeName },
         })
-        .replaceWith((v2ClientType) => getV3ClientTypeFromIdentifier(j, v2ClientType));
+        .filter((v2ClientType) => isV2ClientInputOutputType(getIdentifierName(v2ClientType.node)))
+        .replaceWith((v2ClientType) => getV3ClientTypeName(getIdentifierName(v2ClientType.node)));
     }
   }
 };


### PR DESCRIPTION
### Issue

Improvement noticed in https://github.com/awslabs/aws-sdk-js-codemod/pull/224

### Description

Use filter with isV2ClientInputOutputType in replaceTSTypeReference

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
