### PR TITLE
Support removal of promise() for ExpressionStatement

### DIFF
--- a/.changeset/happy-glasses-turn.md
+++ b/.changeset/happy-glasses-turn.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Support removal of promise() for ExpressionStatement

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.input.js
@@ -2,6 +2,9 @@ import AWS from "aws-sdk";
 
 const client = new AWS.DynamoDB();
 
+// ExpressionStatement
+client.listTables().promise();
+
 // async/await
 try {
   await client.listTables().promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import.output.js
@@ -2,6 +2,9 @@ import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
 const client = new DynamoDB();
 
+// ExpressionStatement
+client.listTables();
+
 // async/await
 try {
   await client.listTables();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.input.js
@@ -2,6 +2,9 @@ import DynamoDBClient from "aws-sdk/clients/dynamodb";
 
 const client = new DynamoDBClient();
 
+// ExpressionStatement
+client.listTables().promise();
+
 // async/await
 try {
   await client.listTables().promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import.output.js
@@ -2,6 +2,9 @@ import { DynamoDB as DynamoDBClient } from "@aws-sdk/client-dynamodb";
 
 const client = new DynamoDBClient();
 
+// ExpressionStatement
+client.listTables();
+
 // async/await
 try {
   await client.listTables();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-require.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-require.input.js
@@ -2,6 +2,9 @@ const DynamoDBClient = require("aws-sdk/clients/dynamodb");
 
 const client = new DynamoDBClient();
 
+// ExpressionStatement
+client.listTables().promise();
+
 // async/await
 try {
   await client.listTables().promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-require.output.js
@@ -4,6 +4,9 @@ const {
 
 const client = new DynamoDBClient();
 
+// ExpressionStatement
+client.listTables();
+
 // async/await
 try {
   await client.listTables();

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -11,6 +11,7 @@ export const removePromiseForCallExpression = (callExpression: ASTPath<CallExpre
     }
     case "ArrowFunctionExpression":
     case "AwaitExpression":
+    case "ExpressionStatement":
     case "ObjectProperty":
     case "ReturnStatement":
     case "VariableDeclarator": {


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/368

### Description

Support removal of promise() for ExpressionStatement

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
