### PR TITLE
Increase vitest timeout to 100 seconds

### DIFF
--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -52,7 +52,7 @@ describe("v2-to-v3", () => {
 
         expect(output.trim()).toEqual(outputCode.trim());
       },
-      60000
+      100000
     );
   });
 });


### PR DESCRIPTION
### Issue

Tests are failing on Node.js 14.x because of a timeout:

Example workflow runs:
* https://github.com/awslabs/aws-sdk-js-codemod/actions/runs/4255026855/jobs/7402098000
* https://github.com/awslabs/aws-sdk-js-codemod/actions/runs/4255104470/jobs/7402280714

```console
 ❯ src/transforms/v2-to-v3/transformer.spec.ts  (74 tests | 1 failed) 82820ms
   ❯ src/transforms/v2-to-v3/transformer.spec.ts > v2-to-v3 > new-client > transforms: service-import-equals.ts
     → Test timed out in 60000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
```

### Description

Increase vitest timeout to 100 seconds

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
