### PR TITLE
Check for NewExpression on v2ClientLocalName

### DIFF
--- a/src/transforms/v2-to-v3/apis/getV2ClientIdNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/apis/getV2ClientIdNamesFromNewExpr.ts
@@ -47,7 +47,7 @@ export const getV2ClientIdNamesFromNewExpr = (
       ...getNames(j, source, getV2ClientNewExpression({ v2GlobalName, v2ClientName }))
     );
     namesFromServiceModule.push(
-      ...getNames(j, source, getV2ClientNewExpression({ v2ClientName: v2ClientLocalName }))
+      ...getNames(j, source, getV2ClientNewExpression({ v2ClientLocalName }))
     );
   }
 

--- a/src/transforms/v2-to-v3/apis/getV2ClientIdNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/apis/getV2ClientIdNamesFromNewExpr.ts
@@ -43,9 +43,11 @@ export const getV2ClientIdNamesFromNewExpr = (
   const namesFromServiceModule = [];
 
   for (const getNames of [getNamesFromVariableDeclarator, getNamesFromAssignmentPattern]) {
-    namesFromGlobalModule.push(
-      ...getNames(j, source, getV2ClientNewExpression({ v2GlobalName, v2ClientName }))
-    );
+    if (v2GlobalName) {
+      namesFromGlobalModule.push(
+        ...getNames(j, source, getV2ClientNewExpression({ v2GlobalName, v2ClientName }))
+      );
+    }
     namesFromServiceModule.push(
       ...getNames(j, source, getV2ClientNewExpression({ v2ClientLocalName }))
     );

--- a/src/transforms/v2-to-v3/utils/getV2ClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/getV2ClientNewExpression.ts
@@ -1,17 +1,19 @@
 import { NewExpression } from "jscodeshift";
 
 export interface ClientNewExpressionOptions {
-  v2GlobalName?: string;
+  v2ClientLocalName?: string;
   v2ClientName?: string;
+  v2GlobalName?: string;
 }
 
 export const getV2ClientNewExpression = ({
-  v2GlobalName,
+  v2ClientLocalName,
   v2ClientName,
+  v2GlobalName,
 }: ClientNewExpressionOptions): NewExpression => {
-  if (!v2GlobalName && !v2ClientName) {
+  if (!v2GlobalName && !v2ClientLocalName) {
     throw new Error(
-      `At least one of the following options must be provided: v2GlobalName, v2ClientName`
+      `At least one of the following options must be provided: v2ClientLocalName, v2GlobalName`
     );
   }
 
@@ -27,6 +29,6 @@ export const getV2ClientNewExpression = ({
 
   return {
     type: "NewExpression",
-    callee: { type: "Identifier", name: v2ClientName },
+    callee: { type: "Identifier", name: v2ClientLocalName },
   } as NewExpression;
 };


### PR DESCRIPTION
### Issue

Issue noticed in https://github.com/awslabs/aws-sdk-js-codemod/pull/302

### Description

Check for NewExpression on v2ClientLocalName

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
