### PR TITLE
Sort v3 named require/imports in transformed code

### DIFF
--- a/.changeset/few-ligers-thank.md
+++ b/.changeset/few-ligers-thank.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Sort v3 named require/imports

--- a/src/transforms/v2-to-v3/__fixtures__/existing/package-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/existing/package-import.output.js
@@ -1,4 +1,4 @@
-import { DynamoDBClient, DynamoDB } from "@aws-sdk/client-dynamodb";
+import { DynamoDB, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 
 const client1 = new DynamoDB();
 const client2 = new DynamoDBClient();

--- a/src/transforms/v2-to-v3/__fixtures__/existing/package-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/existing/package-require.output.js
@@ -1,6 +1,6 @@
 const {
-  DynamoDBClient,
-  DynamoDB
+  DynamoDB,
+  DynamoDBClient
 } = require("@aws-sdk/client-dynamodb");
 
 const client1 = new DynamoDB();

--- a/src/transforms/v2-to-v3/__fixtures__/existing/package-service-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/existing/package-service-import.output.js
@@ -1,4 +1,4 @@
-import { DynamoDBClient, DynamoDB } from "@aws-sdk/client-dynamodb";
+import { DynamoDB, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 
 const client1 = new DynamoDB();
 const client2 = new DynamoDBClient();

--- a/src/transforms/v2-to-v3/__fixtures__/existing/package-service-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/existing/package-service-require.output.js
@@ -1,6 +1,6 @@
 const {
-  DynamoDBClient,
-  DynamoDB
+  DynamoDB,
+  DynamoDBClient
 } = require("@aws-sdk/client-dynamodb");
 
 const client1 = new DynamoDB();

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/global-import-equals.output.ts
@@ -2,8 +2,8 @@ import AWS_S3 = require("@aws-sdk/client-s3");
 
 const {
   S3,
-  waitUntilBucketNotExists,
-  waitUntilBucketExists
+  waitUntilBucketExists,
+  waitUntilBucketNotExists
 } = AWS_S3;
 
 const Bucket = "BUCKET_NAME";

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/global-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/global-import.output.js
@@ -1,4 +1,4 @@
-import { S3, waitUntilBucketNotExists, waitUntilBucketExists } from "@aws-sdk/client-s3";
+import { S3, waitUntilBucketExists, waitUntilBucketNotExists } from "@aws-sdk/client-s3";
 
 const Bucket = "BUCKET_NAME";
 const client = new S3({ region: "REGION" });

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/global-require-property.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/global-require-property.output.js
@@ -1,7 +1,7 @@
 const {
   S3,
-  waitUntilBucketNotExists,
-  waitUntilBucketExists
+  waitUntilBucketExists,
+  waitUntilBucketNotExists
 } = require("@aws-sdk/client-s3");
 
 const Bucket = "BUCKET_NAME";

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/global-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/global-require.output.js
@@ -1,7 +1,7 @@
 const {
   S3,
-  waitUntilBucketNotExists,
-  waitUntilBucketExists
+  waitUntilBucketExists,
+  waitUntilBucketNotExists
 } = require("@aws-sdk/client-s3");
 
 const Bucket = "BUCKET_NAME";

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/service-import-deep.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/service-import-deep.output.js
@@ -1,4 +1,4 @@
-import { S3, waitUntilBucketNotExists, waitUntilBucketExists } from "@aws-sdk/client-s3";
+import { S3, waitUntilBucketExists, waitUntilBucketNotExists } from "@aws-sdk/client-s3";
 
 const Bucket = "BUCKET_NAME";
 const client = new S3({ region: "REGION" });

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/service-import-equals.output.ts
@@ -2,8 +2,8 @@ import AWS_S3 = require("@aws-sdk/client-s3");
 
 const {
   S3,
-  waitUntilBucketNotExists,
-  waitUntilBucketExists
+  waitUntilBucketExists,
+  waitUntilBucketNotExists
 } = AWS_S3;
 
 const Bucket = "BUCKET_NAME";

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/service-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/service-import.output.js
@@ -1,4 +1,4 @@
-import { S3, waitUntilBucketNotExists, waitUntilBucketExists } from "@aws-sdk/client-s3";
+import { S3, waitUntilBucketExists, waitUntilBucketNotExists } from "@aws-sdk/client-s3";
 
 const Bucket = "BUCKET_NAME";
 const client = new S3({ region: "REGION" });

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/service-require-deep.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/service-require-deep.output.js
@@ -1,7 +1,7 @@
 const {
   S3,
-  waitUntilBucketNotExists,
-  waitUntilBucketExists
+  waitUntilBucketExists,
+  waitUntilBucketNotExists
 } = require("@aws-sdk/client-s3");
 
 const Bucket = "BUCKET_NAME";

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/service-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/service-require.output.js
@@ -1,7 +1,7 @@
 const {
   S3,
-  waitUntilBucketNotExists,
-  waitUntilBucketExists
+  waitUntilBucketExists,
+  waitUntilBucketNotExists
 } = require("@aws-sdk/client-s3");
 
 const Bucket = "BUCKET_NAME";

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
@@ -1,9 +1,10 @@
-import { Collection, Identifier, JSCodeshift, ObjectProperty } from "jscodeshift";
+import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getV3ClientDefaultLocalName } from "../utils";
 import { addV3ClientDefaultImportEquals } from "./addV3ClientDefaultImportEquals";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
+import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
 import { V3ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types";
 
 export const addV3ClientNamedImportEquals = (
@@ -24,11 +25,7 @@ export const addV3ClientNamedImportEquals = (
 
   if (existingVarDeclarator.size()) {
     existingVarDeclarator.get(0).node.id.properties.push(namedImportObjectProperty);
-    existingVarDeclarator
-      .get(0)
-      .node.id.properties.sort((a: ObjectProperty, b: ObjectProperty) =>
-        (a.key as Identifier).name.localeCompare((b.key as Identifier).name)
-      );
+    existingVarDeclarator.get(0).node.id.properties.sort(objectPatternPropertyCompareFn);
     return;
   }
 

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
@@ -1,4 +1,4 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import { Collection, Identifier, JSCodeshift, ObjectProperty } from "jscodeshift";
 
 import { getV3ClientDefaultLocalName } from "../utils";
 import { addV3ClientDefaultImportEquals } from "./addV3ClientDefaultImportEquals";
@@ -24,6 +24,11 @@ export const addV3ClientNamedImportEquals = (
 
   if (existingVarDeclarator.size()) {
     existingVarDeclarator.get(0).node.id.properties.push(namedImportObjectProperty);
+    existingVarDeclarator
+      .get(0)
+      .node.id.properties.sort((a: ObjectProperty, b: ObjectProperty) =>
+        (a.key as Identifier).name.localeCompare((b.key as Identifier).name)
+      );
     return;
   }
 

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
@@ -24,8 +24,9 @@ export const addV3ClientNamedImportEquals = (
   });
 
   if (existingVarDeclarator.size()) {
-    existingVarDeclarator.get(0).node.id.properties.push(namedImportObjectProperty);
-    existingVarDeclarator.get(0).node.id.properties.sort(objectPatternPropertyCompareFn);
+    const firstDeclaratorProperties = existingVarDeclarator.get(0).node.id.properties;
+    firstDeclaratorProperties.push(namedImportObjectProperty);
+    firstDeclaratorProperties.sort(objectPatternPropertyCompareFn);
     return;
   }
 

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedRequire.ts
@@ -6,6 +6,7 @@ import { getRequireDeclarators } from "./getRequireDeclarators";
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";
 import { getV2RequireDeclarator } from "./getV2RequireDeclarator";
 import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
+import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
 import { V3ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types";
 
 export const addV3ClientNamedRequire = (
@@ -64,7 +65,9 @@ export const addV3ClientNamedRequire = (
     }
 
     if (existingRequireProperties.length > 0) {
-      (existingRequireProperties[0].id as ObjectPattern).properties.push(v3ClientObjectProperty);
+      const firstRequireProperties = (existingRequireProperties[0].id as ObjectPattern).properties;
+      firstRequireProperties.push(v3ClientObjectProperty);
+      firstRequireProperties.sort(objectPatternPropertyCompareFn);
       return;
     }
   }

--- a/src/transforms/v2-to-v3/modules/importSpecifierCompareFn.ts
+++ b/src/transforms/v2-to-v3/modules/importSpecifierCompareFn.ts
@@ -1,0 +1,30 @@
+import { ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier } from "jscodeshift";
+
+export const importSpecifierCompareFn = (
+  specifier1: ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier,
+  specifier2: ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier
+) => {
+  if (specifier1.type === "ImportSpecifier" && specifier2.type === "ImportSpecifier") {
+    return specifier1.imported.name.localeCompare(specifier2.imported.name);
+  }
+
+  if (
+    specifier1.type === "ImportDefaultSpecifier" &&
+    specifier2.type === "ImportDefaultSpecifier"
+  ) {
+    if (specifier1.local && specifier2.local)
+      return specifier1.local.name.localeCompare(specifier2.local.name);
+    return 0;
+  }
+
+  if (
+    specifier1.type === "ImportNamespaceSpecifier" &&
+    specifier2.type === "ImportNamespaceSpecifier"
+  ) {
+    if (specifier1.local && specifier2.local)
+      return specifier1.local.name.localeCompare(specifier2.local.name);
+    return 0;
+  }
+
+  return 0;
+};

--- a/src/transforms/v2-to-v3/modules/objectPatternPropertyCompareFn.ts
+++ b/src/transforms/v2-to-v3/modules/objectPatternPropertyCompareFn.ts
@@ -7,6 +7,8 @@ import {
   SpreadPropertyPattern,
 } from "jscodeshift";
 
+import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
+
 export type ObjectPatternProperty =
   | Property
   | PropertyPattern
@@ -19,9 +21,14 @@ export const objectPatternPropertyCompareFn = (
   property1: ObjectPatternProperty,
   property2: ObjectPatternProperty
 ) => {
-  if (property1.type === "Property" && property2.type === "Property") {
-    if (property1.key.type === "Identifier" && property2.key.type === "Identifier")
-      return property1.key.name.localeCompare(property2.key.name);
+  if (
+    OBJECT_PROPERTY_TYPE_LIST.includes(property1.type) &&
+    OBJECT_PROPERTY_TYPE_LIST.includes(property2.type)
+  ) {
+    const property1Key = (property1 as Property | ObjectProperty).key;
+    const property2Key = (property2 as Property | ObjectProperty).key;
+    if (property1Key.type === "Identifier" && property2Key.type === "Identifier")
+      return property1Key.name.localeCompare(property2Key.name);
   }
   return 0;
 };

--- a/src/transforms/v2-to-v3/modules/objectPatternPropertyCompareFn.ts
+++ b/src/transforms/v2-to-v3/modules/objectPatternPropertyCompareFn.ts
@@ -1,0 +1,27 @@
+import {
+  ObjectProperty,
+  Property,
+  PropertyPattern,
+  RestProperty,
+  SpreadProperty,
+  SpreadPropertyPattern,
+} from "jscodeshift";
+
+export type ObjectPatternProperty =
+  | Property
+  | PropertyPattern
+  | SpreadPropertyPattern
+  | SpreadProperty
+  | ObjectProperty
+  | RestProperty;
+
+export const objectPatternPropertyCompareFn = (
+  property1: ObjectPatternProperty,
+  property2: ObjectPatternProperty
+) => {
+  if (property1.type === "Property" && property2.type === "Property") {
+    if (property1.key.type === "Identifier" && property2.key.type === "Identifier")
+      return property1.key.name.localeCompare(property2.key.name);
+  }
+  return 0;
+};


### PR DESCRIPTION
### Issue

Required as we add waiter imports in https://github.com/awslabs/aws-sdk-js-codemod/pull/52

### Description

Sort v3ClientDefaultLocalName properties in named require/import equals

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
