### PR TITLE
Rename v2DefaultModuleName to v2GlobalName

### DIFF
--- a/.changeset/dirty-wombats-double.md
+++ b/.changeset/dirty-wombats-double.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Rename v2DefaultModuleName to v2GlobalName to align with v2ClientName

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -34,24 +34,15 @@ export default function transformer(file: FileInfo, api: API) {
 
   for (const [v2ClientName, v3ClientMetadata] of Object.entries(clientMetadata).reverse()) {
     const { v3ClientName, v3ClientPackageName } = v3ClientMetadata;
-    addV3ClientModules(j, source, {
-      v2ClientName,
-      v3ClientName,
-      v3ClientPackageName,
-      v2GlobalName: v2GlobalName,
-    });
-    replaceTSTypeReference(j, source, {
-      v2ClientName,
-      v2GlobalName: v2GlobalName,
-      v3ClientName,
-    });
-    removeV2ClientModule(j, source, { v2ClientName, v2GlobalName: v2GlobalName });
-    removePromiseCalls(j, source, { v2ClientName, v2GlobalName: v2GlobalName });
-    replaceClientCreation(j, source, {
-      v2ClientName,
-      v2GlobalName: v2GlobalName,
-      v3ClientName,
-    });
+
+    const v2Options = { v2ClientName, v2GlobalName };
+    const v3Options = { v3ClientName, v3ClientPackageName };
+
+    addV3ClientModules(j, source, { ...v2Options, ...v3Options });
+    replaceTSTypeReference(j, source, { ...v2Options, v3ClientName });
+    removeV2ClientModule(j, source, v2Options);
+    removePromiseCalls(j, source, v2Options);
+    replaceClientCreation(j, source, { ...v2Options, v3ClientName });
   }
 
   removeDefaultModuleIfNotUsed(j, source, v2GlobalName);

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -5,7 +5,7 @@ import {
   getClientMetadata,
   getV2ClientNames,
   getV2ClientNamesFromDefault,
-  getV2DefaultModuleName,
+  getV2GlobalName,
   isTypeScriptFile,
   removeDefaultModuleIfNotUsed,
   removePromiseCalls,
@@ -20,7 +20,7 @@ export default function transformer(file: FileInfo, api: API) {
 
   // ToDo: Make v2DefaultModuleName optional downstream as it can be undefined.
   // ToDo: Rename v2DefaultModuleName to v2GlobalName to align with v2ClientName.
-  const v2DefaultModuleName = getV2DefaultModuleName(j, source) as string;
+  const v2DefaultModuleName = getV2GlobalName(j, source) as string;
   const v2ClientNames = getV2ClientNames(j, source);
 
   if (!v2DefaultModuleName && v2ClientNames.length === 0) {

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -4,7 +4,7 @@ import {
   addV3ClientModules,
   getClientMetadata,
   getV2ClientNames,
-  getV2ClientNamesFromDefault,
+  getV2ClientNamesFromGlobal,
   getV2GlobalName,
   isTypeScriptFile,
   removePromiseCalls,
@@ -27,7 +27,7 @@ export default function transformer(file: FileInfo, api: API) {
   }
 
   if (v2GlobalName) {
-    v2ClientNames.push(...getV2ClientNamesFromDefault(j, source, v2GlobalName));
+    v2ClientNames.push(...getV2ClientNamesFromGlobal(j, source, v2GlobalName));
   }
 
   const clientMetadata = getClientMetadata(v2ClientNames);

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -7,9 +7,9 @@ import {
   getV2ClientNamesFromDefault,
   getV2GlobalName,
   isTypeScriptFile,
-  removeDefaultModuleIfNotUsed,
   removePromiseCalls,
   removeV2ClientModule,
+  removeV2GlobalModule,
   replaceClientCreation,
   replaceTSTypeReference,
 } from "./utils";
@@ -45,7 +45,7 @@ export default function transformer(file: FileInfo, api: API) {
     replaceClientCreation(j, source, { ...v2Options, v3ClientName });
   }
 
-  removeDefaultModuleIfNotUsed(j, source, v2GlobalName);
+  removeV2GlobalModule(j, source, v2GlobalName);
 
   return source.toSource();
 }

--- a/src/transforms/v2-to-v3/utils/add/addV3ClientImports.ts
+++ b/src/transforms/v2-to-v3/utils/add/addV3ClientImports.ts
@@ -8,12 +8,7 @@ import { AddV3ClientModulesOptions } from "./addV3ClientModules";
 export const addV3ClientImports = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  {
-    v2ClientName,
-    v3ClientName,
-    v3ClientPackageName,
-    v2DefaultModuleName,
-  }: AddV3ClientModulesOptions
+  { v2ClientName, v3ClientName, v3ClientPackageName, v2GlobalName }: AddV3ClientModulesOptions
 ): void => {
   const existingImports = source.find(j.ImportDeclaration, {
     source: { value: v3ClientPackageName },
@@ -41,7 +36,7 @@ export const addV3ClientImports = (
   }
 
   // Add require for input/output types, if needed.
-  const v3ClientTypeNames = getV3ClientTypeNames(j, source, { v2ClientName, v2DefaultModuleName });
+  const v3ClientTypeNames = getV3ClientTypeNames(j, source, { v2ClientName, v2GlobalName });
 
   if (v3ClientTypeNames.length > 0) {
     const clientImports = source.find(j.ImportDeclaration, {

--- a/src/transforms/v2-to-v3/utils/add/addV3ClientModules.ts
+++ b/src/transforms/v2-to-v3/utils/add/addV3ClientModules.ts
@@ -8,7 +8,7 @@ export interface AddV3ClientModulesOptions {
   v2ClientName: string;
   v3ClientName: string;
   v3ClientPackageName: string;
-  v2DefaultModuleName: string;
+  v2GlobalName: string;
 }
 
 export const addV3ClientModules = (

--- a/src/transforms/v2-to-v3/utils/add/addV3ClientRequires.ts
+++ b/src/transforms/v2-to-v3/utils/add/addV3ClientRequires.ts
@@ -20,12 +20,7 @@ const getClientProperty = (j: JSCodeshift, name: Identifier) =>
 export const addV3ClientRequires = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  {
-    v2ClientName,
-    v3ClientName,
-    v3ClientPackageName,
-    v2DefaultModuleName,
-  }: AddV3ClientModulesOptions
+  { v2ClientName, v3ClientName, v3ClientPackageName, v2GlobalName }: AddV3ClientModulesOptions
 ): void => {
   const v3ClientNameProperty = getClientProperty(j, j.identifier(v3ClientName));
   const existingRequires = getRequireVariableDeclaration(j, source, v3ClientPackageName);
@@ -54,7 +49,7 @@ export const addV3ClientRequires = (
   }
 
   // Add require for input/output types, if needed.
-  const v3ClientTypeNames = getV3ClientTypeNames(j, source, { v2ClientName, v2DefaultModuleName });
+  const v3ClientTypeNames = getV3ClientTypeNames(j, source, { v2ClientName, v2GlobalName });
 
   if (v3ClientTypeNames.length > 0) {
     const clientRequires = getRequireVariableDeclaration(j, source, v3ClientPackageName);

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientIdNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientIdNamesFromNewExpr.ts
@@ -39,15 +39,15 @@ export const getV2ClientIdNamesFromNewExpr = (
   source: Collection<unknown>,
   { v2GlobalName, v2ClientName }: GetV2ClientIdNamesFromNewExprOptions
 ): string[] => {
-  const namesFromDefaultModule = [];
+  const namesFromGlobalModule = [];
   const namesFromServiceModule = [];
 
   for (const getNames of [getNamesFromVariableDeclarator, getNamesFromAssignmentPattern]) {
-    namesFromDefaultModule.push(
+    namesFromGlobalModule.push(
       ...getNames(j, source, getV2ClientNewExpression({ v2GlobalName, v2ClientName }))
     );
     namesFromServiceModule.push(...getNames(j, source, getV2ClientNewExpression({ v2ClientName })));
   }
 
-  return getMergedArrayWithoutDuplicates(namesFromDefaultModule, namesFromServiceModule);
+  return getMergedArrayWithoutDuplicates(namesFromGlobalModule, namesFromServiceModule);
 };

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientIdNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientIdNamesFromNewExpr.ts
@@ -5,7 +5,7 @@ import { getV2ClientNewExpression } from "./getV2ClientNewExpression";
 
 export interface GetV2ClientIdNamesFromNewExprOptions {
   v2ClientName: string;
-  v2DefaultModuleName: string;
+  v2GlobalName: string;
 }
 
 const getNamesFromVariableDeclarator = (
@@ -37,14 +37,14 @@ const getNamesFromAssignmentPattern = (
 export const getV2ClientIdNamesFromNewExpr = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2DefaultModuleName, v2ClientName }: GetV2ClientIdNamesFromNewExprOptions
+  { v2GlobalName, v2ClientName }: GetV2ClientIdNamesFromNewExprOptions
 ): string[] => {
   const namesFromDefaultModule = [];
   const namesFromServiceModule = [];
 
   for (const getNames of [getNamesFromVariableDeclarator, getNamesFromAssignmentPattern]) {
     namesFromDefaultModule.push(
-      ...getNames(j, source, getV2ClientNewExpression({ v2DefaultModuleName, v2ClientName }))
+      ...getNames(j, source, getV2ClientNewExpression({ v2GlobalName, v2ClientName }))
     );
     namesFromServiceModule.push(...getNames(j, source, getV2ClientNewExpression({ v2ClientName })));
   }

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientIdNamesFromTSTypeRef.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientIdNamesFromTSTypeRef.ts
@@ -12,7 +12,7 @@ export const getV2ClientIdNamesFromTSTypeRef = (
   source: Collection<unknown>,
   { v2GlobalName, v2ClientName }: GetV2ClientIdNamesFromTSTypeRefOptions
 ): string[] => {
-  const clientIdNamesFromDefaultModule = source
+  const clientIdNamesFromGlobalModule = source
     .find(j.Identifier, {
       typeAnnotation: {
         typeAnnotation: {
@@ -38,7 +38,7 @@ export const getV2ClientIdNamesFromTSTypeRef = (
     .map((identifier) => identifier.name);
 
   return getMergedArrayWithoutDuplicates(
-    clientIdNamesFromDefaultModule,
+    clientIdNamesFromGlobalModule,
     clientIdNamesFromServiceModule
   );
 };

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientIdNamesFromTSTypeRef.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientIdNamesFromTSTypeRef.ts
@@ -4,20 +4,20 @@ import { getMergedArrayWithoutDuplicates } from "./getMergedArrayWithoutDuplicat
 
 export interface GetV2ClientIdNamesFromTSTypeRefOptions {
   v2ClientName: string;
-  v2DefaultModuleName: string;
+  v2GlobalName: string;
 }
 
 export const getV2ClientIdNamesFromTSTypeRef = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2DefaultModuleName, v2ClientName }: GetV2ClientIdNamesFromTSTypeRefOptions
+  { v2GlobalName, v2ClientName }: GetV2ClientIdNamesFromTSTypeRefOptions
 ): string[] => {
   const clientIdNamesFromDefaultModule = source
     .find(j.Identifier, {
       typeAnnotation: {
         typeAnnotation: {
           typeName: {
-            left: { name: v2DefaultModuleName },
+            left: { name: v2GlobalName },
             right: { name: v2ClientName },
           },
         },

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientIdentifiers.ts
@@ -6,21 +6,21 @@ import { getV2ClientIdNamesFromTSTypeRef } from "./getV2ClientIdNamesFromTSTypeR
 
 export interface GetV2ClientIdNamesOptions {
   v2ClientName: string;
-  v2DefaultModuleName: string;
+  v2GlobalName: string;
 }
 
 export const getV2ClientIdentifiers = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2DefaultModuleName, v2ClientName }: GetV2ClientIdNamesOptions
+  { v2GlobalName, v2ClientName }: GetV2ClientIdNamesOptions
 ): Identifier[] => {
   const v2ClientIdNamesFromNewExpr = getV2ClientIdNamesFromNewExpr(j, source, {
-    v2DefaultModuleName,
+    v2GlobalName,
     v2ClientName,
   });
 
   const v2ClientIdNamesFromTSTypeRef = getV2ClientIdNamesFromTSTypeRef(j, source, {
-    v2DefaultModuleName,
+    v2GlobalName,
     v2ClientName,
   });
 

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesFromDefault.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesFromDefault.ts
@@ -7,10 +7,10 @@ import { getV2ClientNamesFromTSTypeRef } from "./getV2ClientNamesFromTSTypeRef";
 export const getV2ClientNamesFromDefault = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  v2DefaultModuleName: string
+  v2GlobalName: string
 ): string[] => {
-  const v2ClientNamesFromNewExpr = getV2ClientNamesFromNewExpr(j, source, v2DefaultModuleName);
-  const v2ClientNamesFromTSTypeRef = getV2ClientNamesFromTSTypeRef(j, source, v2DefaultModuleName);
+  const v2ClientNamesFromNewExpr = getV2ClientNamesFromNewExpr(j, source, v2GlobalName);
+  const v2ClientNamesFromTSTypeRef = getV2ClientNamesFromTSTypeRef(j, source, v2GlobalName);
 
   return getMergedArrayWithoutDuplicates(v2ClientNamesFromNewExpr, v2ClientNamesFromTSTypeRef);
 };

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesFromGlobal.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesFromGlobal.ts
@@ -4,7 +4,7 @@ import { getMergedArrayWithoutDuplicates } from "./getMergedArrayWithoutDuplicat
 import { getV2ClientNamesFromNewExpr } from "./getV2ClientNamesFromNewExpr";
 import { getV2ClientNamesFromTSTypeRef } from "./getV2ClientNamesFromTSTypeRef";
 
-export const getV2ClientNamesFromDefault = (
+export const getV2ClientNamesFromGlobal = (
   j: JSCodeshift,
   source: Collection<unknown>,
   v2GlobalName: string

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesFromNewExpr.ts
@@ -5,10 +5,10 @@ import { getV2ClientNewExpression } from "../get";
 export const getV2ClientNamesFromNewExpr = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  v2DefaultModuleName: string
+  v2GlobalName: string
 ): string[] =>
   source
-    .find(j.NewExpression, getV2ClientNewExpression({ v2DefaultModuleName }))
+    .find(j.NewExpression, getV2ClientNewExpression({ v2GlobalName }))
     .nodes()
     .map(
       (newExpression) => ((newExpression.callee as MemberExpression).property as Identifier).name

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesFromTSTypeRef.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesFromTSTypeRef.ts
@@ -3,11 +3,11 @@ import { Collection, Identifier, JSCodeshift, TSQualifiedName } from "jscodeshif
 export const getV2ClientNamesFromTSTypeRef = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  v2DefaultModuleName: string
+  v2GlobalName: string
 ): string[] =>
   source
     .find(j.TSTypeReference, {
-      typeName: { left: { name: v2DefaultModuleName } },
+      typeName: { left: { name: v2GlobalName } },
     })
     .nodes()
     .map(

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNewExpression.ts
@@ -1,26 +1,26 @@
 import { NewExpression } from "jscodeshift";
 
 export interface ClientNewExpressionOptions {
-  v2DefaultModuleName?: string;
+  v2GlobalName?: string;
   v2ClientName?: string;
   isDocumentClient?: boolean;
 }
 
 export const getV2ClientNewExpression = ({
-  v2DefaultModuleName,
+  v2GlobalName,
   v2ClientName,
 }: ClientNewExpressionOptions): NewExpression => {
-  if (!v2DefaultModuleName && !v2ClientName) {
+  if (!v2GlobalName && !v2ClientName) {
     throw new Error(
-      `At least one of the following options must be provided: v2DefaultModuleName, v2ClientName`
+      `At least one of the following options must be provided: v2GlobalName, v2ClientName`
     );
   }
 
-  if (v2DefaultModuleName) {
+  if (v2GlobalName) {
     return {
       type: "NewExpression",
       callee: {
-        object: { type: "Identifier", name: v2DefaultModuleName },
+        object: { type: "Identifier", name: v2GlobalName },
         property: { type: "Identifier", ...(v2ClientName && { name: v2ClientName }) },
       },
     } as NewExpression;

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientTSTypeRef.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientTSTypeRef.ts
@@ -1,20 +1,20 @@
 import { Identifier, TSQualifiedName, TSTypeReference } from "jscodeshift";
 
 export interface V2ClientTsTypeRefOptions {
-  v2DefaultModuleName?: string;
+  v2GlobalName?: string;
   v2ClientName: string;
   withoutRightSection?: boolean;
 }
 
 export const getV2ClientTSTypeRef = ({
-  v2DefaultModuleName,
+  v2GlobalName,
   v2ClientName,
   withoutRightSection = false,
 }: V2ClientTsTypeRefOptions): TSTypeReference => {
-  if (v2DefaultModuleName) {
+  if (v2GlobalName) {
     const idWithGlobalName = {
       type: "TSQualifiedName",
-      left: { type: "Identifier", name: v2DefaultModuleName },
+      left: { type: "Identifier", name: v2GlobalName },
       right: { type: "Identifier", name: v2ClientName },
     } as TSQualifiedName;
 

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientTypeNames.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientTypeNames.ts
@@ -13,7 +13,7 @@ import { getV2ServiceModulePath } from "./getV2ServiceModulePath";
 
 export interface GetV2ClientTypeNamesOptions {
   v2ClientName: string;
-  v2DefaultModuleName: string;
+  v2GlobalName: string;
 }
 
 const getRightIdentifierName = (
@@ -31,11 +31,11 @@ const getRightIdentifierName = (
 export const getV2ClientTypeNames = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientName, v2DefaultModuleName }: GetV2ClientTypeNamesOptions
+  { v2ClientName, v2GlobalName }: GetV2ClientTypeNamesOptions
 ): string[] => {
   const v2GlobalTSTypeRef = getV2ClientTSTypeRef({
     v2ClientName,
-    v2DefaultModuleName,
+    v2GlobalName,
     withoutRightSection: true,
   });
   const v2ClientTSTypeRef = getV2ClientTSTypeRef({ v2ClientName, withoutRightSection: true });

--- a/src/transforms/v2-to-v3/utils/get/getV2GlobalName.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2GlobalName.ts
@@ -5,7 +5,7 @@ import { containsRequire } from "../containsRequire";
 import { getImportSpecifiers } from "./getImportSpecifiers";
 import { getRequireIdentifierName } from "./getRequireIdentifierName";
 
-export const getV2DefaultModuleName = (
+export const getV2GlobalName = (
   j: JSCodeshift,
   source: Collection<unknown>
 ): string | undefined => {

--- a/src/transforms/v2-to-v3/utils/get/index.ts
+++ b/src/transforms/v2-to-v3/utils/get/index.ts
@@ -3,7 +3,7 @@ export * from "./getRequireVariableDeclaration";
 export * from "./getV2ClientIdentifiers";
 export * from "./getV2ClientIdThisExpressions";
 export * from "./getV2ClientNames";
-export * from "./getV2ClientNamesFromDefault";
+export * from "./getV2ClientNamesFromGlobal";
 export * from "./getV2ClientNewExpression";
 export * from "./getV2ClientTSTypeRef";
 export * from "./getV2ClientTypeNames";

--- a/src/transforms/v2-to-v3/utils/get/index.ts
+++ b/src/transforms/v2-to-v3/utils/get/index.ts
@@ -7,7 +7,7 @@ export * from "./getV2ClientNamesFromDefault";
 export * from "./getV2ClientNewExpression";
 export * from "./getV2ClientTSTypeRef";
 export * from "./getV2ClientTypeNames";
-export * from "./getV2DefaultModuleName";
+export * from "./getV2GlobalName";
 export * from "./getV2ServiceModulePath";
 export * from "./getV3ClientTypeName";
 export * from "./getV3ClientTypeNames";

--- a/src/transforms/v2-to-v3/utils/remove/index.ts
+++ b/src/transforms/v2-to-v3/utils/remove/index.ts
@@ -1,3 +1,3 @@
-export * from "./removeDefaultModuleIfNotUsed";
 export * from "./removePromiseCalls";
 export * from "./removeV2ClientModule";
+export * from "./removeV2GlobalModule";

--- a/src/transforms/v2-to-v3/utils/remove/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/utils/remove/removePromiseCalls.ts
@@ -5,17 +5,17 @@ import { removePromiseForCallExpression } from "./removePromiseForCallExpression
 
 export interface RemovePromiseCallsOptions {
   v2ClientName: string;
-  v2DefaultModuleName: string;
+  v2GlobalName: string;
 }
 
 // Removes .promise() from client API calls.
 export const removePromiseCalls = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2DefaultModuleName, v2ClientName }: RemovePromiseCallsOptions
+  { v2GlobalName, v2ClientName }: RemovePromiseCallsOptions
 ): void => {
   const v2ClientIdentifiers = getV2ClientIdentifiers(j, source, {
-    v2DefaultModuleName,
+    v2GlobalName,
     v2ClientName,
   });
   const v2ClientIdThisExpressions = getV2ClientIdThisExpressions(j, source, v2ClientIdentifiers);

--- a/src/transforms/v2-to-v3/utils/remove/removeV2ClientModule.ts
+++ b/src/transforms/v2-to-v3/utils/remove/removeV2ClientModule.ts
@@ -8,13 +8,13 @@ import { removeRequireIdentifierName } from "./removeRequireIdentifierName";
 
 export interface RemoveV2ClientModuleOptions {
   v2ClientName: string;
-  v2DefaultModuleName: string;
+  v2GlobalName: string;
 }
 
 export const removeV2ClientModule = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientName, v2DefaultModuleName }: RemoveV2ClientModuleOptions
+  { v2ClientName, v2GlobalName }: RemoveV2ClientModuleOptions
 ) => {
   const literalValue = getV2ServiceModulePath(v2ClientName);
   const removeIdentifierNameOptions = {
@@ -29,7 +29,7 @@ export const removeV2ClientModule = (
 
     const v2ClientTypeNames = getV2ClientTypeNames(j, source, {
       v2ClientName,
-      v2DefaultModuleName,
+      v2GlobalName,
     });
     for (const v2ClientTypeName of v2ClientTypeNames) {
       if (isV2ClientInputOutputType(v2ClientTypeName)) {

--- a/src/transforms/v2-to-v3/utils/remove/removeV2GlobalModule.ts
+++ b/src/transforms/v2-to-v3/utils/remove/removeV2GlobalModule.ts
@@ -5,17 +5,17 @@ import { containsRequire } from "../containsRequire";
 import { removeImportIdentifierName } from "./removeImportIdentifierName";
 import { removeRequireIdentifierName } from "./removeRequireIdentifierName";
 
-export const removeDefaultModuleIfNotUsed = (
+export const removeV2GlobalModule = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  defaultModuleName: string
+  v2GlobalName: string
 ) => {
-  const identifierUsages = source.find(j.Identifier, { name: defaultModuleName });
+  const identifierUsages = source.find(j.Identifier, { name: v2GlobalName });
 
   // Only usage is import/require.
   if (identifierUsages.size() === 1) {
     const removeIdentifierNameOptions = {
-      identifierName: defaultModuleName,
+      identifierName: v2GlobalName,
       literalValue: PACKAGE_NAME,
     };
     if (containsRequire(j, source)) {

--- a/src/transforms/v2-to-v3/utils/replace/replaceClientCreation.ts
+++ b/src/transforms/v2-to-v3/utils/replace/replaceClientCreation.ts
@@ -5,18 +5,18 @@ import { getV2ClientNewExpression } from "../get";
 export interface ReplaceClientCreationOptions {
   v2ClientName: string;
   v3ClientName: string;
-  v2DefaultModuleName: string;
+  v2GlobalName: string;
 }
 
 // Replace v2 client creation with v3 client creation.
 export const replaceClientCreation = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2DefaultModuleName, v2ClientName, v3ClientName }: ReplaceClientCreationOptions
+  { v2GlobalName, v2ClientName, v3ClientName }: ReplaceClientCreationOptions
 ): void => {
   // Replace clients created with default module.
   source
-    .find(j.NewExpression, getV2ClientNewExpression({ v2DefaultModuleName, v2ClientName }))
+    .find(j.NewExpression, getV2ClientNewExpression({ v2GlobalName, v2ClientName }))
     .replaceWith((v2ClientNewExpression) =>
       j.newExpression(j.identifier(v3ClientName), v2ClientNewExpression.node.arguments)
     );

--- a/src/transforms/v2-to-v3/utils/replace/replaceTSTypeReference.ts
+++ b/src/transforms/v2-to-v3/utils/replace/replaceTSTypeReference.ts
@@ -6,7 +6,7 @@ import { isV2ClientInputOutputType } from "../isV2ClientInputOutputType";
 export interface ReplaceTypeReferenceOptions {
   v2ClientName: string;
   v3ClientName: string;
-  v2DefaultModuleName: string;
+  v2GlobalName: string;
 }
 
 const isRightSectionIdentifier = (node: TSTypeReference) =>
@@ -21,11 +21,11 @@ const getIdentifierName = (node: TSTypeReference) => (node.typeName as Identifie
 export const replaceTSTypeReference = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2DefaultModuleName, v2ClientName, v3ClientName }: ReplaceTypeReferenceOptions
+  { v2GlobalName, v2ClientName, v3ClientName }: ReplaceTypeReferenceOptions
 ): void => {
   // Replace type reference to client created with default module.
   source
-    .find(j.TSTypeReference, getV2ClientTSTypeRef({ v2ClientName, v2DefaultModuleName }))
+    .find(j.TSTypeReference, getV2ClientTSTypeRef({ v2ClientName, v2GlobalName }))
     .replaceWith((v2ClientType) =>
       j.tsTypeReference(j.identifier(v3ClientName), v2ClientType.node.typeParameters)
     );
@@ -34,7 +34,7 @@ export const replaceTSTypeReference = (
   source
     .find(
       j.TSTypeReference,
-      getV2ClientTSTypeRef({ v2ClientName, v2DefaultModuleName, withoutRightSection: true })
+      getV2ClientTSTypeRef({ v2ClientName, v2GlobalName, withoutRightSection: true })
     )
     .filter((v2ClientType) => isRightSectionIdentifier(v2ClientType.node))
     .filter((v2ClientType) => isV2ClientInputOutputType(getRightIdentifierName(v2ClientType.node)))
@@ -48,7 +48,7 @@ export const replaceTSTypeReference = (
     .replaceWith((v2ClientType) => getV3ClientTypeName(getRightIdentifierName(v2ClientType.node)));
 
   // Replace type reference to client input/output import with named imports.
-  const v2ClientTypeNames = getV2ClientTypeNames(j, source, { v2ClientName, v2DefaultModuleName });
+  const v2ClientTypeNames = getV2ClientTypeNames(j, source, { v2ClientName, v2GlobalName });
   for (const v2ClientTypeName of v2ClientTypeNames) {
     if (isV2ClientInputOutputType(v2ClientTypeName)) {
       source


### PR DESCRIPTION
### Issue

N/A

### Description

Rename v2DefaultModuleName to v2GlobalName to align with v2ClientName

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
