### PR TITLE
Do not apply babeljs to the transform file

### DIFF
--- a/.changeset/few-lemons-carry.md
+++ b/.changeset/few-lemons-carry.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Do not apply babeljs to the transform file

--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -71,7 +71,7 @@ export const getJsCodeshiftParser = () =>
     babel: {
       display_index: 0,
       flag: true,
-      default: true,
+      default: false,
       help: "apply babeljs to the transform file",
     },
     extensions: {


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/347

### Description

Do not apply babeljs to the transform file

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
