### PR TITLE
Add generic bug report and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Bug Report (transform)
+name: Bug Report (generic)
 description: Create a report to help us improve
 title: "[Bug?]: "
 labels: ["bug", "triage"]
@@ -12,63 +12,40 @@ body:
       options:
         - label: "I'd be willing to implement a fix"
 
-  - type: dropdown
-    id: template-name
-    attributes:
-      label: Template name
-      description: Which template are you seeing this error for?
-      options:
-        - v2-to-v3
-        - N/A (described above)
-    validations:
-      required: true
-
   - type: textarea
     attributes:
       label: Describe the bug
       description: |
         A clear and concise description of what the bug is. A bug is **unintended**. A feature not being implemented is **not a bug**.
       placeholder: |
-        eg: Running transform "transformName" on the provided input causes it to crash.
+        eg: aws-sdk-js-codemod crashes with a specific error.
     validations:
       required: true
 
   - type: textarea
     attributes:
-      label: Input code
-      description: The _minimal_ input file to reproduce your issue.
+      label: Steps to reproduce
+      description: The _minimal_ steps to reproduce your issue.
       placeholder: |
-        ```ts
-        import AWS from "aws-sdk";
-
-        const region = "us-west-2";
-        const client = new AWS.DynamoDB({ region });
-        const response = await client.listTables({}).promise();
-        ```
+        Please share code or minimal repo, and steps to reproduce the behavior.
     validations:
       required: true
 
   - type: textarea
     attributes:
-      label: Observed failure
-      description: A concise description of what error you're experiencing.
+      label: Observed behavior
+      description: A clear and concise description of what happens.
       placeholder: |
-        eg: The aws-sdk-js-codemod script returned the following error:
+        eg: The aws-sdk-js-codemod script returned error with the following stack trace:
     validations:
       required: true
 
   - type: textarea
     attributes:
-      label: Expected output
-      description: The output file you expected to see.
+      label: Expected behavior
+      description: A clear and concise description of what you were expecting to happen.
       placeholder: |
-        ```ts
-        import { DynamoDB } from "@aws-sdk/client-dynamodb";
-
-        const region = "us-west-2";
-        const client = new DynamoDB({ region });
-        const response = await client.listTables({});
-        ```
+        eg: The aws-sdk-js-codemod script should have run successfully.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature Request (generic)
+description: This is a generic feature request for aws-sdk-js-codemod.
+title: "[Feature]: "
+labels: ["enhancement"]
+
+body:
+  - type: checkboxes
+    id: selfservice
+    attributes:
+      label: Self-service
+      description: "Adding features is a great way to give back to open-source projects, and we're more than happy to answer questions and provide context."
+      options:
+        - label: "I'd be willing to implement this feature"
+
+  - type: textarea
+    attributes:
+      label: Problem
+      description: |
+        Is your feature request related to a problem? Please describe.
+      placeholder: |
+        A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Solution
+      description: Describe the solution you'd like.
+      placeholder: |
+        A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives
+      description: Describe alternatives you've considered
+      placeholder: |
+        A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context about the problem here. Or a screenshot if applicable.


### PR DESCRIPTION
### Issue

I'd created multiple feature requests which are for `aws-sdk-js-codemod` and not specific to any transform.
For example, https://github.com/awslabs/aws-sdk-js-codemod/issues/180

I had to create a blank template and add details.

### Description

Adds generic bug report and feature request templates

### Testing

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
