### PR TITLE
Replace types when named require is used from aws-sdk

### DIFF
--- a/.changeset/eleven-islands-train.md
+++ b/.changeset/eleven-islands-train.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Replace types for requires

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/global-require.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/global-require.input.ts
@@ -1,0 +1,3 @@
+const AWS = require("aws-sdk");
+
+const testTags: AWS.S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/global-require.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/global-require.output.ts
@@ -1,0 +1,6 @@
+const AWS_S3 = require("@aws-sdk/client-s3"),
+      {
+        S3
+      } = AWS_S3;
+
+const testTags: AWS_S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-require-deep.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-require-deep.input.ts
@@ -1,0 +1,3 @@
+const S3 = require("aws-sdk/clients/s3");
+
+const testTags: S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-require-deep.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-require-deep.output.ts
@@ -1,0 +1,6 @@
+const AWS_S3 = require("@aws-sdk/client-s3"),
+      {
+        S3
+      } = AWS_S3;
+
+const testTags: AWS_S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-require.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-require.input.ts
@@ -1,0 +1,3 @@
+const { S3 } = require("aws-sdk");
+
+const testTags: S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-require.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-require.output.ts
@@ -1,0 +1,6 @@
+const AWS_S3 = require("@aws-sdk/client-s3"),
+      {
+        S3
+      } = AWS_S3;
+
+const testTags: AWS_S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/client-names/getV2ClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/client-names/getV2ClientNamesRecordFromRequire.ts
@@ -17,7 +17,7 @@ export const getV2ClientNamesRecordFromRequire = (
     .flat() as Property[];
 
   for (const idProperty of idPropertiesFromObjectPattern) {
-    if (idProperty.type !== "Property") {
+    if (!["Property", "ObjectProperty"].includes(idProperty.type)) {
       continue;
     }
     const key = idProperty.key as Identifier;

--- a/src/transforms/v2-to-v3/modules/getV2RequireDeclarator.ts
+++ b/src/transforms/v2-to-v3/modules/getV2RequireDeclarator.ts
@@ -28,7 +28,7 @@ export const getV2RequireDeclarator = (
 
   const v2ClientLocalNameObject = {
     type: "ObjectPattern",
-    properties: [{ type: "Property", value: { type: "Identifier", name: v2ClientLocalName } }],
+    properties: [{ value: { type: "Identifier", name: v2ClientLocalName } }],
   } as ObjectPattern;
   // prettier-ignore
   const v2ClientLocalNameObjectDeclarators =

--- a/src/transforms/v2-to-v3/modules/removeRequireObjectProperty.ts
+++ b/src/transforms/v2-to-v3/modules/removeRequireObjectProperty.ts
@@ -14,7 +14,7 @@ export const removeRequireObjectProperty = (
 ) => {
   const id = {
     type: "ObjectPattern",
-    properties: [{ type: "Property", value: { type: "Identifier", name: localName } }],
+    properties: [{ value: { type: "Identifier", name: localName } }],
   } as ObjectPattern;
   const requireDeclarators = getRequireVariableDeclarators(j, source, sourceValue, id);
 
@@ -25,7 +25,7 @@ export const removeRequireObjectProperty = (
     const varDeclaratorId = varDeclarator.value.id as ObjectPattern;
     varDeclaratorId.properties = varDeclaratorId.properties.filter(
       (property) =>
-        property.type !== "Property" ||
+        (property.type !== "Property" && property.type !== "ObjectProperty") ||
         property.value.type !== "Identifier" ||
         property.value.name !== localName
     );


### PR DESCRIPTION
### Issue

Fixes https://github.com/awslabs/aws-sdk-js-codemod/issues/293

### Description

Replace types when named require is used from aws-sdk

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
