### PR TITLE
Add utility getNewExpressionCount

### DIFF
--- a/src/transforms/v2-to-v3/modules/addV3ClientRequires.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientRequires.ts
@@ -1,9 +1,9 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getV3ClientTypeNames } from "../ts-type";
-import { getV2ClientNewExpression } from "../utils";
 import { addV3ClientDefaultRequire } from "./addV3ClientDefaultRequire";
 import { addV3ClientNamedRequire } from "./addV3ClientNamedRequire";
+import { getNewExpressionCount } from "./getNewExpressionCount";
 import { V3ClientModulesOptions } from "./types";
 
 export const addV3ClientRequires = (
@@ -11,7 +11,7 @@ export const addV3ClientRequires = (
   source: Collection<unknown>,
   options: V3ClientModulesOptions
 ): void => {
-  const { v2ClientName, v2ClientLocalName, v2GlobalName } = options;
+  const { v2ClientName, v2GlobalName } = options;
   const v3ClientTypeNames = getV3ClientTypeNames(j, source, { v2ClientName, v2GlobalName });
 
   // Add default require for types, if needed.
@@ -19,12 +19,7 @@ export const addV3ClientRequires = (
     addV3ClientDefaultRequire(j, source, options);
   }
 
-  const newExpressions = source.find(
-    j.NewExpression,
-    getV2ClientNewExpression({ v2ClientName, v2ClientLocalName, v2GlobalName })
-  );
-
-  if (newExpressions.length) {
+  if (getNewExpressionCount(j, source, options) > 0) {
     addV3ClientNamedRequire(j, source, options);
   }
 };

--- a/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
@@ -1,0 +1,28 @@
+import { Collection, JSCodeshift } from "jscodeshift";
+
+import { getV2ClientNewExpression } from "../utils";
+import { V3ClientModulesOptions } from "./types";
+
+export const getNewExpressionCount = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  { v2ClientName, v2ClientLocalName, v2GlobalName }: V3ClientModulesOptions
+): number => {
+  let newExpressionCount = 0;
+
+  if (v2GlobalName) {
+    const newExpressionsFromGlobal = source.find(
+      j.NewExpression,
+      getV2ClientNewExpression({ v2ClientName, v2GlobalName })
+    );
+    newExpressionCount += newExpressionsFromGlobal.length;
+  }
+
+  const newExpressionsFromClientLocalName = source.find(
+    j.NewExpression,
+    getV2ClientNewExpression({ v2ClientLocalName })
+  );
+  newExpressionCount += newExpressionsFromClientLocalName.length;
+
+  return newExpressionCount;
+};

--- a/src/transforms/v2-to-v3/utils/getV2ClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/getV2ClientNewExpression.ts
@@ -17,6 +17,12 @@ export const getV2ClientNewExpression = ({
     );
   }
 
+  if (v2GlobalName && v2ClientLocalName) {
+    throw new Error(
+      `Only one of the following options must be provided: v2ClientLocalName, v2GlobalName`
+    );
+  }
+
   if (v2GlobalName) {
     return {
       type: "NewExpression",


### PR DESCRIPTION
### Issue

Missed in https://github.com/awslabs/aws-sdk-js-codemod/pull/303

### Description

Throws error when both v2GlobalName and v2ClientLocalName are provided

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
