### PR TITLE
Make localName optional in getV3ClientImportSpecifier

### DIFF
--- a/src/transforms/v2-to-v3/modules/addV3ClientImports.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientImports.ts
@@ -36,7 +36,6 @@ export const addV3ClientImports = (
     addV3ClientNamedImport(j, source, {
       ...options,
       importedName: v3WaiterApiName,
-      localName: v3WaiterApiName,
     });
   }
 };

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedImport.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedImport.ts
@@ -9,14 +9,11 @@ import { V3ClientImportSpecifierOptions, V3ClientModulesOptions } from "./types"
 export const addV3ClientNamedImport = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  {
-    localName,
-    importedName,
-    v2ClientName,
-    v2ClientLocalName,
-    v3ClientPackageName,
-  }: V3ClientModulesOptions & V3ClientImportSpecifierOptions
+  options: V3ClientModulesOptions & V3ClientImportSpecifierOptions
 ) => {
+  const { importedName, v2ClientName, v2ClientLocalName, v3ClientPackageName } = options;
+  const localName = options.localName ?? importedName;
+
   const importDeclarations = source.find(j.ImportDeclaration, {
     source: { value: v3ClientPackageName },
   });

--- a/src/transforms/v2-to-v3/modules/getV3ClientImportSpecifier.ts
+++ b/src/transforms/v2-to-v3/modules/getV3ClientImportSpecifier.ts
@@ -6,6 +6,6 @@ export const getV3ClientImportSpecifier = (
   j: JSCodeshift,
   { importedName, localName }: V3ClientImportSpecifierOptions
 ) =>
-  importedName === localName
-    ? j.importSpecifier(j.identifier(importedName))
-    : j.importSpecifier(j.identifier(importedName), j.identifier(localName));
+  localName
+    ? j.importSpecifier(j.identifier(importedName), j.identifier(localName))
+    : j.importSpecifier(j.identifier(importedName));

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -13,5 +13,5 @@ export interface V3ClientRequirePropertyOptions {
 
 export interface V3ClientImportSpecifierOptions {
   importedName: string;
-  localName: string;
+  localName?: string;
 }


### PR DESCRIPTION
### Issue

Requirement noticed in https://github.com/awslabs/aws-sdk-js-codemod/pull/394

### Description

Make localName optional in getV3ClientImportSpecifier

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
