### PR TITLE
Parse through named imports from global path instead of clients

### DIFF
--- a/.changeset/wet-wolves-brake.md
+++ b/.changeset/wet-wolves-brake.md
@@ -2,4 +2,4 @@
 "aws-sdk-js-codemod": patch
 ---
 
-Parse through named imports from global path insted of clients
+Parse through named imports from global path instead of clients

--- a/.changeset/wet-wolves-brake.md
+++ b/.changeset/wet-wolves-brake.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Parse through named imports from global path insted of clients

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromImport.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromImport.ts
@@ -31,12 +31,11 @@ export const getV2ClientNamesRecordFromImport = (
     (specifier) => specifier?.type === "ImportSpecifier"
   ) as ImportSpecifier[];
 
-  for (const clientName of CLIENT_NAMES) {
-    const clientImportSpecifier = specifiersFromNamedImport.find(
-      (specifier) => specifier?.imported.name === clientName
-    );
-    if (clientImportSpecifier) {
-      v2ClientNamesRecord[clientName] = (clientImportSpecifier.local as Identifier).name;
+  for (const specifier of specifiersFromNamedImport) {
+    const importedName = specifier.imported.name;
+    const localName = (specifier.local as Identifier).name;
+    if (CLIENT_NAMES.includes(importedName)) {
+      v2ClientNamesRecord[importedName] = localName ?? importedName;
     }
   }
 

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromRequire.ts
@@ -22,12 +22,12 @@ export const getV2ClientNamesRecordFromRequire = (
 ) => {
   const v2ClientNamesRecord: Record<string, string> = {};
 
-  const idPropertiesFromNamedImport = getRequireIds(j, source, PACKAGE_NAME)
+  const idPropertiesFromObjectPattern = getRequireIds(j, source, PACKAGE_NAME)
     .filter((id) => id.type === "ObjectPattern")
     .map((objectPattern) => (objectPattern as ObjectPattern).properties)
     .flat() as Property[];
 
-  for (const idProperty of idPropertiesFromNamedImport) {
+  for (const idProperty of idPropertiesFromObjectPattern) {
     if (idProperty.type !== "Property") {
       continue;
     }

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromRequire.ts
@@ -27,13 +27,19 @@ export const getV2ClientNamesRecordFromRequire = (
     .map((objectPattern) => (objectPattern as ObjectPattern).properties)
     .flat() as Property[];
 
-  for (const clientName of CLIENT_NAMES) {
-    const propertyWithClientName = idPropertiesFromNamedImport.find(
-      (property) => (property?.key as Identifier).name === clientName
-    );
-    if (propertyWithClientName) {
-      v2ClientNamesRecord[clientName] = (propertyWithClientName.value as Identifier).name;
+  for (const idProperty of idPropertiesFromNamedImport) {
+    if (idProperty.type !== "Property") {
+      continue;
     }
+    const key = idProperty.key as Identifier;
+    if (key.type !== "Identifier") {
+      continue;
+    }
+    const value = idProperty.value as Identifier;
+    if (value.type !== "Identifier") {
+      continue;
+    }
+    v2ClientNamesRecord[key.name] = value.name;
   }
 
   for (const clientName of v2ClientNamesWithServiceModule) {

--- a/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecordFromRequire.ts
@@ -39,7 +39,9 @@ export const getV2ClientNamesRecordFromRequire = (
     if (value.type !== "Identifier") {
       continue;
     }
-    v2ClientNamesRecord[key.name] = value.name;
+    if (CLIENT_NAMES.includes(key.name)) {
+      v2ClientNamesRecord[key.name] = value.name;
+    }
   }
 
   for (const clientName of v2ClientNamesWithServiceModule) {


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/266

### Description

Parse through named imports from global path instead of clients

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
