### PR TITLE
Add instructions to use latest version

### DIFF
--- a/.changeset/great-tigers-whisper.md
+++ b/.changeset/great-tigers-whisper.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Add instructions to clear npx cache to use latest version of aws-sdk-js-codemod

--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ To use aws-sdk-js-codemod, please install [Node.js][install-nodejs].
   ```console
   npx aws-sdk-js-codemod --dry --print -t v2-to-v3 PATH...
   ```
-- Run transform:
+- Run transform, and make changes to files:
   ```console
   npx aws-sdk-js-codemod -t v2-to-v3 PATH...
+  ```
+- To use the latest version of aws-sdk-js-codemod, clear your npx cache. You can either
+  manually delete folder `$(npm get cache)/_npx/*`, or run `clear-npx-cache`.
+  ```console
+  npx clear-npx-cache
   ```
 
 ## Example

--- a/src/utils/getHelpParagraph.ts
+++ b/src/utils/getHelpParagraph.ts
@@ -14,4 +14,6 @@ ${transforms.map((transform) => getTransformDescription(transform).join("\n"))}
 
 Example: aws-sdk-js-codemod -t v2-to-v3 example.js
 
+To use the latest version of aws-sdk-js-codemod, please clear your npx cache and re-run.
+
 ${separator}\n\n`;


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/180

### Description

Add instruction to use latest version in help paragraph and README, by clearing npx cache.

### Testing

```console
$ ./bin/aws-sdk-js-codemod --help
-----------------------------------------------------------------------------------------------
aws-sdk-js-codemod is a lightweight wrapper over jscodeshift.
It processes --help, --version and --transform options before passing them downstream.

You can provide names of the custom transforms instead of a local path or url:

     v2-to-v3  Converts AWS SDK for JavaScript APIs in a Javascript/TypeScript codebase from 
               version 2 (v2) to version 3 (v3). 

Example: aws-sdk-js-codemod -t v2-to-v3 example.js

To use the latest version of aws-sdk-js-codemod, please clear your npx cache and re-run.

-----------------------------------------------------------------------------------------------
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
