### PR TITLE
Add check for s3 client name before transforming upload API

### DIFF
--- a/.changeset/brave-pumpkins-beam.md
+++ b/.changeset/brave-pumpkins-beam.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Add check for s3 client name before transforming upload API

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/not-s3-client.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/not-s3-client.input.js
@@ -1,0 +1,5 @@
+import AWS from "aws-sdk";
+
+const client = new AWS.DynamoDB({ region: "REGION" });
+// Used for testing. DynamoDB does not have upload API.
+await client.upload({}).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/not-s3-client.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/not-s3-client.output.js
@@ -1,0 +1,5 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+
+const client = new DynamoDB({ region: "REGION" });
+// Used for testing. DynamoDB does not have upload API.
+await client.upload({});

--- a/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
@@ -14,6 +14,8 @@ export const replaceS3UploadApi = (
   source: Collection<unknown>,
   options: ReplaceS3UploadApiOptions
 ): void => {
+  if (options.v2ClientName !== "S3") return;
+
   const v2ClientIdentifiers = getV2ClientIdentifiers(j, source, options);
 
   for (const v2ClientId of v2ClientIdentifiers) {


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/448

### Description

Add check for s3 client name before transforming upload API

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
