### PR TITLE
chore(deps-dev): bump prettier to 2.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^8.27.0",
     "eslint-plugin-simple-import-sort": "^8.0.0",
     "lint-staged": "^13.0.3",
-    "prettier": "2.7.1",
+    "prettier": "2.8.3",
     "simple-git-hooks": "^2.8.1",
     "tsx": "^3.12.1",
     "typescript": "~4.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1560,7 +1560,7 @@ __metadata:
     eslint-plugin-simple-import-sort: ^8.0.0
     jscodeshift: 0.14.0
     lint-staged: ^13.0.3
-    prettier: 2.7.1
+    prettier: 2.8.3
     simple-git-hooks: ^2.8.1
     tsx: ^3.12.1
     typescript: ~4.9.4
@@ -4785,12 +4785,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.7.1":
-  version: 2.7.1
-  resolution: "prettier@npm:2.7.1"
+"prettier@npm:2.8.3":
+  version: 2.8.3
+  resolution: "prettier@npm:2.8.3"
   bin:
     prettier: bin-prettier.js
-  checksum: 55a4409182260866ab31284d929b3cb961e5fdb91fe0d2e099dac92eaecec890f36e524b4c19e6ceae839c99c6d7195817579cdffc8e2c80da0cb794463a748b
+  checksum: 92f2ceb522d454370e02082aa74ad27388672f7cee8975028b59517c069fe643bdc73e322675c8faf2ff173d7a626d1a6389f26b474000308e793aa25fff46e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

N/A

### Description

Bumps prettier to 2.8.3

### Testing

Verified that there were no formatting changes

```console
$ yarn prettier --version
2.8.3

$ yarn prettier --write **/*.{ts,json,md}
scripts/generateClientTypesMap/getClientTypesMap.ts 255ms
scripts/generateClientTypesMap/getClientTypesMapWithKeysRemovedFromValues.ts 21ms
...
CONTRIBUTING.md 24ms
README.md 11ms
```
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
