### PR TITLE
Deep import search only for available clients

### DIFF
--- a/.changeset/new-zoos-explode.md
+++ b/.changeset/new-zoos-explode.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Deep import search only for available clients in getV2ClientNamesRecord

--- a/.changeset/new-zoos-explode.md
+++ b/.changeset/new-zoos-explode.md
@@ -2,4 +2,4 @@
 "aws-sdk-js-codemod": patch
 ---
 
-Deep import search only for available clients in getV2ClientNamesRecord
+Deep import search only for available clients

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -5,6 +5,7 @@ import {
   getClientMetadata,
   getV2ClientNamesFromGlobal,
   getV2ClientNamesRecord,
+  getV2ClientNamesWithServiceModule,
   getV2GlobalName,
   isTypeScriptFile,
   removePromiseCalls,
@@ -19,7 +20,8 @@ const transformer = async (file: FileInfo, api: API) => {
   const source = j(file.source);
 
   const v2GlobalName = getV2GlobalName(j, source);
-  const v2ClientNamesRecord = getV2ClientNamesRecord(j, source);
+  const v2ClientNamesWithServiceModule = getV2ClientNamesWithServiceModule(file.source);
+  const v2ClientNamesRecord = getV2ClientNamesRecord(j, source, v2ClientNamesWithServiceModule);
 
   if (!v2GlobalName && Object.keys(v2ClientNamesRecord).length === 0) {
     return source.toSource();

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecord.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecord.ts
@@ -4,7 +4,11 @@ import { hasRequire } from "../has";
 import { getV2ClientNamesRecordFromImport } from "./getV2ClientNamesRecordFromImport";
 import { getV2ClientNamesRecordFromRequire } from "./getV2ClientNamesRecordFromRequire";
 
-export const getV2ClientNamesRecord = (j: JSCodeshift, source: Collection<unknown>) =>
+export const getV2ClientNamesRecord = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  v2ClientNamesWithServiceModule: string[]
+) =>
   hasRequire(j, source)
-    ? getV2ClientNamesRecordFromRequire(j, source)
-    : getV2ClientNamesRecordFromImport(j, source);
+    ? getV2ClientNamesRecordFromRequire(j, source, v2ClientNamesWithServiceModule)
+    : getV2ClientNamesRecordFromImport(j, source, v2ClientNamesWithServiceModule);

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromImport.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromImport.ts
@@ -20,7 +20,11 @@ const getImportSpecifiers = (j: JSCodeshift, source: Collection<unknown>, source
     .map((importDeclaration) => importDeclaration.specifiers)
     .flat() as (ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier)[];
 
-export const getV2ClientNamesRecordFromImport = (j: JSCodeshift, source: Collection<unknown>) => {
+export const getV2ClientNamesRecordFromImport = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  v2ClientNamesWithServiceModule: string[]
+) => {
   const v2ClientNamesRecord: Record<string, string> = {};
 
   const specifiersFromNamedImport = getImportSpecifiers(j, source, PACKAGE_NAME).filter(
@@ -31,18 +35,17 @@ export const getV2ClientNamesRecordFromImport = (j: JSCodeshift, source: Collect
     const clientImportSpecifier = specifiersFromNamedImport.find(
       (specifier) => specifier?.imported.name === clientName
     );
-
     if (clientImportSpecifier) {
       v2ClientNamesRecord[clientName] = (clientImportSpecifier.local as Identifier).name;
-      continue;
     }
+  }
 
+  for (const clientName of v2ClientNamesWithServiceModule) {
     const deepImportPath = getV2ServiceModulePath(clientName);
     const specifiersFromDeepImport = getImportSpecifiers(j, source, deepImportPath).filter(
       (specifier) =>
         ["ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(specifier?.type as string)
     );
-
     if (specifiersFromDeepImport.length > 0) {
       v2ClientNamesRecord[clientName] = (specifiersFromDeepImport[0]?.local as Identifier).name;
     }

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromRequire.ts
@@ -15,7 +15,11 @@ const getRequireIds = (j: JSCodeshift, source: Collection<unknown>, sourceValue:
     .nodes()
     .map((variableDeclarator) => variableDeclarator.id);
 
-export const getV2ClientNamesRecordFromRequire = (j: JSCodeshift, source: Collection<unknown>) => {
+export const getV2ClientNamesRecordFromRequire = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  v2ClientNamesWithServiceModule: string[]
+) => {
   const v2ClientNamesRecord: Record<string, string> = {};
 
   const idPropertiesFromNamedImport = getRequireIds(j, source, PACKAGE_NAME)
@@ -27,12 +31,12 @@ export const getV2ClientNamesRecordFromRequire = (j: JSCodeshift, source: Collec
     const propertyWithClientName = idPropertiesFromNamedImport.find(
       (property) => (property?.key as Identifier).name === clientName
     );
-
     if (propertyWithClientName) {
       v2ClientNamesRecord[clientName] = (propertyWithClientName.value as Identifier).name;
-      continue;
     }
+  }
 
+  for (const clientName of v2ClientNamesWithServiceModule) {
     const deepRequirePath = getV2ServiceModulePath(clientName);
     const idsFromDefaultImport = getRequireIds(j, source, deepRequirePath).filter(
       (id) => id.type === "Identifier"

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesWithServiceModule.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesWithServiceModule.ts
@@ -1,0 +1,13 @@
+import { CLIENT_NAMES, PACKAGE_NAME } from "../config";
+
+const SERVICE_MODULE_PATH_REGEXP = new RegExp(`${PACKAGE_NAME}/clients/([\\w]*)`, "g");
+
+export const getV2ClientNamesWithServiceModule = (fileSource: string) => {
+  const clientsFromServiceModule = new Set(
+    [...fileSource.matchAll(SERVICE_MODULE_PATH_REGEXP)].map((regExpMatch) => regExpMatch[1]).flat()
+  );
+
+  return CLIENT_NAMES.filter((clientName) =>
+    clientsFromServiceModule.has(clientName.toLowerCase())
+  );
+};

--- a/src/transforms/v2-to-v3/utils/get/index.ts
+++ b/src/transforms/v2-to-v3/utils/get/index.ts
@@ -4,6 +4,7 @@ export * from "./getV2ClientIdentifiers";
 export * from "./getV2ClientIdThisExpressions";
 export * from "./getV2ClientNamesFromGlobal";
 export * from "./getV2ClientNamesRecord";
+export * from "./getV2ClientNamesWithServiceModule";
 export * from "./getV2ClientNewExpression";
 export * from "./getV2ClientTSTypeRef";
 export * from "./getV2ClientTypeNames";


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/263

### Description

Deep import search only for available clients in getV2ClientNamesRecord

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
