### PR TITLE
Make existing issue templates specific to transform

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_transform.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_transform.yml
@@ -1,4 +1,4 @@
-name: Bug Report
+name: Bug Report (transform)
 description: Create a report to help us improve
 title: "[Bug?]: "
 labels: ["bug", "triage"]
@@ -12,16 +12,6 @@ body:
       options:
         - label: "I'd be willing to implement a fix"
 
-  - type: textarea
-    attributes:
-      label: Describe the bug
-      description: |
-        A clear and concise description of what the bug is. A bug is **unintended**. A feature not being implemented is **not a bug**.
-      placeholder: |
-        eg: Running transform "transformName" on the provided input causes it to crash.
-    validations:
-      required: true
-
   - type: dropdown
     id: template-name
     attributes:
@@ -30,6 +20,16 @@ body:
       options:
         - v2-to-v3
         - N/A (described above)
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: |
+        A clear and concise description of what the bug is. A bug is **unintended**. A feature not being implemented is **not a bug**.
+      placeholder: |
+        eg: Running transform "transformName" on the provided input causes it to crash.
     validations:
       required: true
 
@@ -62,7 +62,6 @@ body:
       label: Expected output
       description: Thw output file you expected to see.
       placeholder: |
-        ### Expected Output
         ```ts
         import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
@@ -80,13 +79,13 @@ body:
       description: |
         Run `aws-sdk-js-codemod --version` and paste the result into the form
       placeholder: |
-        aws-sdk-js-codemod: 0.1.0
+        aws-sdk-js-codemod: 0.10.2
 
-        jscodeshift: 0.13.1
-          - babel: 7.17.5
-          - babylon: 7.17.3
-          - flow: 0.172.0
-          - recast: 0.20.5
+        jscodeshift: 0.14.0
+        - babel: 7.20.12
+        - babylon: 7.20.7
+        - flow: 0.196.3
+        - recast: 0.21.5
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request_transform.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_transform.yml
@@ -1,6 +1,6 @@
-name: Feature Request
+name: Feature Request (transform)
 description: These issues are for **concrete and actionable proposals**. If you just have
-  a general problem that you would like to brainstorm, open a Discussion instead.
+  a general problem that you would like to brainstorm, open a generic feature request.
 title: "[Feature]: "
 labels: ["enhancement"]
 
@@ -12,6 +12,17 @@ body:
       description: "Adding features is a great way to give back to open-source projects, and we're more than happy to answer questions and provide context."
       options:
         - label: "I'd be willing to implement this feature"
+
+  - type: dropdown
+    id: template-name
+    attributes:
+      label: Template name
+      description: Which template are you adding this feature request for?
+      options:
+        - v2-to-v3
+        - N/A (described above)
+    validations:
+      required: true
 
   - type: textarea
     attributes:


### PR DESCRIPTION
### Issue

N/A

### Description

Makes existing issue templates specific to transform:
* Adds `(transform)` suffix to the template name
* Moves `template-name` drop down to the top in bug report.
* Adds `template-name` drop down in feature request.
* Asks user to create a generic feature request (to be added in a different PR) instead of Discussion. 

### Testing

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
