### PR TITLE
Reverse the sorting order for clientMetadataMap

### DIFF
--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -35,9 +35,8 @@ const transformer = async (file: FileInfo, api: API) => {
     });
   }
 
-  Object.entries(getClientMetadata(v2ClientNamesRecord))
-    .reverse()
-    .forEach(([v2ClientName, v3ClientMetadata]) => {
+  Object.entries(getClientMetadata(v2ClientNamesRecord)).forEach(
+    ([v2ClientName, v3ClientMetadata]) => {
       const { v2ClientLocalName, v3ClientName, v3ClientPackageName } = v3ClientMetadata;
 
       const v2Options = { v2ClientName, v2ClientLocalName, v2GlobalName };
@@ -51,7 +50,8 @@ const transformer = async (file: FileInfo, api: API) => {
       if (v2GlobalName) {
         replaceClientCreation(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
       }
-    });
+    }
+  );
 
   if (v2GlobalName) {
     removeV2GlobalModule(j, source, v2GlobalName);

--- a/src/transforms/v2-to-v3/utils/get/getClientMetadata.ts
+++ b/src/transforms/v2-to-v3/utils/get/getClientMetadata.ts
@@ -16,5 +16,5 @@ export const getClientMetadata = (v2ClientNamesRecord: Record<string, string>): 
       {}
     ) as ClientMetadataMap
   )
-    .sort(([, { v3ClientPackageName: a }], [, { v3ClientPackageName: b }]) => a.localeCompare(b))
+    .sort(([, { v3ClientPackageName: a }], [, { v3ClientPackageName: b }]) => b.localeCompare(a))
     .reduce((r, [k, v]) => ({ ...r, [k]: v }), {});


### PR DESCRIPTION
### Issue

Noticed while implementing https://github.com/awslabs/aws-sdk-js-codemod/issues/268

### Description

Reverses the sorting order for clientMetadataMap so that callee doesn't have to do it

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
