### PR TITLE
Add action to lock threads two weeks after closing

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,30 @@
+name: lock-threads
+
+on:
+  # 00:00 hours UTC, i.e. 16:00 hours PST or 17:00 hours PDT
+  schedule:
+    - cron: "0 0 * * *"
+
+  # allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        if: github.repository == 'awslabs/aws-sdk-js-codemod'
+        with:
+          github-token: ${{ github.token }}
+          issue-inactive-days: 14
+          pr-inactive-days: 14
+          issue-comment: >
+            This thread has been automatically locked since there has not been
+            any recent activity after it was closed. Please open a 
+            [new issue](https://github.com/awslabs/aws-sdk-js-codemod/issues/new/choose)
+            for related bugs and link to relevant comments in this thread.
+          pr-comment: >
+            This thread has been automatically locked since there has not been
+            any recent activity after it was closed. Please open a 
+            [new issue](https://github.com/awslabs/aws-sdk-js-codemod/issues/new/choose)
+            for related bugs and link to relevant comments in this thread.


### PR DESCRIPTION
### Issue

N/A

### Description

Add action to lock threads once they're closed

### Testing

Documentation of https://github.com/dessant/lock-threads

### Additional context

Referred from the action used on aws/aws-sdk-js-v3 https://github.com/aws/aws-sdk-js-v3/blob/main/.github/workflows/lock.yml

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
