### PR TITLE
Force vitest to re-rerun when files are updated in __fixtures__

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,5 @@
     "resolveJsonModule": true,
     "rootDir": "src"
   },
-  "exclude": ["dist", "**/__fixtures__/**", "**/*.spec.ts", "scripts"]
+  "exclude": ["dist", "**/__fixtures__/**", "**/*.spec.ts", "scripts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    forceRerunTriggers: ["**/__fixtures__/**"],
+  },
+});


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/360

### Description

Force vitest to re-rerun when files are updated in __fixtures__

### Testing

Verified that the default watch mode of vitest re-runs the tests when files inside `__fixtures__` are edited.

### Additional context

Docs: https://vitest.dev/config/#forcereruntriggers

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
