### PR TITLE
Add comment with warning when removing .promise() from untested cases

### DIFF
--- a/.changeset/mean-actors-give.md
+++ b/.changeset/mean-actors-give.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": minor
+---
+
+Add comment with warning when removing .promise() from untested cases

--- a/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
@@ -36,7 +36,7 @@ export const removePromiseCalls = (
         },
       })
       .forEach((callExpression) => {
-        removePromiseForCallExpression(callExpression);
+        removePromiseForCallExpression(j, callExpression);
       });
 
     // Remove .promise() from client API request stored in a variable.
@@ -64,7 +64,7 @@ export const removePromiseCalls = (
             },
           })
           .forEach((callExpression) => {
-            removePromiseForCallExpression(callExpression);
+            removePromiseForCallExpression(j, callExpression);
           });
       });
   }

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -1,7 +1,10 @@
-import { ASTPath, CallExpression, MemberExpression } from "jscodeshift";
-import { print } from "recast";
+import { ASTPath, CallExpression, JSCodeshift, MemberExpression } from "jscodeshift";
+import { emitWarning } from "process";
 
-export const removePromiseForCallExpression = (callExpression: ASTPath<CallExpression>) => {
+export const removePromiseForCallExpression = (
+  j: JSCodeshift,
+  callExpression: ASTPath<CallExpression>
+) => {
   switch (callExpression.parentPath.value.type) {
     case "MemberExpression": {
       callExpression.parentPath.value.object = (
@@ -9,6 +12,26 @@ export const removePromiseForCallExpression = (callExpression: ASTPath<CallExpre
       ).object;
       break;
     }
+    default: {
+      emitWarning(
+        `Removal of .promise() not implemented for parentPath: ${callExpression.parentPath.value.type}\n` +
+          `Code processed: ${j(callExpression.parentPath).toSource()}\n\n` +
+          "Please report your use case on https://github.com/awslabs/aws-sdk-js-codemod\n"
+      );
+      const comments = callExpression.parentPath.node.comments || [];
+      comments.push(
+        j.commentLine(
+          " The promise() call was removed by aws-sdk-js-codemod v2-to-v3 transform using best guess."
+        )
+      );
+      comments.push(
+        j.commentLine(
+          " Please check that it is correct, and create an issue on GitHub to report this use case."
+        )
+      );
+      callExpression.parentPath.node.comments = comments;
+    }
+    // eslint-disable-next-line no-fallthrough
     case "ArrowFunctionExpression":
     case "AwaitExpression":
     case "ObjectProperty":
@@ -22,11 +45,5 @@ export const removePromiseForCallExpression = (callExpression: ASTPath<CallExpre
       callExpression.value.callee = currentCalleeObject.callee;
       break;
     }
-    default:
-      throw new Error(
-        `Removal of .promise() not implemented for parentPath: ${callExpression.parentPath.value.type}\n` +
-          `Code processed: ${print(callExpression.parentPath.node).code}\n\n` +
-          "Please report your use case on https://github.com/awslabs/aws-sdk-js-codemod\n"
-      );
   }
 };


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/401

### Description

Add comment with warning when removing .promise() from untested cases

### Testing

CI

Removed case for `AwaitExpression` and verified that the following warning is shown:
```console
(node:88681) Warning: Removal of .promise() not implemented for parentPath: AwaitExpression
Code processed: await client.listTables().promise()

Please report your use case on https://github.com/awslabs/aws-sdk-js-codemod
```

Also verified that code is updated to the following:
```js
// The promise() call was removed by aws-sdk-js-codemod v2-to-v3 transform using best guess.
// Please check that it is correct, and create an issue on GitHub to report this use case.
await client.listTables();
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
