### PR TITLE
Add key-value pair to existing var declarator in import equals

### DIFF
--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
@@ -16,18 +16,15 @@ export const addV3ClientNamedImportEquals = (
   }: V3ClientModulesOptions & V3ClientRequirePropertyOptions
 ) => {
   const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientLocalName);
-  const objectProperty = getV3ClientRequireProperty(j, { keyName, valueName });
+  const namedImportObjectProperty = getV3ClientRequireProperty(j, { keyName, valueName });
 
   const existingVarDeclarator = source.find(j.VariableDeclarator, {
     type: "VariableDeclarator",
-    init: {
-      type: "Identifier",
-      name: v3ClientDefaultLocalName,
-    },
+    init: { type: "Identifier", name: v3ClientDefaultLocalName },
   });
 
   if (existingVarDeclarator.size()) {
-    existingVarDeclarator.get(0).node.id.properties.push(objectProperty);
+    existingVarDeclarator.get(0).node.id.properties.push(namedImportObjectProperty);
     return;
   }
 
@@ -37,7 +34,10 @@ export const addV3ClientNamedImportEquals = (
   );
 
   const varDeclaration = j.variableDeclaration("const", [
-    j.variableDeclarator(j.objectPattern([objectProperty]), j.identifier(v3ClientDefaultLocalName)),
+    j.variableDeclarator(
+      j.objectPattern([namedImportObjectProperty]),
+      j.identifier(v3ClientDefaultLocalName)
+    ),
   ]);
 
   if (existingImportEquals.size()) {

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
@@ -15,10 +15,6 @@ export const addV3ClientNamedImportEquals = (
   }: V3ClientModulesOptions & V3ClientRequirePropertyOptions
 ) => {
   const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientLocalName);
-  const existingImportEquals = source.find(
-    j.TSImportEqualsDeclaration,
-    getImportEqualsDeclaration(v3ClientPackageName)
-  );
 
   const existingVarDeclarator = source.find(j.VariableDeclarator, {
     type: "VariableDeclarator",
@@ -38,6 +34,11 @@ export const addV3ClientNamedImportEquals = (
     );
     return;
   }
+
+  const existingImportEquals = source.find(
+    j.TSImportEqualsDeclaration,
+    getImportEqualsDeclaration(v3ClientPackageName)
+  );
 
   const varDeclaration = j.variableDeclaration("const", [
     j.variableDeclarator(

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
@@ -20,6 +20,25 @@ export const addV3ClientNamedImportEquals = (
     getImportEqualsDeclaration(v3ClientPackageName)
   );
 
+  const existingVarDeclarator = source.find(j.VariableDeclarator, {
+    type: "VariableDeclarator",
+    init: {
+      type: "Identifier",
+      name: v3ClientDefaultLocalName,
+    },
+  });
+
+  if (existingVarDeclarator.size()) {
+    existingVarDeclarator.get(0).node.id.properties.push(
+      j.objectProperty.from({
+        key: j.identifier(keyName),
+        value: j.identifier(valueName),
+        shorthand: true,
+      })
+    );
+    return;
+  }
+
   const varDeclaration = j.variableDeclaration("const", [
     j.variableDeclarator(
       j.objectPattern([


### PR DESCRIPTION
### Issue

Noticed while adding waiter API in https://github.com/awslabs/aws-sdk-js-codemod/pull/52

### Description

Add key-value pair to existing var declarator in import equals

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
