### PR TITLE
Make AwaitExpression/VariableDeclarator generic while removing .promise() API

### DIFF
--- a/.changeset/empty-flowers-speak.md
+++ b/.changeset/empty-flowers-speak.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Make AwaitExpression/VariableDeclarator generic while removing .promise() API

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -3,27 +3,17 @@ import { print } from "recast";
 
 export const removePromiseForCallExpression = (callExpression: ASTPath<CallExpression>) => {
   switch (callExpression.parentPath.value.type) {
-    case "AwaitExpression": {
-      callExpression.parentPath.value.argument = (
-        callExpression.value.callee as MemberExpression
-      ).object;
-      break;
-    }
     case "MemberExpression": {
       callExpression.parentPath.value.object = (
         callExpression.value.callee as MemberExpression
       ).object;
       break;
     }
-    case "VariableDeclarator": {
-      callExpression.parentPath.value.init = (
-        callExpression.value.callee as MemberExpression
-      ).object;
-      break;
-    }
     case "ArrowFunctionExpression":
+    case "AwaitExpression":
     case "ObjectProperty":
-    case "ReturnStatement": {
+    case "ReturnStatement":
+    case "VariableDeclarator": {
       const currentCalleeObject = (callExpression.value.callee as MemberExpression)
         .object as CallExpression;
       if (currentCalleeObject.arguments.length > 0) {


### PR DESCRIPTION
### Issue

Noticed in https://github.com/awslabs/aws-sdk-js-codemod/pull/397

### Description

Make AwaitExpression/VariableDeclarator generic while removing .promise() API.

The two switch cases were doing extra work which wasn't required.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
