### PR TITLE
Add utility getClientNameWithLocalSuffix

### DIFF
--- a/scripts/generateNewClientTests/getClientNameWithLocalSuffix.ts
+++ b/scripts/generateNewClientTests/getClientNameWithLocalSuffix.ts
@@ -1,0 +1,4 @@
+import { LOCAL_NAME_SUFFIX } from "./config";
+
+export const getClientNameWithLocalSuffix = (clientName: string) =>
+  `${clientName}${LOCAL_NAME_SUFFIX}`;

--- a/scripts/generateNewClientTests/getClientNamesWithLocalSuffix.ts
+++ b/scripts/generateNewClientTests/getClientNamesWithLocalSuffix.ts
@@ -1,4 +1,0 @@
-import { LOCAL_NAME_SUFFIX } from "./config";
-
-export const getClientNamesWithLocalSuffix = (clientNames: string[]) =>
-  clientNames.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`);

--- a/scripts/generateNewClientTests/getServiceImportDeepStarWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepStarWithNameOutput.ts
@@ -1,6 +1,6 @@
 import { CLIENT_NAMES_MAP, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
 import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
-import { getClientNamesWithLocalSuffix } from "./getClientNamesWithLocalSuffix";
+import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
 export const getServiceImportDeepStarWithNameOutput = (codegenComment: string) => {
@@ -15,7 +15,7 @@ export const getServiceImportDeepStarWithNameOutput = (codegenComment: string) =
     content += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;
   }
   content += `\n`;
-  content += getV3ClientsNewExpressionCode(getClientNamesWithLocalSuffix(CLIENTS_TO_TEST));
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
 
   return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportWithNameOutput.ts
@@ -1,7 +1,7 @@
 import { CLIENT_NAMES_MAP, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
 import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
 import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
-import { getClientNamesWithLocalSuffix } from "./getClientNamesWithLocalSuffix";
+import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
 export const getServiceImportWithNameOutput = (codegenComment: string) => {
@@ -16,7 +16,7 @@ export const getServiceImportWithNameOutput = (codegenComment: string) => {
     content += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;
   }
   content += `\n`;
-  content += getV3ClientsNewExpressionCode(getClientNamesWithLocalSuffix(CLIENTS_TO_TEST));
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
 
   return content;
 };

--- a/scripts/generateNewClientTests/getServiceRequireWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireWithNameOutput.ts
@@ -1,7 +1,7 @@
 import { CLIENT_NAMES_MAP, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
 import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
 import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
-import { getClientNamesWithLocalSuffix } from "./getClientNamesWithLocalSuffix";
+import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
 export const getServiceRequireWithNameOutput = (codegenComment: string) => {
@@ -22,7 +22,7 @@ export const getServiceRequireWithNameOutput = (codegenComment: string) => {
       `      `;
   }
   content = content.replace(/,\n {6}$/, ";\n\n");
-  content += getV3ClientsNewExpressionCode(getClientNamesWithLocalSuffix(CLIENTS_TO_TEST));
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
 
   return content;
 };


### PR DESCRIPTION
### Issue

More modular alternative to https://github.com/awslabs/aws-sdk-js-codemod/pull/416

### Description

Add utility getClientNameWithLocalSuffix

### Testing

Verified that new-client tests were not updated.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
