### PR TITLE
Add type V2ClientIdentifier

### DIFF
--- a/src/transforms/v2-to-v3/apis/getV2ClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/apis/getV2ClientIdentifiers.ts
@@ -10,11 +10,13 @@ export interface GetV2ClientIdentifiersOptions {
   v2GlobalName?: string;
 }
 
+export type V2ClientIdentifier = Identifier | ThisMemberExpression;
+
 export const getV2ClientIdentifiers = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: GetV2ClientIdentifiersOptions
-): (Identifier | ThisMemberExpression)[] => {
+): V2ClientIdentifier[] => {
   const namesFromNewExpr = getV2ClientIdNamesFromNewExpr(j, source, options);
   const namesFromTSTypeRef = getV2ClientIdNamesFromTSTypeRef(j, source, options);
   const clientIdNames = [...new Set([...namesFromNewExpr, ...namesFromTSTypeRef])];


### PR DESCRIPTION
### Issue

Useful in PRs like https://github.com/awslabs/aws-sdk-js-codemod/pull/434

### Description

Add type V2ClientIdentifier

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
