### PR TITLE
Remove 'AWS_' prefix from input tests

### DIFF
--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.js
@@ -1,6 +1,6 @@
-import AWS_DynamoDB from "aws-sdk/clients/dynamodb";
+import DynamoDBClient from "aws-sdk/clients/dynamodb";
 
-const client = new AWS_DynamoDB();
+const client = new DynamoDBClient();
 
 // Promise without params
 {
@@ -21,7 +21,7 @@ const client = new AWS_DynamoDB();
 
   // Client as class member
   class ClientClassMember {
-    constructor(clientInCtr = new AWS_DynamoDB()) {
+    constructor(clientInCtr = new DynamoDBClient()) {
       this.clientInClass = clientInCtr;
     }
   

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.js
@@ -1,6 +1,6 @@
-import { DynamoDB as AWS_DynamoDB } from "@aws-sdk/client-dynamodb";
+import { DynamoDB as DynamoDBClient } from "@aws-sdk/client-dynamodb";
 
-const client = new AWS_DynamoDB();
+const client = new DynamoDBClient();
 
 // Promise without params
 {
@@ -20,7 +20,7 @@ const client = new AWS_DynamoDB();
 
   // Client as class member
   class ClientClassMember {
-    constructor(clientInCtr = new AWS_DynamoDB()) {
+    constructor(clientInCtr = new DynamoDBClient()) {
       this.clientInClass = clientInCtr;
     }
   

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-require.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-require.input.js
@@ -1,6 +1,6 @@
-const AWS_DynamoDB = require("aws-sdk/clients/dynamodb");
+const DynamoDBClient = require("aws-sdk/clients/dynamodb");
 
-const client = new AWS_DynamoDB();
+const client = new DynamoDBClient();
 
 // Promise without params
 {
@@ -21,7 +21,7 @@ const client = new AWS_DynamoDB();
 
   // Client as class member
   class ClientClassMember {
-    constructor(clientInCtr = new AWS_DynamoDB()) {
+    constructor(clientInCtr = new DynamoDBClient()) {
       this.clientInClass = clientInCtr;
     }
   

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-require.output.js
@@ -1,8 +1,8 @@
 const {
-  DynamoDB: AWS_DynamoDB
+  DynamoDB: DynamoDBClient
 } = require("@aws-sdk/client-dynamodb");
 
-const client = new AWS_DynamoDB();
+const client = new DynamoDBClient();
 
 // Promise without params
 {
@@ -22,7 +22,7 @@ const client = new AWS_DynamoDB();
 
   // Client as class member
   class ClientClassMember {
-    constructor(clientInCtr = new AWS_DynamoDB()) {
+    constructor(clientInCtr = new DynamoDBClient()) {
       this.clientInClass = clientInCtr;
     }
   


### PR DESCRIPTION
### Issue

Tests started failing in the intermediate state of https://github.com/awslabs/aws-sdk-js-codemod/pull/288

### Description

Remove variables with 'AWS_' prefix from input tests, as it's used for default imports https://github.com/awslabs/aws-sdk-js-codemod/pull/276

A fix can be added to use a different localname if variables with `AWS_` prefix are already present in future.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
