### PR TITLE
Add arguments in ArrowFunction/Return while removing promise()

### DIFF
--- a/.changeset/heavy-lemons-train.md
+++ b/.changeset/heavy-lemons-train.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Add callExpression arguments in ArrowFunction/Return while remove promise()

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.ts
@@ -1,7 +1,7 @@
 import AWS from "aws-sdk";
 
-export const listTables = (client: AWS.DynamoDB) => client.listTables().promise();
-export const listTagsOfResource = (client: AWS.DynamoDB) =>
+export const listTables = async (client: AWS.DynamoDB) => client.listTables().promise();
+export const listTagsOfResource = async (client: AWS.DynamoDB) =>
   client.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();
 
 // Client as class member

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.ts
@@ -15,4 +15,8 @@ class ClientClassMember {
   async listTables() {
     return await this.clientInClass.listTables().promise();
   }
+
+  async listTagsOfResource() {
+    return await this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();
+  }
 }

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.ts
@@ -13,10 +13,10 @@ class ClientClassMember {
   }
 
   async listTables() {
-    return await this.clientInClass.listTables().promise();
+    return this.clientInClass.listTables().promise();
   }
 
   async listTagsOfResource() {
-    return await this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();
+    return this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();
   }
 }

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.ts
@@ -1,6 +1,8 @@
 import AWS from "aws-sdk";
 
 export const listTables = (client: AWS.DynamoDB) => client.listTables().promise();
+export const listTagsOfResource = (client: AWS.DynamoDB) =>
+  client.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();
 
 // Client as class member
 class ClientClassMember {

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.ts
@@ -1,7 +1,7 @@
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
-export const listTables = (client: DynamoDB) => client.listTables();
-export const listTagsOfResource = (client: DynamoDB) =>
+export const listTables = async (client: DynamoDB) => client.listTables();
+export const listTagsOfResource = async (client: DynamoDB) =>
   client.listTagsOfResource({ ResourceArn: "STRING_VALUE" });
 
 // Client as class member

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.ts
@@ -15,4 +15,8 @@ class ClientClassMember {
   async listTables() {
     return await this.clientInClass.listTables();
   }
+
+  async listTagsOfResource() {
+    return await this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" });
+  }
 }

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.ts
@@ -13,10 +13,10 @@ class ClientClassMember {
   }
 
   async listTables() {
-    return await this.clientInClass.listTables();
+    return this.clientInClass.listTables();
   }
 
   async listTagsOfResource() {
-    return await this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" });
+    return this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" });
   }
 }

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.ts
@@ -1,6 +1,8 @@
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
 export const listTables = (client: DynamoDB) => client.listTables();
+export const listTagsOfResource = (client: DynamoDB) =>
+  client.listTagsOfResource({ ResourceArn: "STRING_VALUE" });
 
 // Client as class member
 class ClientClassMember {

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.ts
@@ -1,6 +1,8 @@
 import DynamoDB from "aws-sdk/clients/dynamodb";
 
 export const listTables = (client: DynamoDB) => client.listTables().promise();
+export const listTagsOfResource = (client: DynamoDB) =>
+  client.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();
 
 // Client as class member
 class ClientClassMember {

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.ts
@@ -1,7 +1,7 @@
 import DynamoDB from "aws-sdk/clients/dynamodb";
 
-export const listTables = (client: DynamoDB) => client.listTables().promise();
-export const listTagsOfResource = (client: DynamoDB) =>
+export const listTables = async (client: DynamoDB) => client.listTables().promise();
+export const listTagsOfResource = async (client: DynamoDB) =>
   client.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();
 
 // Client as class member

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.ts
@@ -15,4 +15,8 @@ class ClientClassMember {
   async listTables() {
     return await this.clientInClass.listTables().promise();
   }
+
+  async listTagsOfResource() {
+    return await this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();
+  }
 }

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.ts
@@ -13,10 +13,10 @@ class ClientClassMember {
   }
 
   async listTables() {
-    return await this.clientInClass.listTables().promise();
+    return this.clientInClass.listTables().promise();
   }
 
   async listTagsOfResource() {
-    return await this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();
+    return this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();
   }
 }

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.ts
@@ -1,7 +1,7 @@
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
-export const listTables = (client: DynamoDB) => client.listTables();
-export const listTagsOfResource = (client: DynamoDB) =>
+export const listTables = async (client: DynamoDB) => client.listTables();
+export const listTagsOfResource = async (client: DynamoDB) =>
   client.listTagsOfResource({ ResourceArn: "STRING_VALUE" });
 
 // Client as class member

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.ts
@@ -15,4 +15,8 @@ class ClientClassMember {
   async listTables() {
     return await this.clientInClass.listTables();
   }
+
+  async listTagsOfResource() {
+    return await this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" });
+  }
 }

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.ts
@@ -13,10 +13,10 @@ class ClientClassMember {
   }
 
   async listTables() {
-    return await this.clientInClass.listTables();
+    return this.clientInClass.listTables();
   }
 
   async listTagsOfResource() {
-    return await this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" });
+    return this.clientInClass.listTagsOfResource({ ResourceArn: "STRING_VALUE" });
   }
 }

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.ts
@@ -1,6 +1,8 @@
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
 export const listTables = (client: DynamoDB) => client.listTables();
+export const listTagsOfResource = (client: DynamoDB) =>
+  client.listTagsOfResource({ ResourceArn: "STRING_VALUE" });
 
 // Client as class member
 class ClientClassMember {

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -2,27 +2,34 @@ import { ASTPath, CallExpression, MemberExpression } from "jscodeshift";
 
 export const removePromiseForCallExpression = (callExpression: ASTPath<CallExpression>) => {
   switch (callExpression.parentPath.value.type) {
-    case "AwaitExpression":
+    case "AwaitExpression": {
       callExpression.parentPath.value.argument = (
         callExpression.value.callee as MemberExpression
       ).object;
       break;
-    case "MemberExpression":
+    }
+    case "MemberExpression": {
       callExpression.parentPath.value.object = (
         callExpression.value.callee as MemberExpression
       ).object;
       break;
-    case "VariableDeclarator":
+    }
+    case "VariableDeclarator": {
       callExpression.parentPath.value.init = (
         callExpression.value.callee as MemberExpression
       ).object;
       break;
+    }
     case "ArrowFunctionExpression":
-    case "ReturnStatement":
-      callExpression.value.callee = (
-        (callExpression.value.callee as MemberExpression).object as CallExpression
-      ).callee;
+    case "ReturnStatement": {
+      const currentCalleeObject = (callExpression.value.callee as MemberExpression)
+        .object as CallExpression;
+      if (currentCalleeObject.arguments.length > 0) {
+        callExpression.value.arguments = currentCalleeObject.arguments;
+      }
+      callExpression.value.callee = currentCalleeObject.callee;
       break;
+    }
     default:
       throw new Error(
         `Removal of .promise() not implemented for ${callExpression.parentPath.value.type}`


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/352

### Description

Add callExpression arguments in ArrowFunction/Return while removing promise()

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
