### PR TITLE
Rename getV3ImportEqualsCode to getV3PackageImportEqualsCode

### DIFF
--- a/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
@@ -1,12 +1,12 @@
 import { CLIENTS_TO_TEST } from "./config";
 import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
-import { getV3ImportEqualsCode } from "./getV3ImportEqualsCode";
+import { getV3PackageImportEqualsCode } from "./getV3PackageImportEqualsCode";
 
 export const getGlobalImportEqualsOutput = (codegenComment: string) => {
   let content = `${codegenComment};\n`;
 
-  content += getV3ImportEqualsCode(getClientNamesSortedByPackageName(CLIENTS_TO_TEST));
+  content += getV3PackageImportEqualsCode(getClientNamesSortedByPackageName(CLIENTS_TO_TEST));
   content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
   return content;

--- a/scripts/generateNewClientTests/getServiceImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportEqualsOutput.ts
@@ -1,11 +1,11 @@
 import { CLIENTS_TO_TEST } from "./config";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
-import { getV3ImportEqualsCode } from "./getV3ImportEqualsCode";
+import { getV3PackageImportEqualsCode } from "./getV3PackageImportEqualsCode";
 
 export const getServiceImportEqualsOutput = (codegenComment: string) => {
   let content = `${codegenComment};\n`;
 
-  content += getV3ImportEqualsCode(CLIENTS_TO_TEST);
+  content += getV3PackageImportEqualsCode(CLIENTS_TO_TEST);
   content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
   return content;

--- a/scripts/generateNewClientTests/getV3PackageImportEqualsCode.ts
+++ b/scripts/generateNewClientTests/getV3PackageImportEqualsCode.ts
@@ -5,7 +5,7 @@ import {
 } from "../../src/transforms/v2-to-v3/config";
 import { getV3DefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
 
-export const getV3ImportEqualsCode = (clientsToTest: typeof CLIENT_NAMES) => {
+export const getV3PackageImportEqualsCode = (clientsToTest: typeof CLIENT_NAMES) => {
   let content = ``;
 
   for (const v2ClientName of clientsToTest) {


### PR DESCRIPTION
### Issue

N/A

### Description

Rename getV3ImportEqualsCode to getV3PackageImportEqualsCode to align with other `getV3Package*` Utilities

### Testing

Verified that new-client tests are not updated.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
