### PR TITLE
Rename getClientMetadataMap to getClientMetadataRecord

### DIFF
--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -2,7 +2,7 @@ import { API, FileInfo } from "jscodeshift";
 
 import {
   addV3ClientModules,
-  getClientMetadata,
+  getClientMetadataRecord,
   getV2ClientNamesFromGlobal,
   getV2ClientNamesRecord,
   getV2ClientNamesWithServiceModule,
@@ -35,7 +35,7 @@ const transformer = async (file: FileInfo, api: API) => {
     });
   }
 
-  Object.entries(getClientMetadata(v2ClientNamesRecord)).forEach(
+  Object.entries(getClientMetadataRecord(v2ClientNamesRecord)).forEach(
     ([v2ClientName, v3ClientMetadata]) => {
       const { v2ClientLocalName, v3ClientName, v3ClientPackageName } = v3ClientMetadata;
 

--- a/src/transforms/v2-to-v3/utils/get/getClientMetadataRecord.ts
+++ b/src/transforms/v2-to-v3/utils/get/getClientMetadataRecord.ts
@@ -1,10 +1,10 @@
-import { ClientMetadataMap } from "../types";
+import { ClientMetadataRecord } from "../types";
 import { getV3ClientName } from "./getV3ClientName";
 import { getV3ClientPackageName } from "./getV3ClientPackageName";
 
 export const getClientMetadataRecord = (
   v2ClientNamesRecord: Record<string, string>
-): ClientMetadataMap =>
+): ClientMetadataRecord =>
   Object.entries(
     Object.entries(v2ClientNamesRecord).reduce(
       (acc, [v2ClientName, v2ClientLocalName]) => ({
@@ -16,7 +16,7 @@ export const getClientMetadataRecord = (
         },
       }),
       {}
-    ) as ClientMetadataMap
+    ) as ClientMetadataRecord
   )
     .sort(([, { v3ClientPackageName: a }], [, { v3ClientPackageName: b }]) => b.localeCompare(a))
     .reduce((r, [k, v]) => ({ ...r, [k]: v }), {});

--- a/src/transforms/v2-to-v3/utils/get/getClientMetadataRecord.ts
+++ b/src/transforms/v2-to-v3/utils/get/getClientMetadataRecord.ts
@@ -2,7 +2,9 @@ import { ClientMetadataMap } from "../types";
 import { getV3ClientName } from "./getV3ClientName";
 import { getV3ClientPackageName } from "./getV3ClientPackageName";
 
-export const getClientMetadata = (v2ClientNamesRecord: Record<string, string>): ClientMetadataMap =>
+export const getClientMetadataRecord = (
+  v2ClientNamesRecord: Record<string, string>
+): ClientMetadataMap =>
   Object.entries(
     Object.entries(v2ClientNamesRecord).reduce(
       (acc, [v2ClientName, v2ClientLocalName]) => ({

--- a/src/transforms/v2-to-v3/utils/get/index.ts
+++ b/src/transforms/v2-to-v3/utils/get/index.ts
@@ -1,4 +1,4 @@
-export * from "./getClientMetadata";
+export * from "./getClientMetadataRecord";
 export * from "./getRequireVariableDeclaration";
 export * from "./getV2ClientIdentifiers";
 export * from "./getV2ClientIdThisExpressions";

--- a/src/transforms/v2-to-v3/utils/types.ts
+++ b/src/transforms/v2-to-v3/utils/types.ts
@@ -1,4 +1,4 @@
-export type ClientMetadataMap = Record<string, ClientMetadata>;
+export type ClientMetadataRecord = Record<string, ClientMetadata>;
 
 export interface ClientMetadata {
   v2ClientLocalName: string;


### PR DESCRIPTION
### Issue

Noticed while implementing https://github.com/awslabs/aws-sdk-js-codemod/issues/268

### Description

Renames getClientMetadataMap to getClientMetadataRecord to conform with [naming standard of TypeScript](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type), and usage in [other parts](https://github.com/awslabs/aws-sdk-js-codemod/blob/f0abd361dc769d1bda21206acf54dddaf1d64e3f/src/transforms/v2-to-v3/utils/get/getV2ClientNamesRecord.ts) of the code. 

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
