### PR TITLE
Support removal of .promise() with parentPath ObjectProperty

### DIFF
--- a/.changeset/stale-tigers-call.md
+++ b/.changeset/stale-tigers-call.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Support removal of .promise() parentPath ObjectProperty

--- a/.changeset/stale-tigers-call.md
+++ b/.changeset/stale-tigers-call.md
@@ -2,4 +2,4 @@
 "aws-sdk-js-codemod": patch
 ---
 
-Support removal of .promise() parentPath ObjectProperty
+Support removal of .promise() with parentPath ObjectProperty

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.ts
@@ -1,5 +1,9 @@
 import AWS from "aws-sdk";
 
+export const listTablesObjectProperty = async (client: AWS.DynamoDB) => ({
+  promise: client.listTables().promise(),
+});
+
 export const listTables = async (client: AWS.DynamoDB) => client.listTables().promise();
 export const listTagsOfResource = async (client: AWS.DynamoDB) =>
   client.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.ts
@@ -1,5 +1,9 @@
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
+export const listTablesObjectProperty = async (client: DynamoDB) => ({
+  promise: client.listTables(),
+});
+
 export const listTables = async (client: DynamoDB) => client.listTables();
 export const listTagsOfResource = async (client: DynamoDB) =>
   client.listTagsOfResource({ ResourceArn: "STRING_VALUE" });

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.ts
@@ -1,5 +1,9 @@
 import DynamoDB from "aws-sdk/clients/dynamodb";
 
+export const listTablesObjectProperty = async (client: DynamoDB) => ({
+  promise: client.listTables().promise(),
+});
+
 export const listTables = async (client: DynamoDB) => client.listTables().promise();
 export const listTagsOfResource = async (client: DynamoDB) =>
   client.listTagsOfResource({ ResourceArn: "STRING_VALUE" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.ts
@@ -1,5 +1,9 @@
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
+export const listTablesObjectProperty = async (client: DynamoDB) => ({
+  promise: client.listTables(),
+});
+
 export const listTables = async (client: DynamoDB) => client.listTables();
 export const listTagsOfResource = async (client: DynamoDB) =>
   client.listTagsOfResource({ ResourceArn: "STRING_VALUE" });

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -22,6 +22,7 @@ export const removePromiseForCallExpression = (callExpression: ASTPath<CallExpre
       break;
     }
     case "ArrowFunctionExpression":
+    case "ObjectProperty":
     case "ReturnStatement": {
       const currentCalleeObject = (callExpression.value.callee as MemberExpression)
         .object as CallExpression;


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/391

### Description

Support removal of .promise() parentPath ObjectProperty

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
