### PR TITLE
Use generic variable to content in generateNewClientTests

### DIFF
--- a/scripts/generateNewClientTests/getGlobalImportEqualsInput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportEqualsInput.ts
@@ -2,10 +2,10 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getGlobalImportEqualsInput = (codegenComment: string) => {
-  let globalImportEqualsInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  globalImportEqualsInputContent += `import AWS = require("aws-sdk");\n\n`;
-  globalImportEqualsInputContent += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST, `AWS.`);
+  content += `import AWS = require("aws-sdk");\n\n`;
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST, `AWS.`);
 
-  return globalImportEqualsInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
@@ -5,23 +5,23 @@ import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPacka
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
 export const getGlobalImportEqualsOutput = (codegenComment: string) => {
-  let globalImportEqualsOutputContent = `${codegenComment};\n`;
+  let content = `${codegenComment};\n`;
 
   const sortedClientNames = getClientNamesSortedByPackageName(CLIENTS_TO_TEST);
 
   for (const v2ClientName of sortedClientNames) {
     const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientName);
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
-    globalImportEqualsOutputContent += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
+    content += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
 
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
     const v3ObjectPattern =
       v3ClientName === v2ClientName ? v3ClientName : `${v3ClientName}: ${v2ClientName}`;
-    globalImportEqualsOutputContent +=
+    content +=
       `const {\n` + `  ${v3ObjectPattern}\n` + `} = ${getV3DefaultLocalName(v2ClientName)};\n\n`;
   }
 
-  globalImportEqualsOutputContent += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return globalImportEqualsOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getGlobalImportInput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportInput.ts
@@ -2,10 +2,10 @@ import { CLIENT_NAMES } from "../../src/transforms/v2-to-v3/config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getGlobalImportInput = (codegenComment: string) => {
-  let globalImportInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  globalImportInputContent += `import AWS from "aws-sdk";\n\n`;
-  globalImportInputContent += getV2ClientsNewExpressionCode(CLIENT_NAMES, `AWS.`);
+  content += `import AWS from "aws-sdk";\n\n`;
+  content += getV2ClientsNewExpressionCode(CLIENT_NAMES, `AWS.`);
 
-  return globalImportInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getGlobalImportOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportOutput.ts
@@ -4,13 +4,11 @@ import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 import { getV3PackageImportsCode } from "./getV3PackageImportsCode";
 
 export const getGlobalImportOutput = (codegenComment: string) => {
-  let globalImportOutputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  globalImportOutputContent += getV3PackageImportsCode(
-    getClientNamesSortedByPackageName(CLIENT_NAMES)
-  );
-  globalImportOutputContent += `\n`;
-  globalImportOutputContent += getV3ClientsNewExpressionCode(CLIENT_NAMES);
+  content += getV3PackageImportsCode(getClientNamesSortedByPackageName(CLIENT_NAMES));
+  content += `\n`;
+  content += getV3ClientsNewExpressionCode(CLIENT_NAMES);
 
-  return globalImportOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getGlobalImportStarInput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportStarInput.ts
@@ -2,10 +2,10 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getGlobalImportStarInput = (codegenComment: string) => {
-  let globalImportInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  globalImportInputContent += `import * as AWS from "aws-sdk";\n\n`;
-  globalImportInputContent += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST, `AWS.`);
+  content += `import * as AWS from "aws-sdk";\n\n`;
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST, `AWS.`);
 
-  return globalImportInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getGlobalImportStarOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportStarOutput.ts
@@ -4,13 +4,11 @@ import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 import { getV3PackageImportsCode } from "./getV3PackageImportsCode";
 
 export const getGlobalImportStarOutput = (codegenComment: string) => {
-  let globalImportOutputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  globalImportOutputContent += getV3PackageImportsCode(
-    getClientNamesSortedByPackageName(CLIENTS_TO_TEST)
-  );
-  globalImportOutputContent += `\n`;
-  globalImportOutputContent += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += getV3PackageImportsCode(getClientNamesSortedByPackageName(CLIENTS_TO_TEST));
+  content += `\n`;
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return globalImportOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getGlobalRequireInput.ts
+++ b/scripts/generateNewClientTests/getGlobalRequireInput.ts
@@ -2,10 +2,10 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getGlobalRequireInput = (codegenComment: string) => {
-  let globalRequireInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  globalRequireInputContent += `const AWS = require("aws-sdk");\n\n`;
-  globalRequireInputContent += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST, `AWS.`);
+  content += `const AWS = require("aws-sdk");\n\n`;
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST, `AWS.`);
 
-  return globalRequireInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getGlobalRequireOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalRequireOutput.ts
@@ -4,23 +4,23 @@ import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPacka
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
 export const getGlobalRequireOutput = (codegenComment: string) => {
-  let globalRequireOutputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   const sortedClientNames = getClientNamesSortedByPackageName(CLIENTS_TO_TEST);
-  globalRequireOutputContent += `const `;
+  content += `const `;
   for (const v2ClientName of sortedClientNames) {
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
     const v3RequireKeyValuePair =
       v3ClientName === v2ClientName ? v3ClientName : `${v3ClientName}: ${v2ClientName}`;
-    globalRequireOutputContent +=
+    content +=
       `{\n` +
       `        ${v3RequireKeyValuePair}\n` +
       `      } = require("${v3ClientPackageName}"),\n` +
       `      `;
   }
-  globalRequireOutputContent = globalRequireOutputContent.replace(/,\n {6}$/, ";\n\n");
-  globalRequireOutputContent += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content = content.replace(/,\n {6}$/, ";\n\n");
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return globalRequireOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getGlobalRequirePropertyInput.ts
+++ b/scripts/generateNewClientTests/getGlobalRequirePropertyInput.ts
@@ -2,13 +2,13 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getGlobalRequirePropertyInput = (codegenComment: string) => {
-  let globalRequireInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   for (const clientName of CLIENTS_TO_TEST) {
-    globalRequireInputContent += `const ${clientName} = require("aws-sdk").${clientName};\n`;
+    content += `const ${clientName} = require("aws-sdk").${clientName};\n`;
   }
-  globalRequireInputContent += `\n`;
-  globalRequireInputContent += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += `\n`;
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return globalRequireInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportDeepInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepInput.ts
@@ -2,13 +2,13 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceImportDeepInput = (codegenComment: string) => {
-  let serviceImportInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   for (const clientName of CLIENTS_TO_TEST) {
-    serviceImportInputContent += `import ${clientName} from "aws-sdk/clients/${clientName.toLowerCase()}";\n`;
+    content += `import ${clientName} from "aws-sdk/clients/${clientName.toLowerCase()}";\n`;
   }
-  serviceImportInputContent += `\n`;
-  serviceImportInputContent += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += `\n`;
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return serviceImportInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportDeepOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepOutput.ts
@@ -3,11 +3,11 @@ import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 import { getV3PackageImportsCode } from "./getV3PackageImportsCode";
 
 export const getServiceImportDeepOutput = (codegenComment: string) => {
-  let serviceImportOutputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  serviceImportOutputContent += getV3PackageImportsCode(CLIENTS_TO_TEST);
-  serviceImportOutputContent += `\n`;
-  serviceImportOutputContent += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += getV3PackageImportsCode(CLIENTS_TO_TEST);
+  content += `\n`;
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return serviceImportOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportDeepStarInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepStarInput.ts
@@ -2,13 +2,13 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceImportDeepStarInput = (codegenComment: string) => {
-  let serviceImportInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   for (const clientName of CLIENTS_TO_TEST) {
-    serviceImportInputContent += `import * as ${clientName} from "aws-sdk/clients/${clientName.toLowerCase()}";\n`;
+    content += `import * as ${clientName} from "aws-sdk/clients/${clientName.toLowerCase()}";\n`;
   }
-  serviceImportInputContent += `\n`;
-  serviceImportInputContent += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += `\n`;
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return serviceImportInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportDeepStarWithNameInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepStarWithNameInput.ts
@@ -2,15 +2,15 @@ import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceImportDeepStarWithNameInput = (codegenComment: string) => {
-  let serviceImportInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   for (const clientName of CLIENTS_TO_TEST) {
-    serviceImportInputContent += `import * as ${clientName}${LOCAL_NAME_SUFFIX} from "aws-sdk/clients/${clientName.toLowerCase()}";\n`;
+    content += `import * as ${clientName}${LOCAL_NAME_SUFFIX} from "aws-sdk/clients/${clientName.toLowerCase()}";\n`;
   }
-  serviceImportInputContent += `\n`;
-  serviceImportInputContent += getV2ClientsNewExpressionCode(
+  content += `\n`;
+  content += getV2ClientsNewExpressionCode(
     CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
   );
 
-  return serviceImportInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportDeepStarWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepStarWithNameOutput.ts
@@ -3,7 +3,7 @@ import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
 export const getServiceImportDeepStarWithNameOutput = (codegenComment: string) => {
-  let serviceImportOutputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   for (const v2ClientName of CLIENTS_TO_TEST) {
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
@@ -11,12 +11,12 @@ export const getServiceImportDeepStarWithNameOutput = (codegenComment: string) =
     const v3ClientLocalName = `${v2ClientName}${LOCAL_NAME_SUFFIX}`;
     const v3ImportSpecifier =
       v3ClientName === v3ClientLocalName ? v3ClientName : `${v3ClientName} as ${v3ClientLocalName}`;
-    serviceImportOutputContent += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;
+    content += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;
   }
-  serviceImportOutputContent += `\n`;
-  serviceImportOutputContent += getV3ClientsNewExpressionCode(
+  content += `\n`;
+  content += getV3ClientsNewExpressionCode(
     CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
   );
 
-  return serviceImportOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportEqualsInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportEqualsInput.ts
@@ -2,12 +2,12 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceImportEqualsInput = (codegenComment: string) => {
-  let serviceImportEqualsInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   for (const clientName of CLIENTS_TO_TEST) {
-    serviceImportEqualsInputContent += `import ${clientName} = require("aws-sdk/clients/${clientName.toLowerCase()}");\n`;
+    content += `import ${clientName} = require("aws-sdk/clients/${clientName.toLowerCase()}");\n`;
   }
-  serviceImportEqualsInputContent += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return serviceImportEqualsInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportEqualsOutput.ts
@@ -4,21 +4,21 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
 export const getServiceImportEqualsOutput = (codegenComment: string) => {
-  let serviceImportEqualsOutputContent = `${codegenComment};\n`;
+  let content = `${codegenComment};\n`;
 
   for (const v2ClientName of CLIENTS_TO_TEST) {
     const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientName);
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
-    serviceImportEqualsOutputContent += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
+    content += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
 
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
     const v3ObjectPattern =
       v3ClientName === v2ClientName ? v3ClientName : `${v3ClientName}: ${v2ClientName}`;
-    serviceImportEqualsOutputContent +=
+    content +=
       `const {\n` + `  ${v3ObjectPattern}\n` + `} = ${getV3DefaultLocalName(v2ClientName)};\n\n`;
   }
 
-  serviceImportEqualsOutputContent += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return serviceImportEqualsOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportInput.ts
@@ -2,11 +2,11 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceImportInput = (codegenComment: string) => {
-  let serviceImportInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  serviceImportInputContent += `import { ${CLIENTS_TO_TEST.join(", ")} } from "aws-sdk";\n`;
-  serviceImportInputContent += `\n`;
-  serviceImportInputContent += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += `import { ${CLIENTS_TO_TEST.join(", ")} } from "aws-sdk";\n`;
+  content += `\n`;
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return serviceImportInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportOutput.ts
@@ -4,13 +4,11 @@ import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 import { getV3PackageImportsCode } from "./getV3PackageImportsCode";
 
 export const getServiceImportOutput = (codegenComment: string) => {
-  let serviceImportOutputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  serviceImportOutputContent += getV3PackageImportsCode(
-    getClientNamesSortedByPackageName(CLIENTS_TO_TEST)
-  );
-  serviceImportOutputContent += `\n`;
-  serviceImportOutputContent += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += getV3PackageImportsCode(getClientNamesSortedByPackageName(CLIENTS_TO_TEST));
+  content += `\n`;
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return serviceImportOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportWithNameInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportWithNameInput.ts
@@ -2,15 +2,15 @@ import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceImportWithNameInput = (codegenComment: string) => {
-  let serviceImportInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  serviceImportInputContent += `import { \n${CLIENTS_TO_TEST.map(
+  content += `import { \n${CLIENTS_TO_TEST.map(
     (clientName) => `  ${clientName} as ${clientName}${LOCAL_NAME_SUFFIX}`
   ).join(`,\n`)}\n} from "aws-sdk";\n`;
-  serviceImportInputContent += `\n`;
-  serviceImportInputContent += getV2ClientsNewExpressionCode(
+  content += `\n`;
+  content += getV2ClientsNewExpressionCode(
     CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
   );
 
-  return serviceImportInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportWithNameOutput.ts
@@ -4,7 +4,7 @@ import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPacka
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
 export const getServiceImportWithNameOutput = (codegenComment: string) => {
-  let serviceImportOutputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   for (const v2ClientName of getClientNamesSortedByPackageName(CLIENTS_TO_TEST)) {
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
@@ -12,12 +12,12 @@ export const getServiceImportWithNameOutput = (codegenComment: string) => {
     const v3ClientLocalName = `${v2ClientName}${LOCAL_NAME_SUFFIX}`;
     const v3ImportSpecifier =
       v3ClientName === v3ClientLocalName ? v3ClientName : `${v3ClientName} as ${v3ClientLocalName}`;
-    serviceImportOutputContent += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;
+    content += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;
   }
-  serviceImportOutputContent += `\n`;
-  serviceImportOutputContent += getV3ClientsNewExpressionCode(
+  content += `\n`;
+  content += getV3ClientsNewExpressionCode(
     CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
   );
 
-  return serviceImportOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceRequireDeepInput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireDeepInput.ts
@@ -2,13 +2,13 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceRequireDeepInput = (codegenComment: string) => {
-  let serviceRequireInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   for (const clientName of CLIENTS_TO_TEST) {
-    serviceRequireInputContent += `const ${clientName} = require("aws-sdk/clients/${clientName.toLowerCase()}");\n`;
+    content += `const ${clientName} = require("aws-sdk/clients/${clientName.toLowerCase()}");\n`;
   }
-  serviceRequireInputContent += `\n`;
-  serviceRequireInputContent += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += `\n`;
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return serviceRequireInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceRequireDeepOutput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireDeepOutput.ts
@@ -3,17 +3,17 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
 export const getServiceRequireDeepOutput = (codegenComment: string) => {
-  let serviceRequireDeepOutputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   for (const v2ClientName of CLIENTS_TO_TEST) {
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
     const v3RequireKeyValuePair =
       v3ClientName === v2ClientName ? v3ClientName : `${v3ClientName}: ${v2ClientName}`;
-    serviceRequireDeepOutputContent += `const {\n  ${v3RequireKeyValuePair}\n} = require("${v3ClientPackageName}");\n`;
+    content += `const {\n  ${v3RequireKeyValuePair}\n} = require("${v3ClientPackageName}");\n`;
   }
-  serviceRequireDeepOutputContent += `\n`;
-  serviceRequireDeepOutputContent += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += `\n`;
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return serviceRequireDeepOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceRequireInput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireInput.ts
@@ -2,11 +2,11 @@ import { CLIENTS_TO_TEST } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceRequireInput = (codegenComment: string) => {
-  let serviceRequireInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  serviceRequireInputContent += `const { ${CLIENTS_TO_TEST.join(", ")} } = require("aws-sdk");\n`;
-  serviceRequireInputContent += `\n`;
-  serviceRequireInputContent += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += `const { ${CLIENTS_TO_TEST.join(", ")} } = require("aws-sdk");\n`;
+  content += `\n`;
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
-  return serviceRequireInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceRequireWithNameInput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireWithNameInput.ts
@@ -2,15 +2,15 @@ import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceRequireWithNameInput = (codegenComment: string) => {
-  let serviceRequireInputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
-  serviceRequireInputContent += `const { \n${CLIENTS_TO_TEST.map(
+  content += `const { \n${CLIENTS_TO_TEST.map(
     (clientName) => `  ${clientName}: ${clientName}${LOCAL_NAME_SUFFIX}`
   ).join(`,\n`)}\n} = require("aws-sdk");\n`;
-  serviceRequireInputContent += `\n`;
-  serviceRequireInputContent += getV2ClientsNewExpressionCode(
+  content += `\n`;
+  content += getV2ClientsNewExpressionCode(
     CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
   );
 
-  return serviceRequireInputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getServiceRequireWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireWithNameOutput.ts
@@ -4,26 +4,26 @@ import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPacka
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
 export const getServiceRequireWithNameOutput = (codegenComment: string) => {
-  let globalRequireOutputContent = `${codegenComment}\n`;
+  let content = `${codegenComment}\n`;
 
   const sortedClientNames = getClientNamesSortedByPackageName(CLIENTS_TO_TEST);
-  globalRequireOutputContent += `const `;
+  content += `const `;
   for (const v2ClientName of sortedClientNames) {
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
     const v3ClientLocalName = `${v2ClientName}${LOCAL_NAME_SUFFIX}`;
     const v3RequireKeyValuePair =
       v3ClientName === v3ClientLocalName ? v3ClientName : `${v3ClientName}: ${v3ClientLocalName}`;
-    globalRequireOutputContent +=
+    content +=
       `{\n` +
       `        ${v3RequireKeyValuePair}\n` +
       `      } = require("${v3ClientPackageName}"),\n` +
       `      `;
   }
-  globalRequireOutputContent = globalRequireOutputContent.replace(/,\n {6}$/, ";\n\n");
-  globalRequireOutputContent += getV3ClientsNewExpressionCode(
+  content = content.replace(/,\n {6}$/, ";\n\n");
+  content += getV3ClientsNewExpressionCode(
     CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
   );
 
-  return globalRequireOutputContent;
+  return content;
 };

--- a/scripts/generateNewClientTests/getV2ClientsNewExpressionCode.ts
+++ b/scripts/generateNewClientTests/getV2ClientsNewExpressionCode.ts
@@ -1,7 +1,7 @@
 export const getV2ClientsNewExpressionCode = (clientsToTest: string[], prefix?: string) => {
-  let v2ClientsNewExpressionCode = ``;
+  let content = ``;
   for (const clientName of clientsToTest) {
-    v2ClientsNewExpressionCode += `new ${prefix || ""}${clientName}();\n`;
+    content += `new ${prefix || ""}${clientName}();\n`;
   }
-  return v2ClientsNewExpressionCode;
+  return content;
 };

--- a/scripts/generateNewClientTests/getV3ClientsNewExpressionCode.ts
+++ b/scripts/generateNewClientTests/getV3ClientsNewExpressionCode.ts
@@ -1,7 +1,7 @@
 export const getV3ClientsNewExpressionCode = (clientsToTest: string[]) => {
-  let v3ClientsNewExpressionCode = ``;
+  let content = ``;
   for (const v2ClientName of clientsToTest) {
-    v3ClientsNewExpressionCode += `new ${v2ClientName}();\n`;
+    content += `new ${v2ClientName}();\n`;
   }
-  return v3ClientsNewExpressionCode;
+  return content;
 };

--- a/scripts/generateNewClientTests/getV3PackageImportsCode.ts
+++ b/scripts/generateNewClientTests/getV3PackageImportsCode.ts
@@ -5,13 +5,13 @@ import {
 } from "../../src/transforms/v2-to-v3/config";
 
 export const getV3PackageImportsCode = (sortedV2ClientNames: typeof CLIENT_NAMES) => {
-  let v3PackageImportsCode = ``;
+  let content = ``;
   for (const v2ClientName of sortedV2ClientNames) {
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
     const v3ImportSpecifier =
       v3ClientName === v2ClientName ? v3ClientName : `${v3ClientName} as ${v2ClientName}`;
-    v3PackageImportsCode += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;
+    content += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;
   }
-  return v3PackageImportsCode;
+  return content;
 };


### PR DESCRIPTION
### Issue

Sometimes variables are not renamed in PRs like https://github.com/awslabs/aws-sdk-js-codemod/pull/412

### Description

Use generic variable to content in generateNewClientTests

### Testing

Verified that new-client tests were not updated

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
