### PR TITLE
Support transformation of waiter API on a client class member

### DIFF
--- a/.changeset/unlucky-snails-grab.md
+++ b/.changeset/unlucky-snails-grab.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Support transformation of waiter API on a client class member

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/client-class-member.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/client-class-member.input.js
@@ -1,0 +1,12 @@
+import AWS from "aws-sdk";
+
+// Client as class member
+class ClientClassMember {
+  constructor(clientInCtr = new AWS.S3()) {
+    this.clientInClass = clientInCtr;
+  }
+
+  async listTables() {
+    return this.clientInClass.waitFor("bucketExists", { Bucket }).promise();
+  }
+}

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/client-class-member.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/client-class-member.input.ts
@@ -2,7 +2,9 @@ import AWS from "aws-sdk";
 
 // Client as class member
 class ClientClassMember {
-  constructor(clientInCtr = new AWS.S3()) {
+  private clientInClass: AWS.S3;
+
+  constructor(clientInCtr: AWS.S3) {
     this.clientInClass = clientInCtr;
   }
 

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/client-class-member.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/client-class-member.output.js
@@ -1,0 +1,15 @@
+import { S3, waitUntilBucketExists } from "@aws-sdk/client-s3";
+
+// Client as class member
+class ClientClassMember {
+  constructor(clientInCtr = new S3()) {
+    this.clientInClass = clientInCtr;
+  }
+
+  async listTables() {
+    return waitUntilBucketExists({
+      client: this.clientInClass,
+      maxWaitTime: 200
+    }, { Bucket });
+  }
+}

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/client-class-member.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/client-class-member.output.ts
@@ -2,7 +2,9 @@ import { S3, waitUntilBucketExists } from "@aws-sdk/client-s3";
 
 // Client as class member
 class ClientClassMember {
-  constructor(clientInCtr = new S3()) {
+  private clientInClass: S3;
+
+  constructor(clientInCtr: S3) {
     this.clientInClass = clientInCtr;
   }
 

--- a/src/transforms/v2-to-v3/apis/getV2ClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/apis/getV2ClientIdentifiers.ts
@@ -2,6 +2,7 @@ import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 import { getV2ClientIdNamesFromNewExpr } from "./getV2ClientIdNamesFromNewExpr";
 import { getV2ClientIdNamesFromTSTypeRef } from "./getV2ClientIdNamesFromTSTypeRef";
+import { getV2ClientIdThisExpressions, ThisMemberExpression } from "./getV2ClientIdThisExpressions";
 
 export interface GetV2ClientIdentifiersOptions {
   v2ClientName: string;
@@ -13,9 +14,16 @@ export const getV2ClientIdentifiers = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: GetV2ClientIdentifiersOptions
-): Identifier[] => {
+): (Identifier | ThisMemberExpression)[] => {
   const namesFromNewExpr = getV2ClientIdNamesFromNewExpr(j, source, options);
   const namesFromTSTypeRef = getV2ClientIdNamesFromTSTypeRef(j, source, options);
   const clientIdNames = [...new Set([...namesFromNewExpr, ...namesFromTSTypeRef])];
-  return clientIdNames.map((clientidName) => ({ type: "Identifier", name: clientidName }));
+
+  const v2ClientIdentifiers: Identifier[] = clientIdNames.map((clientidName) => ({
+    type: "Identifier",
+    name: clientidName,
+  }));
+  const v2ClientIdThisExpressions = getV2ClientIdThisExpressions(j, source, v2ClientIdentifiers);
+
+  return [...v2ClientIdentifiers, ...v2ClientIdThisExpressions];
 };

--- a/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
@@ -1,7 +1,6 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
-import { getV2ClientIdThisExpressions } from "./getV2ClientIdThisExpressions";
 import { removePromiseForCallExpression } from "./removePromiseForCallExpression";
 
 export interface RemovePromiseCallsOptions {
@@ -17,9 +16,8 @@ export const removePromiseCalls = (
   options: RemovePromiseCallsOptions
 ): void => {
   const v2ClientIdentifiers = getV2ClientIdentifiers(j, source, options);
-  const v2ClientIdThisExpressions = getV2ClientIdThisExpressions(j, source, v2ClientIdentifiers);
 
-  for (const v2ClientId of [...v2ClientIdentifiers, ...v2ClientIdThisExpressions]) {
+  for (const v2ClientId of v2ClientIdentifiers) {
     // Remove .promise() from client API calls.
     source
       .find(j.CallExpression, {


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/awslabs/aws-sdk-js-codemod/pull/52

### Description

Support transformation of waiter API on a client class member

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
