### PR TITLE
Add transformation for s3 ManagedUploadOptions in an identifier

### DIFF
--- a/.changeset/moody-experts-lie.md
+++ b/.changeset/moody-experts-lie.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Add transformation for s3 ManagedUploadOptions in an identifier

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/options-identifier.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/options-identifier.input.js
@@ -1,0 +1,18 @@
+import AWS from "aws-sdk";
+
+const client = new AWS.S3({ region: "REGION" });
+
+const uploadParams = {
+  Body: "BODY",
+  Bucket: "Bucket",
+  ContentType: "ContentType",
+  Key: "Key",
+};
+const uploadOptions = {
+  partSize: 1024 * 1024 * 5,
+  queueSize: 1,
+  leavePartsOnError: true,
+  tags: [],
+};
+
+await client.upload(uploadParams, uploadOptions).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/options-identifier.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/options-identifier.output.js
@@ -1,0 +1,23 @@
+import { Upload } from "@aws-sdk/lib-storage";
+import { S3 } from "@aws-sdk/client-s3";
+
+const client = new S3({ region: "REGION" });
+
+const uploadParams = {
+  Body: "BODY",
+  Bucket: "Bucket",
+  ContentType: "ContentType",
+  Key: "Key",
+};
+const uploadOptions = {
+  partSize: 1024 * 1024 * 5,
+  queueSize: 1,
+  leavePartsOnError: true,
+  tags: [],
+};
+
+await new Upload({
+  client,
+  params: uploadParams,
+  ...uploadOptions
+}).done();

--- a/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
@@ -50,8 +50,15 @@ export const replaceS3UploadApi = (
         }
 
         const options = callExpression.node.arguments[1];
-        if (options && options.type === "ObjectExpression") {
-          properties.push(...options.properties);
+        if (options) {
+          switch (options.type) {
+            case "ObjectExpression":
+              properties.push(...options.properties);
+              break;
+            case "Identifier":
+              properties.push(j.spreadElement(options));
+              break;
+          }
         }
 
         return j.newExpression(j.identifier("Upload"), [j.objectExpression(properties)]);


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/awslabs/aws-sdk-js-codemod/pull/439
Similar to identifier test for params in https://github.com/awslabs/aws-sdk-js-codemod/pull/442

### Description

Add transformation for s3 ManagedUploadOptions in an identifier

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
