### PR TITLE
Remove Content suffix from scripts/generateNewClientTests

### DIFF
--- a/scripts/generateNewClientTests/getGlobalImportInput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportInput.ts
@@ -1,6 +1,6 @@
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
-export const getGlobalImportInputContent = (codegenComment: string) => {
+export const getGlobalImportInput = (codegenComment: string) => {
   let globalImportInputContent = `${codegenComment}\n`;
 
   globalImportInputContent += `import AWS from "aws-sdk";\n\n`;

--- a/scripts/generateNewClientTests/getGlobalImportOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportOutput.ts
@@ -2,7 +2,7 @@ import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPacka
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 import { getV3PackageImportsCode } from "./getV3PackageImportsCode";
 
-export const getGlobalImportOutputContent = (codegenComment: string) => {
+export const getGlobalImportOutput = (codegenComment: string) => {
   let globalImportOutputContent = `${codegenComment}\n`;
 
   globalImportOutputContent += getV3PackageImportsCode(getClientNamesSortedByPackageName());

--- a/scripts/generateNewClientTests/getGlobalRequireInput.ts
+++ b/scripts/generateNewClientTests/getGlobalRequireInput.ts
@@ -1,6 +1,6 @@
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
-export const getGlobalRequireInputContent = (codegenComment: string) => {
+export const getGlobalRequireInput = (codegenComment: string) => {
   let globalRequireInputContent = `${codegenComment}\n`;
 
   globalRequireInputContent += `const AWS = require("aws-sdk");\n\n`;

--- a/scripts/generateNewClientTests/getGlobalRequireOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalRequireOutput.ts
@@ -2,7 +2,7 @@ import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPacka
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 import { getV3PackageRequireCode } from "./getV3PackageRequireCode";
 
-export const getGlobalRequireOutputContent = (codegenComment: string) => {
+export const getGlobalRequireOutput = (codegenComment: string) => {
   let globalRequireOutputContent = `${codegenComment}\n\n`;
 
   globalRequireOutputContent += getV3PackageRequireCode(getClientNamesSortedByPackageName(), {

--- a/scripts/generateNewClientTests/getServiceImportDeepInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepInput.ts
@@ -1,7 +1,7 @@
 import { CLIENT_NAMES } from "../../src/transforms/v2-to-v3/utils/config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
-export const getServiceImportInputContent = (codegenComment: string) => {
+export const getServiceImportDeepInput = (codegenComment: string) => {
   let serviceImportInputContent = `${codegenComment}\n`;
 
   for (const clientName of CLIENT_NAMES) {

--- a/scripts/generateNewClientTests/getServiceImportDeepOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepOutput.ts
@@ -2,7 +2,7 @@ import { CLIENT_NAMES } from "../../src/transforms/v2-to-v3/utils/config";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 import { getV3PackageImportsCode } from "./getV3PackageImportsCode";
 
-export const getServiceImportOutputContent = (codegenComment: string) => {
+export const getServiceImportDeepOutput = (codegenComment: string) => {
   let serviceImportOutputContent = `${codegenComment}\n`;
 
   serviceImportOutputContent += getV3PackageImportsCode(CLIENT_NAMES);

--- a/scripts/generateNewClientTests/getServiceRequireDeepInput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireDeepInput.ts
@@ -1,7 +1,7 @@
 import { CLIENT_NAMES } from "../../src/transforms/v2-to-v3/utils/config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
-export const getServiceRequireInputContent = (codegenComment: string) => {
+export const getServiceRequireDeepInput = (codegenComment: string) => {
   let serviceRequireInputContent = `${codegenComment}\n`;
 
   for (const clientName of CLIENT_NAMES) {

--- a/scripts/generateNewClientTests/getServiceRequireDeepOutput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireDeepOutput.ts
@@ -2,7 +2,7 @@ import { CLIENT_NAMES } from "../../src/transforms/v2-to-v3/utils/config";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 import { getV3PackageRequireCode } from "./getV3PackageRequireCode";
 
-export const getServiceRequireOutputContent = (codegenComment: string) => {
+export const getServiceRequireDeepOutput = (codegenComment: string) => {
   let serviceRequireOutputContent = `${codegenComment}\n`;
 
   serviceRequireOutputContent += getV3PackageRequireCode(CLIENT_NAMES);

--- a/scripts/generateNewClientTests/index.ts
+++ b/scripts/generateNewClientTests/index.ts
@@ -3,14 +3,14 @@
 import { writeFile } from "fs/promises";
 import { join } from "path";
 
-import { getGlobalImportInputContent } from "./getGlobalImportInputContent";
-import { getGlobalImportOutputContent } from "./getGlobalImportOutputContent";
-import { getGlobalRequireInputContent } from "./getGlobalRequireInputContent";
-import { getGlobalRequireOutputContent } from "./getGlobalRequireOutputContent";
-import { getServiceImportInputContent } from "./getServiceImportInputContent";
-import { getServiceImportOutputContent } from "./getServiceImportOutputContent";
-import { getServiceRequireInputContent } from "./getServiceRequireInputContent";
-import { getServiceRequireOutputContent } from "./getServiceRequireOutputContent";
+import { getGlobalImportInput } from "./getGlobalImportInput";
+import { getGlobalImportOutput } from "./getGlobalImportOutput";
+import { getGlobalRequireInput } from "./getGlobalRequireInput";
+import { getGlobalRequireOutput } from "./getGlobalRequireOutput";
+import { getServiceImportDeepInput } from "./getServiceImportDeepInput";
+import { getServiceImportDeepOutput } from "./getServiceImportDeepOutput";
+import { getServiceRequireDeepInput } from "./getServiceRequireDeepInput";
+import { getServiceRequireDeepOutput } from "./getServiceRequireDeepOutput";
 
 // The "use strict" directive is added to so that comments can be attached to it.
 // Recast removes the comments while removing import/require.
@@ -24,14 +24,14 @@ const newClientTestsPath = join(__dirname, "..", "..", newClientsTestsFolder);
 
 (async () => {
   for (const [fileName, getFileContent] of [
-    ["global-import.input.js", getGlobalImportInputContent],
-    ["global-import.output.js", getGlobalImportOutputContent],
-    ["global-require.input.js", getGlobalRequireInputContent],
-    ["global-require.output.js", getGlobalRequireOutputContent],
-    ["service-import-deep.input.js", getServiceImportInputContent],
-    ["service-import-deep.output.js", getServiceImportOutputContent],
-    ["service-require-deep.input.js", getServiceRequireInputContent],
-    ["service-require-deep.output.js", getServiceRequireOutputContent],
+    ["global-import.input.js", getGlobalImportInput],
+    ["global-import.output.js", getGlobalImportOutput],
+    ["global-require.input.js", getGlobalRequireInput],
+    ["global-require.output.js", getGlobalRequireOutput],
+    ["service-import-deep.input.js", getServiceImportDeepInput],
+    ["service-import-deep.output.js", getServiceImportDeepOutput],
+    ["service-require-deep.input.js", getServiceRequireDeepInput],
+    ["service-require-deep.output.js", getServiceRequireDeepOutput],
   ] as [string, (comment: string) => string][]) {
     const filePath = join(newClientTestsPath, fileName);
     await writeFile(filePath, getFileContent(codegenComment));


### PR DESCRIPTION
### Issue

For ease of naming in https://github.com/awslabs/aws-sdk-js-codemod/issues/242

### Description

Remove Content prefix from scripts/generateNewClientTests

### Testing

Ran the following scripts and verified tests haven't been updated:
```console
$ yarn tsx scripts/generateNewClientTests/index.ts
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
