### PR TITLE
Import *ImportDeep from *ImportDeepStar

### DIFF
--- a/scripts/generateNewClientTests/getServiceImportDeepStarWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepStarWithNameOutput.ts
@@ -1,14 +1,3 @@
-import { CLIENTS_TO_TEST } from "./config";
-import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
-import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
-import { getV3PackageImportsCode } from "./getV3PackageImportsCode";
+import { getServiceImportDeepWithNameOutput } from "./getServiceImportDeepWithNameOutput";
 
-export const getServiceImportDeepStarWithNameOutput = (codegenComment: string) => {
-  let content = `${codegenComment}\n`;
-
-  content += getV3PackageImportsCode(CLIENTS_TO_TEST, { useLocalSuffix: true });
-  content += `\n`;
-  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
-
-  return content;
-};
+export const getServiceImportDeepStarWithNameOutput = getServiceImportDeepWithNameOutput;

--- a/scripts/generateNewClientTests/getServiceImportDeepWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportDeepWithNameOutput.ts
@@ -1,3 +1,14 @@
-import { getServiceImportDeepStarWithNameOutput } from "./getServiceImportDeepStarWithNameOutput";
+import { CLIENTS_TO_TEST } from "./config";
+import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
+import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
+import { getV3PackageImportsCode } from "./getV3PackageImportsCode";
 
-export const getServiceImportDeepWithNameOutput = getServiceImportDeepStarWithNameOutput;
+export const getServiceImportDeepWithNameOutput = (codegenComment: string) => {
+  let content = `${codegenComment}\n`;
+
+  content += getV3PackageImportsCode(CLIENTS_TO_TEST, { useLocalSuffix: true });
+  content += `\n`;
+  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
+
+  return content;
+};


### PR DESCRIPTION
### Issue

Noticed during https://github.com/awslabs/aws-sdk-js-codemod/pull/428

### Description

Import `*ImportDeep` from `*ImportDeepStar` as standardization

### Testing

Verified that new-client tests weren't updated

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
