### PR TITLE
Rename `Client` to `Module` in utility function names

### DIFF
--- a/src/transforms/v2-to-v3/modules/addV3Modules.ts
+++ b/src/transforms/v2-to-v3/modules/addV3Modules.ts
@@ -7,7 +7,7 @@ import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { V3ClientModulesOptions } from "./types";
 
-export const addV3ClientModules = (
+export const addV3Modules = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: V3ClientModulesOptions

--- a/src/transforms/v2-to-v3/modules/index.ts
+++ b/src/transforms/v2-to-v3/modules/index.ts
@@ -1,4 +1,4 @@
-export * from "./addV3ClientModules";
+export * from "./addV3Modules";
 export * from "./getImportEqualsDeclaration";
 export * from "./getImportSpecifiers";
 export * from "./getRequireDeclaratorsWithProperty";

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -8,7 +8,7 @@ import {
   getV2ClientNamesRecord,
 } from "./client-names";
 import {
-  addV3ClientModules,
+  addV3Modules,
   getV2GlobalNameFromModule,
   removeV2ClientModule,
   removeV2GlobalModule,
@@ -42,7 +42,7 @@ const transformer = async (file: FileInfo, api: API) => {
     const v2Options = { v2ClientName, v2ClientLocalName, v2GlobalName };
     const v3Options = { v3ClientName, v3ClientPackageName };
 
-    addV3ClientModules(j, source, { ...v2Options, ...v3Options });
+    addV3Modules(j, source, { ...v2Options, ...v3Options });
     replaceTSTypeReference(j, source, { ...v2Options, v3ClientName });
     removeV2ClientModule(j, source, v2Options);
     removePromiseCalls(j, source, v2Options);


### PR DESCRIPTION
### Issue

PR to add s3.upload API in https://github.com/awslabs/aws-sdk-js-codemod/pull/394 will add non-client package modules in the transform

### Description

Rename `Client` to `Module` in utility function names

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
