### PR TITLE
Call getClientNameWithLocalSuffix from scripts

### DIFF
--- a/scripts/generateNewClientTests/getServiceImportDeepStarWithNameInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepStarWithNameInput.ts
@@ -1,4 +1,4 @@
-import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
+import { CLIENTS_TO_TEST } from "./config";
 import { getClientDeepImportPath } from "./getClientDeepImportPath";
 import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
@@ -7,9 +7,8 @@ export const getServiceImportDeepStarWithNameInput = (codegenComment: string) =>
   let content = `${codegenComment}\n`;
 
   for (const clientName of CLIENTS_TO_TEST) {
-    content += `import * as ${clientName}${LOCAL_NAME_SUFFIX} from "${getClientDeepImportPath(
-      clientName
-    )}";\n`;
+    const importName = getClientNameWithLocalSuffix(clientName);
+    content += `import * as ${importName} from "${getClientDeepImportPath(clientName)}";\n`;
   }
   content += `\n`;
   content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));

--- a/scripts/generateNewClientTests/getServiceImportDeepStarWithNameInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepStarWithNameInput.ts
@@ -1,5 +1,6 @@
 import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
 import { getClientDeepImportPath } from "./getClientDeepImportPath";
+import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceImportDeepStarWithNameInput = (codegenComment: string) => {
@@ -11,9 +12,7 @@ export const getServiceImportDeepStarWithNameInput = (codegenComment: string) =>
     )}";\n`;
   }
   content += `\n`;
-  content += getV2ClientsNewExpressionCode(
-    CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
-  );
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
 
   return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportDeepStarWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepStarWithNameOutput.ts
@@ -1,5 +1,5 @@
 import { CLIENT_NAMES_MAP, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
-import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
+import { CLIENTS_TO_TEST } from "./config";
 import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 
@@ -9,7 +9,7 @@ export const getServiceImportDeepStarWithNameOutput = (codegenComment: string) =
   for (const v2ClientName of CLIENTS_TO_TEST) {
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
-    const v3ClientLocalName = `${v2ClientName}${LOCAL_NAME_SUFFIX}`;
+    const v3ClientLocalName = getClientNameWithLocalSuffix(v2ClientName);
     const v3ImportSpecifier =
       v3ClientName === v3ClientLocalName ? v3ClientName : `${v3ClientName} as ${v3ClientLocalName}`;
     content += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;

--- a/scripts/generateNewClientTests/getServiceImportWithNameInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportWithNameInput.ts
@@ -1,4 +1,5 @@
 import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
+import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceImportWithNameInput = (codegenComment: string) => {
@@ -8,9 +9,7 @@ export const getServiceImportWithNameInput = (codegenComment: string) => {
     (clientName) => `  ${clientName} as ${clientName}${LOCAL_NAME_SUFFIX}`
   ).join(`,\n`)}\n} from "aws-sdk";\n`;
   content += `\n`;
-  content += getV2ClientsNewExpressionCode(
-    CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
-  );
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
 
   return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportWithNameInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportWithNameInput.ts
@@ -1,4 +1,4 @@
-import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
+import { CLIENTS_TO_TEST } from "./config";
 import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
@@ -6,7 +6,7 @@ export const getServiceImportWithNameInput = (codegenComment: string) => {
   let content = `${codegenComment}\n`;
 
   content += `import { \n${CLIENTS_TO_TEST.map(
-    (clientName) => `  ${clientName} as ${clientName}${LOCAL_NAME_SUFFIX}`
+    (clientName) => `  ${clientName} as ${getClientNameWithLocalSuffix(clientName)}`
   ).join(`,\n`)}\n} from "aws-sdk";\n`;
   content += `\n`;
   content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));

--- a/scripts/generateNewClientTests/getServiceImportWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportWithNameOutput.ts
@@ -1,5 +1,5 @@
 import { CLIENT_NAMES_MAP, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
-import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
+import { CLIENTS_TO_TEST } from "./config";
 import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
 import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
@@ -10,7 +10,7 @@ export const getServiceImportWithNameOutput = (codegenComment: string) => {
   for (const v2ClientName of getClientNamesSortedByPackageName(CLIENTS_TO_TEST)) {
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
-    const v3ClientLocalName = `${v2ClientName}${LOCAL_NAME_SUFFIX}`;
+    const v3ClientLocalName = getClientNameWithLocalSuffix(v2ClientName);
     const v3ImportSpecifier =
       v3ClientName === v3ClientLocalName ? v3ClientName : `${v3ClientName} as ${v3ClientLocalName}`;
     content += `import { ${v3ImportSpecifier} } from "${v3ClientPackageName}";\n`;

--- a/scripts/generateNewClientTests/getServiceRequireWithNameInput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireWithNameInput.ts
@@ -1,4 +1,4 @@
-import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
+import { CLIENTS_TO_TEST } from "./config";
 import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
@@ -6,7 +6,7 @@ export const getServiceRequireWithNameInput = (codegenComment: string) => {
   let content = `${codegenComment}\n`;
 
   content += `const { \n${CLIENTS_TO_TEST.map(
-    (clientName) => `  ${clientName}: ${clientName}${LOCAL_NAME_SUFFIX}`
+    (clientName) => `  ${clientName}: ${getClientNameWithLocalSuffix(clientName)}`
   ).join(`,\n`)}\n} = require("aws-sdk");\n`;
   content += `\n`;
   content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));

--- a/scripts/generateNewClientTests/getServiceRequireWithNameInput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireWithNameInput.ts
@@ -1,4 +1,5 @@
 import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
+import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV2ClientsNewExpressionCode } from "./getV2ClientsNewExpressionCode";
 
 export const getServiceRequireWithNameInput = (codegenComment: string) => {
@@ -8,9 +9,7 @@ export const getServiceRequireWithNameInput = (codegenComment: string) => {
     (clientName) => `  ${clientName}: ${clientName}${LOCAL_NAME_SUFFIX}`
   ).join(`,\n`)}\n} = require("aws-sdk");\n`;
   content += `\n`;
-  content += getV2ClientsNewExpressionCode(
-    CLIENTS_TO_TEST.map((clientName) => `${clientName}${LOCAL_NAME_SUFFIX}`)
-  );
+  content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
 
   return content;
 };

--- a/scripts/generateNewClientTests/getServiceRequireWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireWithNameOutput.ts
@@ -1,5 +1,5 @@
 import { CLIENT_NAMES_MAP, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
-import { CLIENTS_TO_TEST, LOCAL_NAME_SUFFIX } from "./config";
+import { CLIENTS_TO_TEST } from "./config";
 import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
 import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
@@ -12,7 +12,7 @@ export const getServiceRequireWithNameOutput = (codegenComment: string) => {
   for (const v2ClientName of sortedClientNames) {
     const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
-    const v3ClientLocalName = `${v2ClientName}${LOCAL_NAME_SUFFIX}`;
+    const v3ClientLocalName = getClientNameWithLocalSuffix(v2ClientName);
     const v3RequireKeyValuePair =
       v3ClientName === v3ClientLocalName ? v3ClientName : `${v3ClientName}: ${v3ClientLocalName}`;
     content +=


### PR DESCRIPTION
### Issue

Call utility added in https://github.com/awslabs/aws-sdk-js-codemod/pull/417

### Description

Call getClientNameWithLocalSuffix from scripts

### Testing

Verified that new-client tests are not updated.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
