### PR TITLE
chore(deps-dev): bump eslint-plugin-simple-import-sort to ^9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@typescript-eslint/parser": "^5.43.0",
     "aws-sdk": "2.1288.0",
     "eslint": "^8.27.0",
-    "eslint-plugin-simple-import-sort": "^8.0.0",
+    "eslint-plugin-simple-import-sort": "^9.0.0",
     "lint-staged": "^13.0.3",
     "prettier": "2.8.3",
     "simple-git-hooks": "^2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,7 +1608,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.43.0
     aws-sdk: 2.1288.0
     eslint: ^8.27.0
-    eslint-plugin-simple-import-sort: ^8.0.0
+    eslint-plugin-simple-import-sort: ^9.0.0
     jscodeshift: 0.14.0
     lint-staged: ^13.0.3
     prettier: 2.8.3
@@ -2659,12 +2659,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-simple-import-sort@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "eslint-plugin-simple-import-sort@npm:8.0.0"
+"eslint-plugin-simple-import-sort@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "eslint-plugin-simple-import-sort@npm:9.0.0"
   peerDependencies:
     eslint: ">=5.0.0"
-  checksum: d2a92a7d148803ee9ad4f081892a8d03820198c36a0f4f16a97d9f686a714edc9c9a9e51cc79cb0ba1afff76a1fde6a5eae50e9e3754928068227c92a2db5d6b
+  checksum: 09dac706f11e625c4994a4452d799a3fc8ad928fd9a1a3891943a1b54cccf2d30a95066a81a13e8f40204441f8d140bd2a735db4870ef42799f6aed94398c88a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

N/A

### Description

Bump eslint-plugin-simple-import-sort to ^9.0.0

### Testing

Verified that no new lint errors or changed were shown
```console
$ yarn eslint src/**/*.ts
```

The major version bump is only to support imports inside `declare module`
https://github.com/lydell/eslint-plugin-simple-import-sort/blob/main/CHANGELOG.md#version-900-2023-01-16

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
