### PR TITLE
Add tests for import equals in api-basic-type

### DIFF
--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/global-import-equals.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/global-import-equals.input.ts
@@ -1,0 +1,3 @@
+import AWS = require("aws-sdk");
+
+const testTags: AWS.S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/global-import-equals.output.ts
@@ -1,0 +1,7 @@
+import AWS_S3 = require("@aws-sdk/client-s3");
+
+const {
+  S3
+} = AWS_S3;
+
+const testTags: AWS_S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-import-equals.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-import-equals.input.ts
@@ -1,0 +1,3 @@
+import S3 = require("aws-sdk/clients/s3");
+
+const testTags: S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-import-equals.output.ts
@@ -1,0 +1,7 @@
+import AWS_S3 = require("@aws-sdk/client-s3");
+
+const {
+  S3
+} = AWS_S3;
+
+const testTags: AWS_S3.Tag[] = [{ Key: "key", Value: "value" }];


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/awslabs/aws-sdk-js-codemod/pull/289

### Description

Add tests for import equals in api-basic-type

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
