### PR TITLE
Add option addLocalNameSuffix in getV3ClientsNewExpressionCode

### DIFF
--- a/scripts/generateNewClientTests/getServiceImportDeepStarWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepStarWithNameOutput.ts
@@ -14,9 +14,7 @@ export const getServiceImportDeepStarWithNameOutput = (codegenComment: string) =
     content += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;
   }
   content += `\n`;
-  content += getV3ClientsNewExpressionCode(
-    CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
-  );
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST, { addLocalNameSuffix: true });
 
   return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportWithNameOutput.ts
@@ -15,9 +15,7 @@ export const getServiceImportWithNameOutput = (codegenComment: string) => {
     content += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;
   }
   content += `\n`;
-  content += getV3ClientsNewExpressionCode(
-    CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
-  );
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST, { addLocalNameSuffix: true });
 
   return content;
 };

--- a/scripts/generateNewClientTests/getServiceRequireWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireWithNameOutput.ts
@@ -21,9 +21,7 @@ export const getServiceRequireWithNameOutput = (codegenComment: string) => {
       `      `;
   }
   content = content.replace(/,\n {6}$/, ";\n\n");
-  content += getV3ClientsNewExpressionCode(
-    CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
-  );
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST, { addLocalNameSuffix: true });
 
   return content;
 };

--- a/scripts/generateNewClientTests/getV3ClientsNewExpressionCode.ts
+++ b/scripts/generateNewClientTests/getV3ClientsNewExpressionCode.ts
@@ -1,7 +1,22 @@
-export const getV3ClientsNewExpressionCode = (clientsToTest: string[]) => {
+import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
+
+export interface V3ClientsNewExpressionCodeOptions {
+  sortByPackageName?: boolean;
+}
+
+export const getV3ClientsNewExpressionCode = (
+  clientsToTest: string[],
+  options?: V3ClientsNewExpressionCodeOptions
+) => {
   let content = ``;
-  for (const v2ClientName of clientsToTest) {
-    content += `new ${v2ClientName}();\n`;
+
+  const { sortByPackageName = false } = options || {};
+  const clientNames = sortByPackageName
+    ? getClientNamesSortedByPackageName(clientsToTest)
+    : clientsToTest;
+
+  for (const clientName of clientNames) {
+    content += `new ${clientName}();\n`;
   }
   return content;
 };

--- a/scripts/generateNewClientTests/getV3ClientsNewExpressionCode.ts
+++ b/scripts/generateNewClientTests/getV3ClientsNewExpressionCode.ts
@@ -1,7 +1,7 @@
-import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
+import { LOCAL_NAME_SUFFIX } from "./config";
 
 export interface V3ClientsNewExpressionCodeOptions {
-  sortByPackageName?: boolean;
+  addLocalNameSuffix?: boolean;
 }
 
 export const getV3ClientsNewExpressionCode = (
@@ -10,13 +10,9 @@ export const getV3ClientsNewExpressionCode = (
 ) => {
   let content = ``;
 
-  const { sortByPackageName = false } = options || {};
-  const clientNames = sortByPackageName
-    ? getClientNamesSortedByPackageName(clientsToTest)
-    : clientsToTest;
-
-  for (const clientName of clientNames) {
-    content += `new ${clientName}();\n`;
+  const { addLocalNameSuffix = false } = options || {};
+  for (const clientName of clientsToTest) {
+    content += `new ${clientName}${addLocalNameSuffix ? LOCAL_NAME_SUFFIX : ""}();\n`;
   }
   return content;
 };


### PR DESCRIPTION
### Issue

N/A

### Description

Add option addLocalNameSuffix in getV3ClientsNewExpressionCode to reduce duplicate code

### Testing

Verified that new-client tests were not updated.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
