### PR TITLE
Rename literalValue to sourceValue

### DIFF
--- a/src/transforms/v2-to-v3/utils/get/getImportIdentifierName.ts
+++ b/src/transforms/v2-to-v3/utils/get/getImportIdentifierName.ts
@@ -3,12 +3,12 @@ import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 export const getImportIdentifierName = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  literalValue: string
+  sourceValue: string
 ): string | undefined => {
   const importSpecifiers = source
     .find(j.ImportDeclaration, {
       type: "ImportDeclaration",
-      source: { value: literalValue },
+      source: { value: sourceValue },
     })
     .nodes()
     .map((importDeclaration) => importDeclaration.specifiers)

--- a/src/transforms/v2-to-v3/utils/get/getRequireIdentifierName.ts
+++ b/src/transforms/v2-to-v3/utils/get/getRequireIdentifierName.ts
@@ -3,7 +3,7 @@ import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 export const getRequireIdentifierName = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  literalValue: string
+  sourceValue: string
 ): string | undefined =>
   (
     source
@@ -12,7 +12,7 @@ export const getRequireIdentifierName = (
         init: {
           type: "CallExpression",
           callee: { type: "Identifier", name: "require" },
-          arguments: [{ value: literalValue }],
+          arguments: [{ value: sourceValue }],
         },
       })
       .nodes()[0]?.id as Identifier

--- a/src/transforms/v2-to-v3/utils/get/getRequireVariableDeclaration.ts
+++ b/src/transforms/v2-to-v3/utils/get/getRequireVariableDeclaration.ts
@@ -3,7 +3,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 export const getRequireVariableDeclaration = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  literalValue: string
+  sourceValue: string
 ) =>
   source.find(j.VariableDeclaration, {
     declarations: [
@@ -11,7 +11,7 @@ export const getRequireVariableDeclaration = (
         init: {
           type: "CallExpression",
           callee: { type: "Identifier", name: "require" },
-          arguments: [{ value: literalValue }],
+          arguments: [{ value: sourceValue }],
         },
       },
     ],

--- a/src/transforms/v2-to-v3/utils/remove/removeImportIdentifierName.ts
+++ b/src/transforms/v2-to-v3/utils/remove/removeImportIdentifierName.ts
@@ -3,7 +3,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 export interface RemoveImportIdentifierNameOptions {
   importedName?: string;
   localName: string;
-  literalValue: string;
+  sourceValue: string;
 }
 
 export const removeImportIdentifierName = (
@@ -11,13 +11,13 @@ export const removeImportIdentifierName = (
   source: Collection<unknown>,
   options: RemoveImportIdentifierNameOptions
 ) => {
-  const { localName, literalValue } = options;
+  const { localName, sourceValue } = options;
   const importedName = options.importedName ?? localName;
 
   source
     .find(j.ImportDeclaration, {
       specifiers: [{ local: { name: localName } }],
-      source: { value: literalValue },
+      source: { value: sourceValue },
     })
     .forEach((declarationPath) => {
       // Remove import from ImportDeclaration.

--- a/src/transforms/v2-to-v3/utils/remove/removeRequireIdentifierName.ts
+++ b/src/transforms/v2-to-v3/utils/remove/removeRequireIdentifierName.ts
@@ -4,15 +4,15 @@ import { getRequireVariableDeclaration } from "../get";
 
 export interface RemoveRequireIdentifierNameOptions {
   localName: string;
-  literalValue: string;
+  sourceValue: string;
 }
 
 export const removeRequireIdentifierName = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { localName, literalValue }: RemoveRequireIdentifierNameOptions
+  { localName, sourceValue }: RemoveRequireIdentifierNameOptions
 ) => {
-  getRequireVariableDeclaration(j, source, literalValue)
+  getRequireVariableDeclaration(j, source, sourceValue)
     .filter(
       (nodePath) =>
         ((nodePath.value.declarations[0] as VariableDeclarator).id as Identifier).name === localName

--- a/src/transforms/v2-to-v3/utils/remove/removeV2ClientModule.ts
+++ b/src/transforms/v2-to-v3/utils/remove/removeV2ClientModule.ts
@@ -18,10 +18,10 @@ export const removeV2ClientModule = (
   options: RemoveV2ClientModuleOptions
 ) => {
   const { v2ClientName, v2ClientLocalName } = options;
-  const literalValue = getV2ServiceModulePath(v2ClientName);
+  const sourceValue = getV2ServiceModulePath(v2ClientName);
   const removeIdentifierNameOptions = {
     localName: v2ClientLocalName,
-    literalValue,
+    sourceValue,
   };
 
   if (containsRequire(j, source)) {
@@ -34,7 +34,7 @@ export const removeV2ClientModule = (
       if (isV2ClientInputOutputType(v2ClientTypeName)) {
         removeImportIdentifierName(j, source, {
           localName: v2ClientTypeName,
-          literalValue,
+          sourceValue,
         });
       }
     }

--- a/src/transforms/v2-to-v3/utils/remove/removeV2GlobalModule.ts
+++ b/src/transforms/v2-to-v3/utils/remove/removeV2GlobalModule.ts
@@ -16,7 +16,7 @@ export const removeV2GlobalModule = (
   if (identifierUsages.size() === 1) {
     const removeIdentifierNameOptions = {
       localName: v2GlobalName,
-      literalValue: PACKAGE_NAME,
+      sourceValue: PACKAGE_NAME,
     };
     if (containsRequire(j, source)) {
       removeRequireIdentifierName(j, source, removeIdentifierNameOptions);


### PR DESCRIPTION
### Issue

Noticed in https://github.com/awslabs/aws-sdk-js-codemod/pull/245

### Description

Renames literalValue to sourceValue, as the value is stored in "source" key which is a Literal

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
