### PR TITLE
Add comments for unsupported S3 ManagedUpload with callback

### DIFF
--- a/.changeset/big-dogs-appear.md
+++ b/.changeset/big-dogs-appear.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Add comments for unsupported S3 ManagedUpload with callback

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback-arrow-fn.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback-arrow-fn.input.js
@@ -1,0 +1,14 @@
+import AWS from "aws-sdk";
+
+const client = new AWS.S3({ region: "REGION" });
+const uploadParams = {
+  Body: "BODY",
+  Bucket: "Bucket",
+  ContentType: "ContentType",
+  Key: "Key",
+};
+
+client.upload(uploadParams, (err, data) => {
+  if (err) console.log(err, err.stack); // an error occurred
+  else console.log(data); // successful response
+});

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback-arrow-fn.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback-arrow-fn.output.js
@@ -1,0 +1,16 @@
+import AWS from "aws-sdk";
+
+const client = new AWS.S3({ region: "REGION" });
+const uploadParams = {
+  Body: "BODY",
+  Bucket: "Bucket",
+  ContentType: "ContentType",
+  Key: "Key",
+};
+
+// S3 ManagedUpload with callbacks are not supported in AWS SDK for JavaScript (v3).
+// Please convert to `await client.upload(params, options).promise()`, and re-run aws-sdk-js-codemod.
+client.upload(uploadParams, (err, data) => {
+  if (err) console.log(err, err.stack); // an error occurred
+  else console.log(data); // successful response
+});

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback.input.js
@@ -1,0 +1,14 @@
+import AWS from "aws-sdk";
+
+const client = new AWS.S3({ region: "REGION" });
+const uploadParams = {
+  Body: "BODY",
+  Bucket: "Bucket",
+  ContentType: "ContentType",
+  Key: "Key",
+};
+
+client.upload(uploadParams, function (err, data) {
+  if (err) console.log(err, err.stack); // an error occurred
+  else console.log(data); // successful response
+});

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/callback.output.js
@@ -1,0 +1,16 @@
+import AWS from "aws-sdk";
+
+const client = new AWS.S3({ region: "REGION" });
+const uploadParams = {
+  Body: "BODY",
+  Bucket: "Bucket",
+  ContentType: "ContentType",
+  Key: "Key",
+};
+
+// S3 ManagedUpload with callbacks are not supported in AWS SDK for JavaScript (v3).
+// Please convert to `await client.upload(params, options).promise()`, and re-run aws-sdk-js-codemod.
+client.upload(uploadParams, function (err, data) {
+  if (err) console.log(err, err.stack); // an error occurred
+  else console.log(data); // successful response
+});

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -3,6 +3,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 import { FUNCTION_TYPE_LIST } from "../config";
 import { getClientWaiterStates } from "./getClientWaiterStates";
 import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
+import { getV2ClientS3UploadCallExpression } from "./getV2ClientS3UploadCallExpression";
 import { getV2ClientWaiterCallExpression } from "./getV2ClientWaiterCallExpression";
 
 export interface CommentsForUnsupportedAPIsOptions {
@@ -37,6 +38,31 @@ export const addNotSupportedComments = (
             comments.push(
               j.commentLine(
                 " Please convert to `await client.waitFor(state, params).promise()`, and re-run aws-sdk-js-codemod."
+              )
+            );
+            callExpression.node.comments = comments;
+          }
+        });
+    }
+  }
+
+  if (options.v2ClientName === "S3") {
+    for (const v2ClientId of v2ClientIdentifiers) {
+      source
+        .find(j.CallExpression, getV2ClientS3UploadCallExpression(v2ClientId))
+        .forEach((callExpression) => {
+          const args = callExpression.node.arguments;
+
+          if (FUNCTION_TYPE_LIST.includes(args[args.length - 1].type)) {
+            const comments = callExpression.node.comments || [];
+            comments.push(
+              j.commentLine(
+                " S3 ManagedUpload with callbacks are not supported in AWS SDK for JavaScript (v3)."
+              )
+            );
+            comments.push(
+              j.commentLine(
+                " Please convert to `await client.upload(params, options).promise()`, and re-run aws-sdk-js-codemod."
               )
             );
             callExpression.node.comments = comments;

--- a/src/transforms/v2-to-v3/apis/getV2ClientS3UploadCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getV2ClientS3UploadCallExpression.ts
@@ -1,0 +1,15 @@
+import { CallExpression } from "jscodeshift";
+
+import { V2ClientIdentifier } from "./getV2ClientIdentifiers";
+
+export const getV2ClientS3UploadCallExpression = (
+  v2ClientId: V2ClientIdentifier
+  // @ts-expect-error Property 'arguments' is missing in type
+): CallExpression => ({
+  type: "CallExpression",
+  callee: {
+    type: "MemberExpression",
+    object: v2ClientId,
+    property: { type: "Identifier", name: "upload" },
+  },
+});

--- a/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
@@ -1,6 +1,7 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
+import { getV2ClientS3UploadCallExpression } from "./getV2ClientS3UploadCallExpression";
 
 export interface ReplaceS3UploadApiOptions {
   v2ClientName: string;
@@ -18,14 +19,7 @@ export const replaceS3UploadApi = (
 
   for (const v2ClientId of v2ClientIdentifiers) {
     source
-      .find(j.CallExpression, {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          object: v2ClientId,
-          property: { type: "Identifier", name: "upload" },
-        },
-      })
+      .find(j.CallExpression, getV2ClientS3UploadCallExpression(v2ClientId))
       .replaceWith((callExpression) => {
         const params = callExpression.node.arguments[0];
 


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/446

### Description

Add comments for unsupported S3 ManagedUpload with callback

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
