### PR TITLE
Make valueName optional in getV3ClientRequireProperty

### DIFF
--- a/src/transforms/v2-to-v3/modules/addV3ClientImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientImportEquals.ts
@@ -35,7 +35,6 @@ export const addV3ClientImportEquals = (
     addV3ClientNamedImportEquals(j, source, {
       ...options,
       keyName: v3WaiterApiName,
-      valueName: v3WaiterApiName,
     });
   }
 };

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedRequire.ts
@@ -12,15 +12,11 @@ import { V3ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types"
 export const addV3ClientNamedRequire = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  {
-    keyName,
-    valueName,
-    v2ClientName,
-    v2ClientLocalName,
-    v2GlobalName,
-    v3ClientPackageName,
-  }: V3ClientModulesOptions & V3ClientRequirePropertyOptions
+  options: V3ClientModulesOptions & V3ClientRequirePropertyOptions
 ) => {
+  const { keyName, v2ClientName, v2ClientLocalName, v2GlobalName, v3ClientPackageName } = options;
+  const valueName = options.valueName ?? keyName;
+
   const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientLocalName);
   const v3ClientObjectProperty = getV3ClientRequireProperty(j, { keyName, valueName });
   const existingRequires = getRequireDeclarators(j, source, v3ClientPackageName);

--- a/src/transforms/v2-to-v3/modules/addV3ClientRequires.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientRequires.ts
@@ -35,7 +35,6 @@ export const addV3ClientRequires = (
     addV3ClientNamedRequire(j, source, {
       ...options,
       keyName: v3WaiterApiName,
-      valueName: v3WaiterApiName,
     });
   }
 };

--- a/src/transforms/v2-to-v3/modules/getV3ClientRequireProperty.ts
+++ b/src/transforms/v2-to-v3/modules/getV3ClientRequireProperty.ts
@@ -8,6 +8,6 @@ export const getV3ClientRequireProperty = (
 ) =>
   j.objectProperty.from({
     key: j.identifier(keyName),
-    value: j.identifier(valueName),
+    value: j.identifier(valueName ?? keyName),
     shorthand: true,
   });

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -8,7 +8,7 @@ export interface V3ClientModulesOptions {
 
 export interface V3ClientRequirePropertyOptions {
   keyName: string;
-  valueName: string;
+  valueName?: string;
 }
 
 export interface V3ClientImportSpecifierOptions {


### PR DESCRIPTION
### Issue

Similar to https://github.com/awslabs/aws-sdk-js-codemod/pull/395

### Description

Make valueName optional in getV3ClientRequireProperty

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
