### PR TITLE
Fix eslint warning forbidden non-null assertion

### DIFF
--- a/src/transforms/v2-to-v3/ts-type/getTypeRefForString.ts
+++ b/src/transforms/v2-to-v3/ts-type/getTypeRefForString.ts
@@ -24,8 +24,9 @@ export const getTypeRefForString = (
     return j.tsTypeReference(j.identifier(v3ClientTypeString));
   }
 
-  if (v3ClientTypeString.startsWith("Array<")) {
-    const type = arrayRegex.exec(v3ClientTypeString)![1];
+  const arrayRegexMatches = arrayRegex.exec(v3ClientTypeString);
+  if (arrayRegexMatches) {
+    const type = arrayRegexMatches[1];
     const typeArgument = getTypeRefForString(j, v3ClientDefaultLocalName, type);
     return j.tsTypeReference.from({
       typeName: j.identifier("Array"),
@@ -35,8 +36,9 @@ export const getTypeRefForString = (
     });
   }
 
-  if (v3ClientTypeString.startsWith("Record<")) {
-    const type = recordRegex.exec(v3ClientTypeString)![1];
+  const recordRegexMatches = recordRegex.exec(v3ClientTypeString);
+  if (recordRegexMatches) {
+    const type = recordRegexMatches[1];
     const typeArgument = getTypeRefForString(j, v3ClientDefaultLocalName, type);
     return j.tsTypeReference.from({
       typeName: j.identifier("Record"),


### PR DESCRIPTION
### Issue

The warning is shown under "Unchanged files with check annotations" in PRs.
Example https://github.com/awslabs/aws-sdk-js-codemod/pull/321/files

### Description

Runs regular expression to find matches, instead of using string search.

### Testing

Verified that no lint warning is shown in CI.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
