### PR TITLE
Remove unused imports from addV3ClientRequires

### DIFF
--- a/src/transforms/v2-to-v3/utils/add/addV3ClientRequires.ts
+++ b/src/transforms/v2-to-v3/utils/add/addV3ClientRequires.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift, ObjectPattern, VariableDeclarator } from "jscodeshift";
+import { Collection, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
 import {


### PR DESCRIPTION
### Issue

Missed in https://github.com/awslabs/aws-sdk-js-codemod/pull/245

### Description

Remove unused imports from addV3ClientRequires

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
