### PR TITLE
Remove suffix IdentifierName from removeImportEquals

### DIFF
--- a/src/transforms/v2-to-v3/modules/removeImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/removeImportEquals.ts
@@ -1,14 +1,14 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-export interface RemoveImportEqualsIdentifierNameOptions {
+export interface RemoveImportEqualsOptions {
   localName: string;
   sourceValue: string;
 }
 
-export const removeImportEqualsIdentifierName = (
+export const removeImportEquals = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { localName, sourceValue }: RemoveImportEqualsIdentifierNameOptions
+  { localName, sourceValue }: RemoveImportEqualsOptions
 ) => {
   source
     .find(j.TSImportEqualsDeclaration, {

--- a/src/transforms/v2-to-v3/modules/removeV2ClientModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeV2ClientModule.ts
@@ -6,7 +6,7 @@ import { getV2ServiceModulePath } from "../utils";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { removeImportDefault } from "./removeImportDefault";
-import { removeImportEqualsIdentifierName } from "./removeImportEqualsIdentifierName";
+import { removeImportEquals } from "./removeImportEquals";
 import { removeImportNamed } from "./removeImportNamed";
 import { removeRequireIdentifier } from "./removeRequireIdentifier";
 import { removeRequireObjectProperty } from "./removeRequireObjectProperty";
@@ -32,7 +32,7 @@ export const removeV2ClientModule = (
     removeRequireIdentifier(j, source, defaultOptions);
     removeRequireObjectProperty(j, source, namedOptions);
   } else if (hasImportEquals(j, source)) {
-    removeImportEqualsIdentifierName(j, source, defaultOptions);
+    removeImportEquals(j, source, defaultOptions);
   } else {
     removeImportDefault(j, source, defaultOptions);
     removeImportNamed(j, source, namedOptions);

--- a/src/transforms/v2-to-v3/modules/removeV2GlobalModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeV2GlobalModule.ts
@@ -4,7 +4,7 @@ import { PACKAGE_NAME } from "../config";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { removeImportDefault } from "./removeImportDefault";
-import { removeImportEqualsIdentifierName } from "./removeImportEqualsIdentifierName";
+import { removeImportEquals } from "./removeImportEquals";
 import { removeRequireIdentifier } from "./removeRequireIdentifier";
 
 export const removeV2GlobalModule = (
@@ -20,7 +20,7 @@ export const removeV2GlobalModule = (
     if (hasRequire(j, source)) {
       removeRequireIdentifier(j, source, defaultOptions);
     } else if (hasImportEquals(j, source)) {
-      removeImportEqualsIdentifierName(j, source, defaultOptions);
+      removeImportEquals(j, source, defaultOptions);
     } else {
       removeImportDefault(j, source, defaultOptions);
     }


### PR DESCRIPTION
### Issue

Using naming from https://github.com/awslabs/aws-sdk-js-codemod/pull/296

### Description

Remove suffix IdentifierName from removeImportEqualsIdentifierName

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
