### PR TITLE
Remove client import equals if clients are not created

### DIFF
--- a/.changeset/fuzzy-singers-nail.md
+++ b/.changeset/fuzzy-singers-nail.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove client import equals if clients are not created

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/global-import-equals.output.ts
@@ -1,7 +1,3 @@
 import AWS_S3 = require("@aws-sdk/client-s3");
 
-const {
-  S3
-} = AWS_S3;
-
 const testTags: AWS_S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/service-import-equals.output.ts
@@ -1,7 +1,3 @@
 import AWS_S3 = require("@aws-sdk/client-s3");
 
-const {
-  S3
-} = AWS_S3;
-
 const testTags: AWS_S3.Tag[] = [{ Key: "key", Value: "value" }];

--- a/src/transforms/v2-to-v3/modules/addV3ClientDefaultImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientDefaultImportEquals.ts
@@ -1,0 +1,52 @@
+import { Collection, JSCodeshift } from "jscodeshift";
+
+import { getV3ClientDefaultLocalName } from "../utils";
+import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
+import { getV2ImportEqualsDeclaration } from "./getV2ImportEqualsDeclaration";
+import { V3ClientModulesOptions } from "./types";
+
+export const addV3ClientDefaultImportEquals = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  { v2ClientLocalName, v2ClientName, v2GlobalName, v3ClientPackageName }: V3ClientModulesOptions
+) => {
+  const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientLocalName);
+  const existingImportEquals = source.find(
+    j.TSImportEqualsDeclaration,
+    getImportEqualsDeclaration(v3ClientPackageName)
+  );
+
+  if (existingImportEquals.size()) {
+    if (
+      existingImportEquals
+        .nodes()
+        .some(
+          (importEqualsDeclaration) => importEqualsDeclaration.id.name === v3ClientDefaultLocalName
+        )
+    ) {
+      return;
+    }
+  }
+
+  // Insert after global, or service import equals.
+  const v2ImportEqualsDeclaration = getV2ImportEqualsDeclaration(j, source, {
+    v2ClientName,
+    v2ClientLocalName,
+    v2GlobalName,
+  }).at(0);
+
+  const importDeclaration = j.tsImportEqualsDeclaration(
+    j.identifier(v3ClientDefaultLocalName),
+    j.tsExternalModuleReference(j.stringLiteral(v3ClientPackageName))
+  );
+
+  if (v2ImportEqualsDeclaration && v2ImportEqualsDeclaration.nodes().length > 0) {
+    v2ImportEqualsDeclaration.at(0).insertAfter(importDeclaration);
+  } else {
+    // Unreachable code, throw error
+    throw new Error(
+      "Base Import Equals Declaration not found to insert new Import Declaration.\n" +
+        "Please report your use case on https://github.com/awslabs/aws-sdk-js-codemod"
+    );
+  }
+};

--- a/src/transforms/v2-to-v3/modules/addV3ClientImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientImportEquals.ts
@@ -1,8 +1,8 @@
-import { Collection, JSCodeshift, TSExternalModuleReference } from "jscodeshift";
+import { Collection, JSCodeshift } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
-import { getV2ServiceModulePath, getV3ClientDefaultLocalName } from "../utils";
+import { getV3ClientDefaultLocalName } from "../utils";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
+import { getV2ImportEqualsDeclaration } from "./getV2ImportEqualsDeclaration";
 import { V3ClientModulesOptions } from "./types";
 
 export const addV3ClientImportEquals = (
@@ -35,27 +35,7 @@ export const addV3ClientImportEquals = (
   }
 
   // Insert after global, or service import equals.
-  source
-    .find(j.TSImportEqualsDeclaration, getImportEqualsDeclaration())
-    .filter((importEqualsDeclaration) => {
-      const identifierName = importEqualsDeclaration.value.id.name;
-      const importEqualsModuleRef = importEqualsDeclaration.value
-        .moduleReference as TSExternalModuleReference;
-      const expressionValue = importEqualsModuleRef.expression.value;
-
-      if (expressionValue === PACKAGE_NAME && identifierName === v2GlobalName) {
-        return true;
-      }
-
-      if (
-        expressionValue === getV2ServiceModulePath(v2ClientName) &&
-        identifierName === v2ClientLocalName
-      ) {
-        return true;
-      }
-
-      return false;
-    })
+  getV2ImportEqualsDeclaration(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName })
     .at(0)
     .insertAfter(
       j.variableDeclaration("const", [

--- a/src/transforms/v2-to-v3/modules/addV3ClientImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientImportEquals.ts
@@ -35,26 +35,31 @@ export const addV3ClientImportEquals = (
   }
 
   // Insert after global, or service import equals.
-  getV2ImportEqualsDeclaration(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName })
-    .at(0)
-    .insertAfter(
-      j.variableDeclaration("const", [
-        j.variableDeclarator(
-          j.objectPattern([
-            j.objectProperty.from({
-              key: j.identifier(v3ClientName),
-              value: j.identifier(v2ClientLocalName),
-              shorthand: true,
-            }),
-          ]),
-          j.identifier(v3ClientDefaultLocalName)
-        ),
-      ])
+  const v2ImportEqualsDeclaration = getV2ImportEqualsDeclaration(j, source, {
+    v2ClientName,
+    v2ClientLocalName,
+    v2GlobalName,
+  }).at(0);
+
+  v2ImportEqualsDeclaration.insertAfter(
+    j.variableDeclaration("const", [
+      j.variableDeclarator(
+        j.objectPattern([
+          j.objectProperty.from({
+            key: j.identifier(v3ClientName),
+            value: j.identifier(v2ClientLocalName),
+            shorthand: true,
+          }),
+        ]),
+        j.identifier(v3ClientDefaultLocalName)
+      ),
+    ])
+  );
+
+  v2ImportEqualsDeclaration.insertAfter(
+    j.tsImportEqualsDeclaration(
+      j.identifier(v3ClientDefaultLocalName),
+      j.tsExternalModuleReference(j.stringLiteral(v3ClientPackageName))
     )
-    .insertAfter(
-      j.tsImportEqualsDeclaration(
-        j.identifier(v3ClientDefaultLocalName),
-        j.tsExternalModuleReference(j.stringLiteral(v3ClientPackageName))
-      )
-    );
+  );
 };

--- a/src/transforms/v2-to-v3/modules/addV3ClientImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientImportEquals.ts
@@ -1,10 +1,9 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV3ClientDefaultLocalName } from "../utils";
+import { addV3ClientDefaultImportEquals } from "./addV3ClientDefaultImportEquals";
+import { addV3ClientNamedImportEquals } from "./addV3ClientNamedImportEquals";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
-import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getNewExpressionCount } from "./getNewExpressionCount";
-import { getV2ImportEqualsDeclaration } from "./getV2ImportEqualsDeclaration";
 import { V3ClientModulesOptions } from "./types";
 
 export const addV3ClientImportEquals = (
@@ -12,58 +11,12 @@ export const addV3ClientImportEquals = (
   source: Collection<unknown>,
   options: V3ClientModulesOptions
 ): void => {
-  const { v2ClientLocalName, v2ClientName, v2GlobalName, v3ClientName, v3ClientPackageName } =
-    options;
-
-  const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientLocalName);
-  const existingImportEquals = source.find(
-    j.TSImportEqualsDeclaration,
-    getImportEqualsDeclaration(v3ClientPackageName)
-  );
-
-  if (existingImportEquals.size()) {
-    if (
-      existingImportEquals
-        .nodes()
-        .some(
-          (importEqualsDeclaration) => importEqualsDeclaration.id.name === v3ClientDefaultLocalName
-        )
-    ) {
-      return;
-    }
-  }
-
-  // Insert after global, or service import equals.
-  const v2ImportEqualsDeclaration = getV2ImportEqualsDeclaration(j, source, {
-    v2ClientName,
-    v2ClientLocalName,
-    v2GlobalName,
-  }).at(0);
+  addV3ClientDefaultImportEquals(j, source, options);
 
   if (
     getNewExpressionCount(j, source, options) > 0 ||
     getClientTSTypeRefCount(j, source, options) > 0
   ) {
-    v2ImportEqualsDeclaration.insertAfter(
-      j.variableDeclaration("const", [
-        j.variableDeclarator(
-          j.objectPattern([
-            j.objectProperty.from({
-              key: j.identifier(v3ClientName),
-              value: j.identifier(v2ClientLocalName),
-              shorthand: true,
-            }),
-          ]),
-          j.identifier(v3ClientDefaultLocalName)
-        ),
-      ])
-    );
+    addV3ClientNamedImportEquals(j, source, options);
   }
-
-  v2ImportEqualsDeclaration.insertAfter(
-    j.tsImportEqualsDeclaration(
-      j.identifier(v3ClientDefaultLocalName),
-      j.tsExternalModuleReference(j.stringLiteral(v3ClientPackageName))
-    )
-  );
 };

--- a/src/transforms/v2-to-v3/modules/addV3ClientImports.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientImports.ts
@@ -2,11 +2,9 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getV3ClientTypeNames } from "../ts-type";
 import { addV3ClientDefaultImport } from "./addV3ClientDefaultImport";
-import { addV3ClientImportEquals } from "./addV3ClientImportEquals";
 import { addV3ClientNamedImport } from "./addV3ClientNamedImport";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
-import { hasImportEquals } from "./hasImportEquals";
 import { V3ClientModulesOptions } from "./types";
 
 export const addV3ClientImports = (
@@ -14,11 +12,6 @@ export const addV3ClientImports = (
   source: Collection<unknown>,
   options: V3ClientModulesOptions
 ): void => {
-  if (hasImportEquals(j, source)) {
-    addV3ClientImportEquals(j, source, options);
-    return;
-  }
-
   const { v2ClientLocalName, v2ClientName, v2GlobalName } = options;
   const v3ClientTypeNames = getV3ClientTypeNames(j, source, {
     v2ClientLocalName,

--- a/src/transforms/v2-to-v3/modules/addV3ClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientModules.ts
@@ -1,7 +1,9 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
+import { addV3ClientImportEquals } from "./addV3ClientImportEquals";
 import { addV3ClientImports } from "./addV3ClientImports";
 import { addV3ClientRequires } from "./addV3ClientRequires";
+import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { V3ClientModulesOptions } from "./types";
 
@@ -12,4 +14,6 @@ export const addV3ClientModules = (
 ): void =>
   hasRequire(j, source)
     ? addV3ClientRequires(j, source, options)
+    : hasImportEquals(j, source)
+    ? addV3ClientImportEquals(j, source, options)
     : addV3ClientImports(j, source, options);

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
@@ -1,0 +1,48 @@
+import { Collection, JSCodeshift } from "jscodeshift";
+
+import { getV3ClientDefaultLocalName } from "../utils";
+import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
+import { V3ClientModulesOptions } from "./types";
+
+export const addV3ClientNamedImportEquals = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  { v2ClientLocalName, v3ClientName, v3ClientPackageName }: V3ClientModulesOptions
+) => {
+  const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientLocalName);
+  const existingImportEquals = source.find(
+    j.TSImportEqualsDeclaration,
+    getImportEqualsDeclaration(v3ClientPackageName)
+  );
+
+  const varDeclaration = j.variableDeclaration("const", [
+    j.variableDeclarator(
+      j.objectPattern([
+        j.objectProperty.from({
+          key: j.identifier(v3ClientName),
+          value: j.identifier(v2ClientLocalName),
+          shorthand: true,
+        }),
+      ]),
+      j.identifier(v3ClientDefaultLocalName)
+    ),
+  ]);
+
+  if (existingImportEquals.size()) {
+    const v3ClientImportEquals = existingImportEquals.filter(
+      (importEqualsDeclaration) =>
+        importEqualsDeclaration.value.id.name === v3ClientDefaultLocalName
+    );
+
+    if (v3ClientImportEquals.size() > 0) {
+      v3ClientImportEquals.at(0).insertAfter(varDeclaration);
+      return;
+    }
+  }
+
+  // Unreachable code, throw error
+  throw new Error(
+    "The named import equals can't exist on it's own.\n" +
+      "Please report your use case on https://github.com/awslabs/aws-sdk-js-codemod"
+  );
+};

--- a/src/transforms/v2-to-v3/modules/getV2ImportEqualsDeclaration.ts
+++ b/src/transforms/v2-to-v3/modules/getV2ImportEqualsDeclaration.ts
@@ -1,0 +1,39 @@
+import { Collection, JSCodeshift, TSExternalModuleReference } from "jscodeshift";
+
+import { PACKAGE_NAME } from "../config";
+import { getV2ServiceModulePath } from "../utils";
+import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
+
+export interface GetV2ImportEqualsDeclarationOptions {
+  v2ClientName: string;
+  v2ClientLocalName: string;
+  v2GlobalName?: string;
+}
+
+export const getV2ImportEqualsDeclaration = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  { v2ClientName, v2ClientLocalName, v2GlobalName }: GetV2ImportEqualsDeclarationOptions
+) =>
+  // Return global or service import declaration.
+  source
+    .find(j.TSImportEqualsDeclaration, getImportEqualsDeclaration())
+    .filter((importEqualsDeclaration) => {
+      const identifierName = importEqualsDeclaration.value.id.name;
+      const importEqualsModuleRef = importEqualsDeclaration.value
+        .moduleReference as TSExternalModuleReference;
+      const expressionValue = importEqualsModuleRef.expression.value;
+
+      if (expressionValue === PACKAGE_NAME && identifierName === v2GlobalName) {
+        return true;
+      }
+
+      if (
+        expressionValue === getV2ServiceModulePath(v2ClientName) &&
+        identifierName === v2ClientLocalName
+      ) {
+        return true;
+      }
+
+      return false;
+    });


### PR DESCRIPTION
### Issue

Related to https://github.com/awslabs/aws-sdk-js-codemod/issues/285

### Description

Removes client import equals if clients are not created

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
