### PR TITLE
Remove Client from getV3ClientDefaultLocalName

### DIFF
--- a/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
@@ -1,5 +1,5 @@
 import { CLIENT_NAMES_MAP, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
-import { getV3ClientDefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
+import { getV3DefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
 import { CLIENTS_TO_TEST } from "./config";
 import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
@@ -10,7 +10,7 @@ export const getGlobalImportEqualsOutput = (codegenComment: string) => {
   const sortedClientNames = getClientNamesSortedByPackageName(CLIENTS_TO_TEST);
 
   for (const v2ClientName of sortedClientNames) {
-    const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientName);
+    const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientName);
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
     globalImportEqualsOutputContent += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
 
@@ -18,9 +18,7 @@ export const getGlobalImportEqualsOutput = (codegenComment: string) => {
     const v3ObjectPattern =
       v3ClientName === v2ClientName ? v3ClientName : `${v3ClientName}: ${v2ClientName}`;
     globalImportEqualsOutputContent +=
-      `const {\n` +
-      `  ${v3ObjectPattern}\n` +
-      `} = ${getV3ClientDefaultLocalName(v2ClientName)};\n\n`;
+      `const {\n` + `  ${v3ObjectPattern}\n` + `} = ${getV3DefaultLocalName(v2ClientName)};\n\n`;
   }
 
   globalImportEqualsOutputContent += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);

--- a/scripts/generateNewClientTests/getServiceImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportEqualsOutput.ts
@@ -1,5 +1,5 @@
 import { CLIENT_NAMES_MAP, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
-import { getV3ClientDefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
+import { getV3DefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
 import { CLIENTS_TO_TEST } from "./config";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
@@ -7,7 +7,7 @@ export const getServiceImportEqualsOutput = (codegenComment: string) => {
   let serviceImportEqualsOutputContent = `${codegenComment};\n`;
 
   for (const v2ClientName of CLIENTS_TO_TEST) {
-    const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientName);
+    const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientName);
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
     serviceImportEqualsOutputContent += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
 
@@ -15,9 +15,7 @@ export const getServiceImportEqualsOutput = (codegenComment: string) => {
     const v3ObjectPattern =
       v3ClientName === v2ClientName ? v3ClientName : `${v3ClientName}: ${v2ClientName}`;
     serviceImportEqualsOutputContent +=
-      `const {\n` +
-      `  ${v3ObjectPattern}\n` +
-      `} = ${getV3ClientDefaultLocalName(v2ClientName)};\n\n`;
+      `const {\n` + `  ${v3ObjectPattern}\n` + `} = ${getV3DefaultLocalName(v2ClientName)};\n\n`;
   }
 
   serviceImportEqualsOutputContent += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);

--- a/src/transforms/v2-to-v3/modules/addV3ClientDefaultImport.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientDefaultImport.ts
@@ -1,6 +1,6 @@
 import { Collection, ImportDefaultSpecifier, JSCodeshift } from "jscodeshift";
 
-import { getV3ClientDefaultLocalName } from "../utils";
+import { getV3DefaultLocalName } from "../utils";
 import { getImportSpecifiers } from "./getImportSpecifiers";
 import { getV2ImportDeclaration } from "./getV2ImportDeclaration";
 import { V3ClientModulesOptions } from "./types";
@@ -10,7 +10,7 @@ export const addV3ClientDefaultImport = (
   source: Collection<unknown>,
   { v2ClientLocalName, v2ClientName, v3ClientPackageName }: V3ClientModulesOptions
 ) => {
-  const localName = getV3ClientDefaultLocalName(v2ClientLocalName);
+  const localName = getV3DefaultLocalName(v2ClientLocalName);
   const defaultImportSpecifier = j.importDefaultSpecifier(j.identifier(localName));
 
   const importDeclarations = source.find(j.ImportDeclaration, {

--- a/src/transforms/v2-to-v3/modules/addV3ClientDefaultImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientDefaultImportEquals.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV3ClientDefaultLocalName } from "../utils";
+import { getV3DefaultLocalName } from "../utils";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getV2ImportEqualsDeclaration } from "./getV2ImportEqualsDeclaration";
 import { V3ClientModulesOptions } from "./types";
@@ -10,7 +10,7 @@ export const addV3ClientDefaultImportEquals = (
   source: Collection<unknown>,
   { v2ClientLocalName, v2ClientName, v2GlobalName, v3ClientPackageName }: V3ClientModulesOptions
 ) => {
-  const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientLocalName);
+  const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientLocalName);
   const existingImportEquals = source.find(
     j.TSImportEqualsDeclaration,
     getImportEqualsDeclaration(v3ClientPackageName)

--- a/src/transforms/v2-to-v3/modules/addV3ClientDefaultRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientDefaultRequire.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV3ClientDefaultLocalName } from "../utils";
+import { getV3DefaultLocalName } from "../utils";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 import { getV2RequireDeclarator } from "./getV2RequireDeclarator";
 import { V3ClientModulesOptions } from "./types";
@@ -10,7 +10,7 @@ export const addV3ClientDefaultRequire = (
   source: Collection<unknown>,
   { v2ClientName, v2ClientLocalName, v3ClientPackageName, v2GlobalName }: V3ClientModulesOptions
 ) => {
-  const identifierName = getV3ClientDefaultLocalName(v2ClientLocalName);
+  const identifierName = getV3DefaultLocalName(v2ClientLocalName);
   const existingRequires = getRequireDeclarators(j, source, v3ClientPackageName);
 
   if (

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedImportEquals.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV3ClientDefaultLocalName } from "../utils";
+import { getV3DefaultLocalName } from "../utils";
 import { addV3ClientDefaultImportEquals } from "./addV3ClientDefaultImportEquals";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
@@ -15,7 +15,7 @@ export const addV3ClientNamedImportEquals = (
   const { keyName, valueName, ...v3ClientModulesOptions } = options;
   const { v2ClientLocalName, v3ClientPackageName } = v3ClientModulesOptions;
 
-  const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientLocalName);
+  const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientLocalName);
   const namedImportObjectProperty = getV3ClientRequireProperty(j, { keyName, valueName });
 
   const existingVarDeclarator = source.find(j.VariableDeclarator, {

--- a/src/transforms/v2-to-v3/modules/addV3ClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addV3ClientNamedRequire.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift, ObjectPattern, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
-import { getV3ClientDefaultLocalName } from "../utils";
+import { getV3DefaultLocalName } from "../utils";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";
 import { getV2RequireDeclarator } from "./getV2RequireDeclarator";
@@ -17,7 +17,7 @@ export const addV3ClientNamedRequire = (
   const { keyName, v2ClientName, v2ClientLocalName, v2GlobalName, v3ClientPackageName } = options;
   const valueName = options.valueName ?? keyName;
 
-  const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientLocalName);
+  const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientLocalName);
   const v3ClientObjectProperty = getV3ClientRequireProperty(j, { keyName, valueName });
   const existingRequires = getRequireDeclarators(j, source, v3ClientPackageName);
 

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypeReference.ts
@@ -5,7 +5,7 @@ import {
   V2_CLIENT_INPUT_SUFFIX_LIST,
   V2_CLIENT_OUTPUT_SUFFIX_LIST,
 } from "../config";
-import { getV3ClientDefaultLocalName } from "../utils";
+import { getV3DefaultLocalName } from "../utils";
 import { getTypeRefForString } from "./getTypeRefForString";
 
 export interface GetV3ClientTypeReferenceOptions {
@@ -25,7 +25,7 @@ export const getV3ClientTypeReference = (
   { v2ClientLocalName, v2ClientName, v2ClientTypeName }: GetV3ClientTypeReferenceOptions
 ): TSType => {
   const clientTypesMap = CLIENT_TYPES_MAP[v2ClientName];
-  const v3ClientDefaultLocalName = getV3ClientDefaultLocalName(v2ClientLocalName);
+  const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientLocalName);
 
   if (Object.keys(clientTypesMap).includes(v2ClientTypeName)) {
     return getTypeRefForString(j, v3ClientDefaultLocalName, clientTypesMap[v2ClientTypeName]);

--- a/src/transforms/v2-to-v3/utils/getV3ClientDefaultLocalName.ts
+++ b/src/transforms/v2-to-v3/utils/getV3ClientDefaultLocalName.ts
@@ -1,2 +1,0 @@
-export const getV3ClientDefaultLocalName = (v2ClientLocalName: string) =>
-  `AWS_${v2ClientLocalName}`;

--- a/src/transforms/v2-to-v3/utils/getV3DefaultLocalName.ts
+++ b/src/transforms/v2-to-v3/utils/getV3DefaultLocalName.ts
@@ -1,0 +1,1 @@
+export const getV3DefaultLocalName = (localNameSuffix: string) => `AWS_${localNameSuffix}`;

--- a/src/transforms/v2-to-v3/utils/index.ts
+++ b/src/transforms/v2-to-v3/utils/index.ts
@@ -1,5 +1,5 @@
 export * from "./getV2ClientNewExpression";
 export * from "./getV2ClientTSTypeRef";
 export * from "./getV2ServiceModulePath";
-export * from "./getV3ClientDefaultLocalName";
+export * from "./getV3DefaultLocalName";
 export * from "./isTypeScriptFile";


### PR DESCRIPTION
### Issue

PR to add s3.upload API in https://github.com/awslabs/aws-sdk-js-codemod/pull/394 will add non-client package imports in the transform

### Description

Remove Client from getV3ClientDefaultLocalName

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
