### PR TITLE
Remove dependency on runInlineTest from testUtils

### DIFF
--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -1,11 +1,9 @@
 import { readdirSync } from "fs";
 import { readFile } from "fs/promises";
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore: Could not find a declaration file for module 'jscodeshift/dist/testUtils'
-import { runInlineTest } from "jscodeshift/dist/testUtils";
+import jscodeshift from "jscodeshift";
 import { join } from "path";
 
-import transformer from "./transformer";
+import transform from "./transformer";
 
 describe("v2-to-v3", () => {
   jest.setTimeout(30000);
@@ -43,7 +41,17 @@ describe("v2-to-v3", () => {
       `transforms: %s.%s`,
       async (filePrefix, fileExtension) => {
         const { input, outputCode } = await getTestMetadata(subDirPath, filePrefix, fileExtension);
-        runInlineTest(transformer, null, input, outputCode);
+
+        const output = transform(input, {
+          j: jscodeshift,
+          jscodeshift,
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          stats: () => {},
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          report: () => {},
+        });
+
+        expect(output.trim()).toEqual(outputCode.trim());
       }
     );
   });


### PR DESCRIPTION
### Issue

Required for calling an async transformer in https://github.com/awslabs/aws-sdk-js-codemod/pull/252

### Description

Remove dependency on runInlineTest from testUtils

### Testing

CI

### Additional context

Support not present in testUtils: https://github.com/facebook/jscodeshift/issues/516

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
