### PR TITLE
Print code in removePromiseForCallExpression error message

### DIFF
--- a/.changeset/early-students-kick.md
+++ b/.changeset/early-students-kick.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Print code in removePromiseForCallExpression error message

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -1,4 +1,5 @@
 import { ASTPath, CallExpression, MemberExpression } from "jscodeshift";
+import { print } from "recast";
 
 export const removePromiseForCallExpression = (callExpression: ASTPath<CallExpression>) => {
   switch (callExpression.parentPath.value.type) {
@@ -32,7 +33,9 @@ export const removePromiseForCallExpression = (callExpression: ASTPath<CallExpre
     }
     default:
       throw new Error(
-        `Removal of .promise() not implemented for ${callExpression.parentPath.value.type}`
+        `Removal of .promise() not implemented for parentPath: ${callExpression.parentPath.value.type}\n` +
+          `Code processed: ${print(callExpression.parentPath.node).code}\n\n` +
+          "Please report your use case on https://github.com/awslabs/aws-sdk-js-codemod\n"
       );
   }
 };


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/369

### Description

Print code in removePromiseForCallExpression error message

### Testing

Verified that the code sample is printed in error message by uncommenting valid test cases

```js
Removal of .promise() not implemented for parentPath: AwaitExpression
Code processed: await client.listTables().promise()

Please report your use case on https://github.com/awslabs/aws-sdk-js-codemod
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
