### PR TITLE
Add initial support for DynamoDB DocumentClient transformation

### DIFF
--- a/.changeset/fresh-pears-rescue.md
+++ b/.changeset/fresh-pears-rescue.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": minor
+---
+
+Add initial support for DynamoDB DocumentClient transformation

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import-equals.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import-equals.input.ts
@@ -1,0 +1,4 @@
+import AWS = require("aws-sdk");
+
+const documentClient = new AWS.DynamoDB.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import-equals.output.ts
@@ -1,0 +1,14 @@
+import AWS_lib_dynamodb = require("@aws-sdk/lib-dynamodb");
+
+const {
+  DynamoDBDocument
+} = AWS_lib_dynamodb;
+
+import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
+
+const {
+  DynamoDB
+} = AWS_DynamoDB;
+
+const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import.input.js
@@ -1,0 +1,4 @@
+import AWS from "aws-sdk";
+
+const documentClient = new AWS.DynamoDB.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import.output.js
@@ -1,5 +1,5 @@
-import { DynamoDB } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
 const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
 const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import.output.js
@@ -1,0 +1,5 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+
+const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-require.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-require.input.js
@@ -1,0 +1,4 @@
+const AWS = require("aws-sdk");
+
+const documentClient = new AWS.DynamoDB.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-require.output.js
@@ -1,0 +1,9 @@
+const {
+        DynamoDBDocument
+      } = require("@aws-sdk/lib-dynamodb"),
+      {
+        DynamoDB
+      } = require("@aws-sdk/client-dynamodb");
+
+const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-with-name.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-with-name.input.js
@@ -1,0 +1,4 @@
+import DynamoDBClient from "aws-sdk/clients/dynamodb";
+
+const documentClient = new DynamoDBClient.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-with-name.output.js
@@ -1,0 +1,5 @@
+import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+import { DynamoDB as DynamoDBClient } from "@aws-sdk/client-dynamodb";
+
+const documentClient = DynamoDBDocument.from(new DynamoDBClient({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep.input.js
@@ -1,0 +1,4 @@
+import DynamoDB from "aws-sdk/clients/dynamodb";
+
+const documentClient = new DynamoDB.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep.output.js
@@ -1,0 +1,5 @@
+import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+
+const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals-with-name.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals-with-name.input.ts
@@ -1,0 +1,4 @@
+import DynamoDBClient = require("aws-sdk/clients/dynamodb");
+
+const documentClient = new DynamoDBClient.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals-with-name.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals-with-name.output.ts
@@ -1,0 +1,14 @@
+import AWS_lib_dynamodb = require("@aws-sdk/lib-dynamodb");
+
+const {
+  DynamoDBDocument
+} = AWS_lib_dynamodb;
+
+import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
+
+const {
+  DynamoDB: DynamoDBClient
+} = AWS_DynamoDB;
+
+const documentClient = DynamoDBDocument.from(new DynamoDBClient({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals.input.ts
@@ -1,0 +1,4 @@
+import DynamoDB = require("aws-sdk/clients/dynamodb");
+
+const documentClient = new DynamoDB.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals.output.ts
@@ -1,0 +1,14 @@
+import AWS_lib_dynamodb = require("@aws-sdk/lib-dynamodb");
+
+const {
+  DynamoDBDocument
+} = AWS_lib_dynamodb;
+
+import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
+
+const {
+  DynamoDB
+} = AWS_DynamoDB;
+
+const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-with-name.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-with-name.input.js
@@ -1,0 +1,4 @@
+import { DynamoDB as DynamoDBClient } from "aws-sdk";
+
+const documentClient = new DynamoDBClient.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-with-name.output.js
@@ -1,0 +1,5 @@
+import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+import { DynamoDB as DynamoDBClient } from "@aws-sdk/client-dynamodb";
+
+const documentClient = DynamoDBDocument.from(new DynamoDBClient({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import.input.js
@@ -1,0 +1,4 @@
+import { DynamoDB } from "aws-sdk";
+
+const documentClient = new DynamoDB.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import.output.js
@@ -1,0 +1,5 @@
+import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+
+const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep-with-name.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep-with-name.input.js
@@ -1,0 +1,4 @@
+const DynamoDBClient = require("aws-sdk/clients/dynamodb");
+
+const documentClient = new DynamoDBClient.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep-with-name.output.js
@@ -1,0 +1,9 @@
+const {
+        DynamoDBDocument
+      } = require("@aws-sdk/lib-dynamodb"),
+      {
+        DynamoDB: DynamoDBClient
+      } = require("@aws-sdk/client-dynamodb");
+
+const documentClient = DynamoDBDocument.from(new DynamoDBClient({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep.input.js
@@ -1,0 +1,4 @@
+const DynamoDB = require("aws-sdk/clients/dynamodb");
+
+const documentClient = new DynamoDB.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep.output.js
@@ -1,0 +1,9 @@
+const {
+        DynamoDBDocument
+      } = require("@aws-sdk/lib-dynamodb"),
+      {
+        DynamoDB
+      } = require("@aws-sdk/client-dynamodb");
+
+const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-with-name.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-with-name.input.js
@@ -1,0 +1,4 @@
+const { DynamoDB: DynamoDBClient } = require("aws-sdk");
+
+const documentClient = new DynamoDBClient.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-with-name.output.js
@@ -1,0 +1,9 @@
+const {
+        DynamoDBDocument
+      } = require("@aws-sdk/lib-dynamodb"),
+      {
+        DynamoDB: DynamoDBClient
+      } = require("@aws-sdk/client-dynamodb");
+
+const documentClient = DynamoDBDocument.from(new DynamoDBClient({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require.input.js
@@ -1,0 +1,4 @@
+const { DynamoDB } = require("aws-sdk");
+
+const documentClient = new DynamoDB.DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require.output.js
@@ -1,0 +1,9 @@
+const {
+        DynamoDBDocument
+      } = require("@aws-sdk/lib-dynamodb"),
+      {
+        DynamoDB
+      } = require("@aws-sdk/client-dynamodb");
+
+const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/apis/getClientIdNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdNamesFromNewExpr.ts
@@ -1,6 +1,7 @@
 import { Collection, Identifier, JSCodeshift, NewExpression } from "jscodeshift";
 
-import { getClientNewExpression } from "../utils";
+import { DYNAMODB } from "../config";
+import { getClientNewExpression, getDocClientNewExpression } from "../utils";
 
 export interface GetClientIdNamesFromNewExprOptions {
   v2ClientName: string;
@@ -47,10 +48,20 @@ export const getClientIdNamesFromNewExpr = (
       namesFromGlobalModule.push(
         ...getNames(j, source, getClientNewExpression({ v2GlobalName, v2ClientName }))
       );
+      if (v2ClientName === DYNAMODB) {
+        namesFromGlobalModule.push(
+          ...getNames(j, source, getDocClientNewExpression({ v2GlobalName }))
+        );
+      }
     }
     namesFromServiceModule.push(
       ...getNames(j, source, getClientNewExpression({ v2ClientLocalName }))
     );
+    if (v2ClientName === DYNAMODB) {
+      namesFromServiceModule.push(
+        ...getNames(j, source, getDocClientNewExpression({ v2ClientLocalName }))
+      );
+    }
   }
 
   return [...new Set([...namesFromGlobalModule, ...namesFromServiceModule])];

--- a/src/transforms/v2-to-v3/client-instances/index.ts
+++ b/src/transforms/v2-to-v3/client-instances/index.ts
@@ -1,1 +1,2 @@
 export * from "./replaceClientCreation";
+export * from "./replaceDocClientCreation";

--- a/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
@@ -1,0 +1,34 @@
+import { Collection, JSCodeshift } from "jscodeshift";
+
+import { DYNAMODB } from "../config";
+import { getDocClientNewExpression } from "../utils";
+
+export interface ReplaceDocClientCreationOptions {
+  v2ClientLocalName: string;
+  v2GlobalName?: string;
+}
+
+export const replaceDocClientCreation = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  { v2ClientLocalName, v2GlobalName }: ReplaceDocClientCreationOptions
+): void => {
+  if (v2GlobalName) {
+    source
+      .find(j.NewExpression, getDocClientNewExpression({ v2GlobalName }))
+      .replaceWith((v2DocClientNewExpression) =>
+        j.callExpression(
+          j.memberExpression(j.identifier("DynamoDBDocument"), j.identifier("from")),
+          [j.newExpression(j.identifier(DYNAMODB), v2DocClientNewExpression.node.arguments)]
+        )
+      );
+  }
+
+  source
+    .find(j.NewExpression, getDocClientNewExpression({ v2ClientLocalName }))
+    .replaceWith((v2DocClientNewExpression) =>
+      j.callExpression(j.memberExpression(j.identifier("DynamoDBDocument"), j.identifier("from")), [
+        j.newExpression(j.identifier(v2ClientLocalName), v2DocClientNewExpression.node.arguments),
+      ])
+    );
+};

--- a/src/transforms/v2-to-v3/client-names/getNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/client-names/getNamesFromNewExpr.ts
@@ -1,15 +1,26 @@
 import { Collection, Identifier, JSCodeshift, MemberExpression } from "jscodeshift";
 
-import { getClientNewExpression } from "../utils";
+import { getClientNewExpression, getV2DocClientNewExpression } from "../utils";
 
 export const getNamesFromNewExpr = (
   j: JSCodeshift,
   source: Collection<unknown>,
   v2GlobalName: string
-): string[] =>
-  source
+): string[] => [
+  ...source
     .find(j.NewExpression, getClientNewExpression({ v2GlobalName }))
     .nodes()
     .map(
       (newExpression) => ((newExpression.callee as MemberExpression).property as Identifier).name
-    );
+    ),
+  ...source
+    .find(j.NewExpression, getV2DocClientNewExpression({ v2GlobalName }))
+    .nodes()
+    .map(
+      (newExpression) =>
+        (
+          ((newExpression.callee as MemberExpression).object as MemberExpression)
+            .property as Identifier
+        ).name
+    ),
+];

--- a/src/transforms/v2-to-v3/client-names/getNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/client-names/getNamesFromNewExpr.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, JSCodeshift, MemberExpression } from "jscodeshift";
 
-import { getClientNewExpression, getV2DocClientNewExpression } from "../utils";
+import { getClientNewExpression, getDocClientNewExpression } from "../utils";
 
 export const getNamesFromNewExpr = (
   j: JSCodeshift,
@@ -14,7 +14,7 @@ export const getNamesFromNewExpr = (
       (newExpression) => ((newExpression.callee as MemberExpression).property as Identifier).name
     ),
   ...source
-    .find(j.NewExpression, getV2DocClientNewExpression({ v2GlobalName }))
+    .find(j.NewExpression, getDocClientNewExpression({ v2GlobalName }))
     .nodes()
     .map(
       (newExpression) =>

--- a/src/transforms/v2-to-v3/config/constants.ts
+++ b/src/transforms/v2-to-v3/config/constants.ts
@@ -1,5 +1,9 @@
 export const PACKAGE_NAME = "aws-sdk";
 
+export const DYNAMODB = "DynamoDB";
+export const DOCUMENT_CLIENT = "DocumentClient";
+export const DYNAMODB_DOCUMENT_CLIENT = [DYNAMODB, DOCUMENT_CLIENT].join(".");
+
 export const V2_CLIENT_INPUT_SUFFIX_LIST = ["Input", "Request"];
 export const V2_CLIENT_OUTPUT_SUFFIX_LIST = ["Output", "Response"];
 

--- a/src/transforms/v2-to-v3/modules/addClientImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientImportEquals.ts
@@ -5,6 +5,7 @@ import { getV3ClientTypesCount } from "../ts-type";
 import { addClientDefaultImportEquals } from "./addClientDefaultImportEquals";
 import { addClientNamedImportEquals } from "./addClientNamedImportEquals";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
+import { getDocClientNewExpressionCount } from "./getDocClientNewExpressionCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
 import { ClientModulesOptions } from "./types";
 
@@ -43,6 +44,15 @@ export const addClientImportEquals = (
       ...options,
       keyName: "Upload",
       v3ClientPackageName: "@aws-sdk/lib-storage",
+    });
+  }
+
+  const docClientNewExpressionCount = getDocClientNewExpressionCount(j, source, options);
+  if (docClientNewExpressionCount > 0) {
+    addClientNamedImportEquals(j, source, {
+      ...options,
+      keyName: "DynamoDBDocument",
+      v3ClientPackageName: "@aws-sdk/lib-dynamodb",
     });
   }
 };

--- a/src/transforms/v2-to-v3/modules/addClientImports.ts
+++ b/src/transforms/v2-to-v3/modules/addClientImports.ts
@@ -5,6 +5,7 @@ import { getV3ClientTypesCount } from "../ts-type";
 import { addClientDefaultImport } from "./addClientDefaultImport";
 import { addClientNamedImport } from "./addClientNamedImport";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
+import { getDocClientNewExpressionCount } from "./getDocClientNewExpressionCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
 import { ClientModulesOptions } from "./types";
 
@@ -44,6 +45,15 @@ export const addClientImports = (
       ...options,
       importedName: "Upload",
       v3ClientPackageName: "@aws-sdk/lib-storage",
+    });
+  }
+
+  const docClientNewExpressionCount = getDocClientNewExpressionCount(j, source, options);
+  if (docClientNewExpressionCount > 0) {
+    addClientNamedImport(j, source, {
+      ...options,
+      importedName: "DynamoDBDocument",
+      v3ClientPackageName: "@aws-sdk/lib-dynamodb",
     });
   }
 };

--- a/src/transforms/v2-to-v3/modules/addClientRequires.ts
+++ b/src/transforms/v2-to-v3/modules/addClientRequires.ts
@@ -5,6 +5,7 @@ import { getV3ClientTypesCount } from "../ts-type";
 import { addClientDefaultRequire } from "./addClientDefaultRequire";
 import { addClientNamedRequire } from "./addClientNamedRequire";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
+import { getDocClientNewExpressionCount } from "./getDocClientNewExpressionCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
 import { ClientModulesOptions } from "./types";
 
@@ -43,6 +44,15 @@ export const addClientRequires = (
       ...options,
       keyName: "Upload",
       v3ClientPackageName: "@aws-sdk/lib-storage",
+    });
+  }
+
+  const docClientNewExpressionCount = getDocClientNewExpressionCount(j, source, options);
+  if (docClientNewExpressionCount > 0) {
+    addClientNamedRequire(j, source, {
+      ...options,
+      keyName: "DynamoDBDocument",
+      v3ClientPackageName: "@aws-sdk/lib-dynamodb",
     });
   }
 };

--- a/src/transforms/v2-to-v3/modules/getDocClientNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getDocClientNewExpressionCount.ts
@@ -1,0 +1,33 @@
+import { Collection, JSCodeshift } from "jscodeshift";
+
+import { DYNAMODB } from "../config";
+import { getDocClientNewExpression } from "../utils";
+import { ClientModulesOptions } from "./types";
+
+export const getDocClientNewExpressionCount = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  { v2ClientName, v2ClientLocalName, v2GlobalName }: ClientModulesOptions
+): number => {
+  if (v2ClientName !== DYNAMODB) {
+    return 0;
+  }
+
+  let newExpressionCount = 0;
+
+  if (v2GlobalName) {
+    const newExpressionsFromGlobalNameDocClient = source.find(
+      j.NewExpression,
+      getDocClientNewExpression({ v2GlobalName })
+    );
+    newExpressionCount += newExpressionsFromGlobalNameDocClient.length;
+  }
+
+  const newExpressionsFromClientLocalNameDocClient = source.find(
+    j.NewExpression,
+    getDocClientNewExpression({ v2ClientLocalName })
+  );
+  newExpressionCount += newExpressionsFromClientLocalNameDocClient.length;
+
+  return newExpressionCount;
+};

--- a/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getClientNewExpression } from "../utils";
+import { DYNAMODB } from "../config";
+import { getClientNewExpression, getV2DocClientNewExpression } from "../utils";
 import { ClientModulesOptions } from "./types";
 
 export const getNewExpressionCount = (
@@ -16,6 +17,14 @@ export const getNewExpressionCount = (
       getClientNewExpression({ v2ClientName, v2GlobalName })
     );
     newExpressionCount += newExpressionsFromGlobalName.length;
+
+    if (v2ClientName === DYNAMODB) {
+      const newExpressionsFromGlobalNameDocClient = source.find(
+        j.NewExpression,
+        getV2DocClientNewExpression({ v2GlobalName })
+      );
+      newExpressionCount += newExpressionsFromGlobalNameDocClient.length;
+    }
   }
 
   const newExpressionsFromClientLocalName = source.find(

--- a/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
@@ -33,5 +33,13 @@ export const getNewExpressionCount = (
   );
   newExpressionCount += newExpressionsFromClientLocalName.length;
 
+  if (v2ClientName === DYNAMODB) {
+    const newExpressionsFromClientLocalNameDocClient = source.find(
+      j.NewExpression,
+      getV2DocClientNewExpression({ v2ClientLocalName })
+    );
+    newExpressionCount += newExpressionsFromClientLocalNameDocClient.length;
+  }
+
   return newExpressionCount;
 };

--- a/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
@@ -1,14 +1,15 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { DYNAMODB } from "../config";
-import { getClientNewExpression, getDocClientNewExpression } from "../utils";
+import { getClientNewExpression } from "../utils";
+import { getDocClientNewExpressionCount } from "./getDocClientNewExpressionCount";
 import { ClientModulesOptions } from "./types";
 
 export const getNewExpressionCount = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientName, v2ClientLocalName, v2GlobalName }: ClientModulesOptions
+  options: ClientModulesOptions
 ): number => {
+  const { v2ClientName, v2ClientLocalName, v2GlobalName } = options;
   let newExpressionCount = 0;
 
   if (v2GlobalName) {
@@ -17,14 +18,6 @@ export const getNewExpressionCount = (
       getClientNewExpression({ v2ClientName, v2GlobalName })
     );
     newExpressionCount += newExpressionsFromGlobalName.length;
-
-    if (v2ClientName === DYNAMODB) {
-      const newExpressionsFromGlobalNameDocClient = source.find(
-        j.NewExpression,
-        getDocClientNewExpression({ v2GlobalName })
-      );
-      newExpressionCount += newExpressionsFromGlobalNameDocClient.length;
-    }
   }
 
   const newExpressionsFromClientLocalName = source.find(
@@ -33,13 +26,7 @@ export const getNewExpressionCount = (
   );
   newExpressionCount += newExpressionsFromClientLocalName.length;
 
-  if (v2ClientName === DYNAMODB) {
-    const newExpressionsFromClientLocalNameDocClient = source.find(
-      j.NewExpression,
-      getDocClientNewExpression({ v2ClientLocalName })
-    );
-    newExpressionCount += newExpressionsFromClientLocalNameDocClient.length;
-  }
+  newExpressionCount += getDocClientNewExpressionCount(j, source, options);
 
   return newExpressionCount;
 };

--- a/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { DYNAMODB } from "../config";
-import { getClientNewExpression, getV2DocClientNewExpression } from "../utils";
+import { getClientNewExpression, getDocClientNewExpression } from "../utils";
 import { ClientModulesOptions } from "./types";
 
 export const getNewExpressionCount = (
@@ -21,7 +21,7 @@ export const getNewExpressionCount = (
     if (v2ClientName === DYNAMODB) {
       const newExpressionsFromGlobalNameDocClient = source.find(
         j.NewExpression,
-        getV2DocClientNewExpression({ v2GlobalName })
+        getDocClientNewExpression({ v2GlobalName })
       );
       newExpressionCount += newExpressionsFromGlobalNameDocClient.length;
     }
@@ -36,7 +36,7 @@ export const getNewExpressionCount = (
   if (v2ClientName === DYNAMODB) {
     const newExpressionsFromClientLocalNameDocClient = source.find(
       j.NewExpression,
-      getV2DocClientNewExpression({ v2ClientLocalName })
+      getDocClientNewExpression({ v2ClientLocalName })
     );
     newExpressionCount += newExpressionsFromClientLocalNameDocClient.length;
   }

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -2,12 +2,13 @@ import { API, FileInfo } from "jscodeshift";
 
 import { addNotSupportedComments, removePromiseCalls, replaceWaiterApi } from "./apis";
 import { replaceS3UploadApi } from "./apis/replaceS3UploadApi";
-import { replaceClientCreation } from "./client-instances";
+import { replaceClientCreation, replaceDocClientCreation } from "./client-instances";
 import {
   getClientMetadataRecord,
   getClientNamesFromGlobal,
   getClientNamesRecord,
 } from "./client-names";
+import { DYNAMODB } from "./config";
 import {
   addClientModules,
   getGlobalNameFromModule,
@@ -62,6 +63,10 @@ const transformer = async (file: FileInfo, api: API) => {
 
     if (v2GlobalName) {
       replaceClientCreation(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
+    }
+
+    if (v2ClientName === DYNAMODB) {
+      replaceDocClientCreation(j, source, { v2ClientLocalName, v2GlobalName });
     }
   }
 

--- a/src/transforms/v2-to-v3/utils/getClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/getClientNewExpression.ts
@@ -1,5 +1,7 @@
 import { NewExpression } from "jscodeshift";
 
+import { DOCUMENT_CLIENT, DYNAMODB_DOCUMENT_CLIENT } from "../config";
+
 export interface GetClientNewExpressionOptions {
   v2ClientLocalName?: string;
   v2ClientName?: string;
@@ -24,11 +26,40 @@ export const getClientNewExpression = ({
   }
 
   if (v2GlobalName) {
+    // Hack for AWS.DynamoDB.DocumentClient
+    if (v2ClientName === DYNAMODB_DOCUMENT_CLIENT) {
+      const [DynamoDB, DocumentClient] = v2ClientName.split(".");
+      return {
+        type: "NewExpression",
+        callee: {
+          type: "MemberExpression",
+          object: {
+            type: "MemberExpression",
+            object: { type: "Identifier", name: v2GlobalName },
+            property: { type: "Identifier", name: DynamoDB },
+          },
+          property: { type: "Identifier", name: DocumentClient },
+        },
+      } as NewExpression;
+    }
+
     return {
       type: "NewExpression",
       callee: {
         object: { type: "Identifier", name: v2GlobalName },
         property: { type: "Identifier", ...(v2ClientName && { name: v2ClientName }) },
+      },
+    } as NewExpression;
+  }
+
+  // Hack for DynamoDBLocalName.DocumentClient
+  if (v2ClientLocalName && v2ClientLocalName.endsWith(`.${DOCUMENT_CLIENT}`)) {
+    const [DynamoDBLocalName, DocumentClient] = v2ClientLocalName.split(".");
+    return {
+      type: "NewExpression",
+      callee: {
+        object: { type: "Identifier", name: DynamoDBLocalName },
+        property: { type: "Identifier", name: DocumentClient },
       },
     } as NewExpression;
   }

--- a/src/transforms/v2-to-v3/utils/getClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/getClientNewExpression.ts
@@ -1,8 +1,6 @@
 import { NewExpression } from "jscodeshift";
 
-import { DOCUMENT_CLIENT, DYNAMODB_DOCUMENT_CLIENT } from "../config";
-
-export interface GetClientNewExpressionOptions {
+export interface ClientNewExpressionOptions {
   v2ClientLocalName?: string;
   v2ClientName?: string;
   v2GlobalName?: string;
@@ -12,7 +10,7 @@ export const getClientNewExpression = ({
   v2ClientLocalName,
   v2ClientName,
   v2GlobalName,
-}: GetClientNewExpressionOptions): NewExpression => {
+}: ClientNewExpressionOptions): NewExpression => {
   if (!v2GlobalName && !v2ClientLocalName) {
     throw new Error(
       `One of the following options must be provided: v2ClientLocalName, v2GlobalName`
@@ -26,40 +24,11 @@ export const getClientNewExpression = ({
   }
 
   if (v2GlobalName) {
-    // Hack for AWS.DynamoDB.DocumentClient
-    if (v2ClientName === DYNAMODB_DOCUMENT_CLIENT) {
-      const [DynamoDB, DocumentClient] = v2ClientName.split(".");
-      return {
-        type: "NewExpression",
-        callee: {
-          type: "MemberExpression",
-          object: {
-            type: "MemberExpression",
-            object: { type: "Identifier", name: v2GlobalName },
-            property: { type: "Identifier", name: DynamoDB },
-          },
-          property: { type: "Identifier", name: DocumentClient },
-        },
-      } as NewExpression;
-    }
-
     return {
       type: "NewExpression",
       callee: {
         object: { type: "Identifier", name: v2GlobalName },
         property: { type: "Identifier", ...(v2ClientName && { name: v2ClientName }) },
-      },
-    } as NewExpression;
-  }
-
-  // Hack for DynamoDBLocalName.DocumentClient
-  if (v2ClientLocalName && v2ClientLocalName.endsWith(`.${DOCUMENT_CLIENT}`)) {
-    const [DynamoDBLocalName, DocumentClient] = v2ClientLocalName.split(".");
-    return {
-      type: "NewExpression",
-      callee: {
-        object: { type: "Identifier", name: DynamoDBLocalName },
-        property: { type: "Identifier", name: DocumentClient },
       },
     } as NewExpression;
   }

--- a/src/transforms/v2-to-v3/utils/getDocClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/getDocClientNewExpression.ts
@@ -7,7 +7,7 @@ export interface DocClientNewExpression {
   v2GlobalName?: string;
 }
 
-export const getV2DocClientNewExpression = ({
+export const getDocClientNewExpression = ({
   v2ClientLocalName,
   v2GlobalName,
 }: DocClientNewExpression): NewExpression => {

--- a/src/transforms/v2-to-v3/utils/getDocClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/getDocClientNewExpression.ts
@@ -2,7 +2,7 @@ import { NewExpression } from "jscodeshift";
 
 import { DOCUMENT_CLIENT, DYNAMODB_DOCUMENT_CLIENT } from "../config";
 
-export interface DocClientNewExpression {
+export interface GetDocClientNewExpressionOptions {
   v2ClientLocalName?: string;
   v2GlobalName?: string;
 }
@@ -10,7 +10,7 @@ export interface DocClientNewExpression {
 export const getDocClientNewExpression = ({
   v2ClientLocalName,
   v2GlobalName,
-}: DocClientNewExpression): NewExpression => {
+}: GetDocClientNewExpressionOptions): NewExpression => {
   if (!v2GlobalName && !v2ClientLocalName) {
     throw new Error(
       `One of the following options must be provided: v2ClientLocalName, v2GlobalName`

--- a/src/transforms/v2-to-v3/utils/getV2DocClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/getV2DocClientNewExpression.ts
@@ -1,0 +1,49 @@
+import { NewExpression } from "jscodeshift";
+
+import { DOCUMENT_CLIENT, DYNAMODB_DOCUMENT_CLIENT } from "../config";
+
+export interface DocClientNewExpression {
+  v2ClientLocalName?: string;
+  v2GlobalName?: string;
+}
+
+export const getV2DocClientNewExpression = ({
+  v2ClientLocalName,
+  v2GlobalName,
+}: DocClientNewExpression): NewExpression => {
+  if (!v2GlobalName && !v2ClientLocalName) {
+    throw new Error(
+      `One of the following options must be provided: v2ClientLocalName, v2GlobalName`
+    );
+  }
+
+  if (v2GlobalName && v2ClientLocalName) {
+    throw new Error(
+      `Only one of the following options must be provided: v2ClientLocalName, v2GlobalName`
+    );
+  }
+
+  if (v2GlobalName) {
+    const [DynamoDBClientName, DocumentClientName] = DYNAMODB_DOCUMENT_CLIENT.split(".");
+    return {
+      type: "NewExpression",
+      callee: {
+        type: "MemberExpression",
+        object: {
+          type: "MemberExpression",
+          object: { type: "Identifier", name: v2GlobalName },
+          property: { type: "Identifier", name: DynamoDBClientName },
+        },
+        property: { type: "Identifier", name: DocumentClientName },
+      },
+    } as NewExpression;
+  }
+
+  return {
+    type: "NewExpression",
+    callee: {
+      object: { type: "Identifier", name: v2ClientLocalName },
+      property: { type: "Identifier", name: DOCUMENT_CLIENT },
+    },
+  } as NewExpression;
+};

--- a/src/transforms/v2-to-v3/utils/index.ts
+++ b/src/transforms/v2-to-v3/utils/index.ts
@@ -2,4 +2,5 @@ export * from "./getClientDeepImportPath";
 export * from "./getClientNewExpression";
 export * from "./getClientTSTypeRef";
 export * from "./getDefaultLocalName";
+export * from "./getV2DocClientNewExpression";
 export * from "./isTypeScriptFile";

--- a/src/transforms/v2-to-v3/utils/index.ts
+++ b/src/transforms/v2-to-v3/utils/index.ts
@@ -2,5 +2,5 @@ export * from "./getClientDeepImportPath";
 export * from "./getClientNewExpression";
 export * from "./getClientTSTypeRef";
 export * from "./getDefaultLocalName";
-export * from "./getV2DocClientNewExpression";
+export * from "./getDocClientNewExpression";
 export * from "./isTypeScriptFile";


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/51

### Description

Add initial support for DynamoDB DocumentClient transformation

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
