### PR TITLE
Add utility getV3ImportEqualsCode

### DIFF
--- a/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
@@ -1,11 +1,12 @@
 import { CLIENTS_TO_TEST } from "./config";
+import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 import { getV3ImportEqualsCode } from "./getV3ImportEqualsCode";
 
 export const getGlobalImportEqualsOutput = (codegenComment: string) => {
   let content = `${codegenComment};\n`;
 
-  content += getV3ImportEqualsCode(CLIENTS_TO_TEST, { sortByPackageName: true });
+  content += getV3ImportEqualsCode(getClientNamesSortedByPackageName(CLIENTS_TO_TEST));
   content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
   return content;

--- a/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
@@ -1,26 +1,11 @@
-import { CLIENT_NAMES_MAP, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
-import { getV3DefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
 import { CLIENTS_TO_TEST } from "./config";
-import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
+import { getV3ImportEqualsCode } from "./getV3ImportEqualsCode";
 
 export const getGlobalImportEqualsOutput = (codegenComment: string) => {
   let content = `${codegenComment};\n`;
 
-  const sortedClientNames = getClientNamesSortedByPackageName(CLIENTS_TO_TEST);
-
-  for (const v2ClientName of sortedClientNames) {
-    const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientName);
-    const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
-    content += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
-
-    const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
-    const v3ObjectPattern =
-      v3ClientName === v2ClientName ? v3ClientName : `${v3ClientName}: ${v2ClientName}`;
-    content +=
-      `const {\n` + `  ${v3ObjectPattern}\n` + `} = ${getV3DefaultLocalName(v2ClientName)};\n\n`;
-  }
-
+  content += getV3ImportEqualsCode(CLIENTS_TO_TEST, { sortByPackageName: true });
   content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
   return content;

--- a/scripts/generateNewClientTests/getServiceImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportEqualsOutput.ts
@@ -1,23 +1,11 @@
-import { CLIENT_NAMES_MAP, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
-import { getV3DefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
 import { CLIENTS_TO_TEST } from "./config";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
+import { getV3ImportEqualsCode } from "./getV3ImportEqualsCode";
 
 export const getServiceImportEqualsOutput = (codegenComment: string) => {
   let content = `${codegenComment};\n`;
 
-  for (const v2ClientName of CLIENTS_TO_TEST) {
-    const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientName);
-    const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
-    content += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
-
-    const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
-    const v3ObjectPattern =
-      v3ClientName === v2ClientName ? v3ClientName : `${v3ClientName}: ${v2ClientName}`;
-    content +=
-      `const {\n` + `  ${v3ObjectPattern}\n` + `} = ${getV3DefaultLocalName(v2ClientName)};\n\n`;
-  }
-
+  content += getV3ImportEqualsCode(CLIENTS_TO_TEST);
   content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
   return content;

--- a/scripts/generateNewClientTests/getV3ImportEqualsCode.ts
+++ b/scripts/generateNewClientTests/getV3ImportEqualsCode.ts
@@ -4,24 +4,11 @@ import {
   CLIENT_PACKAGE_NAMES_MAP,
 } from "../../src/transforms/v2-to-v3/config";
 import { getV3DefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
-import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
 
-export interface V3ImportEqualsCodeOptions {
-  sortByPackageName?: boolean;
-}
-
-export const getV3ImportEqualsCode = (
-  clientsToTest: typeof CLIENT_NAMES,
-  options?: V3ImportEqualsCodeOptions
-) => {
+export const getV3ImportEqualsCode = (clientsToTest: typeof CLIENT_NAMES) => {
   let content = ``;
 
-  const { sortByPackageName = false } = options || {};
-  const clientNames = sortByPackageName
-    ? getClientNamesSortedByPackageName(clientsToTest)
-    : clientsToTest;
-
-  for (const v2ClientName of clientNames) {
+  for (const v2ClientName of clientsToTest) {
     const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientName);
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
     content += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;

--- a/scripts/generateNewClientTests/getV3ImportEqualsCode.ts
+++ b/scripts/generateNewClientTests/getV3ImportEqualsCode.ts
@@ -1,0 +1,37 @@
+import {
+  CLIENT_NAMES,
+  CLIENT_NAMES_MAP,
+  CLIENT_PACKAGE_NAMES_MAP,
+} from "../../src/transforms/v2-to-v3/config";
+import { getV3DefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
+import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
+
+export interface V3ImportEqualsCodeOptions {
+  sortByPackageName?: boolean;
+}
+
+export const getV3ImportEqualsCode = (
+  clientsToTest: typeof CLIENT_NAMES,
+  options?: V3ImportEqualsCodeOptions
+) => {
+  let content = ``;
+
+  const { sortByPackageName = false } = options || {};
+  const clientNames = sortByPackageName
+    ? getClientNamesSortedByPackageName(clientsToTest)
+    : clientsToTest;
+
+  for (const v2ClientName of clientNames) {
+    const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientName);
+    const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
+    content += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
+
+    const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
+    const v3ObjectPattern =
+      v3ClientName === v2ClientName ? v3ClientName : `${v3ClientName}: ${v2ClientName}`;
+    content +=
+      `const {\n` + `  ${v3ObjectPattern}\n` + `} = ${getV3DefaultLocalName(v2ClientName)};\n\n`;
+  }
+
+  return content;
+};


### PR DESCRIPTION
### Issue

Refactoring similar to https://github.com/awslabs/aws-sdk-js-codemod/pull/414

### Description

Adds utility getV3ImportEqualsCode

### Testing

Verified that new-client tests are not updated.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
