### PR TITLE
Remove v2 and v3 from utility names in modules

### DIFF
--- a/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
@@ -34,13 +34,13 @@ export const addClientDefaultImport = (
     v2ClientLocalName,
   });
 
-  const importDeclaration = j.importDeclaration(
+  const v3ImportDeclaration = j.importDeclaration(
     [defaultImportSpecifier],
     j.stringLiteral(v3ClientPackageName)
   );
 
   if (v2ImportDeclaration && v2ImportDeclaration.nodes().length > 0) {
-    v2ImportDeclaration.at(0).insertAfter(importDeclaration);
+    v2ImportDeclaration.at(0).insertAfter(v3ImportDeclaration);
   } else {
     // Unreachable code, throw error
     throw new Error(

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
@@ -5,7 +5,7 @@ import { getImportSpecifiers } from "./getImportSpecifiers";
 import { getV2ImportDeclaration } from "./getV2ImportDeclaration";
 import { V3ClientModulesOptions } from "./types";
 
-export const addV3ClientDefaultImport = (
+export const addClientDefaultImport = (
   j: JSCodeshift,
   source: Collection<unknown>,
   { v2ClientLocalName, v2ClientName, v3ClientPackageName }: V3ClientModulesOptions

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
@@ -3,12 +3,12 @@ import { Collection, ImportDefaultSpecifier, JSCodeshift } from "jscodeshift";
 import { getV3DefaultLocalName } from "../utils";
 import { getImportSpecifiers } from "./getImportSpecifiers";
 import { getV2ImportDeclaration } from "./getV2ImportDeclaration";
-import { V3ClientModulesOptions } from "./types";
+import { ClientModulesOptions } from "./types";
 
 export const addClientDefaultImport = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientLocalName, v2ClientName, v3ClientPackageName }: V3ClientModulesOptions
+  { v2ClientLocalName, v2ClientName, v3ClientPackageName }: ClientModulesOptions
 ) => {
   const localName = getV3DefaultLocalName(v2ClientLocalName);
   const defaultImportSpecifier = j.importDefaultSpecifier(j.identifier(localName));

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
@@ -6,7 +6,7 @@ import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix
 import { getV2ImportEqualsDeclaration } from "./getV2ImportEqualsDeclaration";
 import { V3ClientModulesOptions } from "./types";
 
-export const addV3ClientDefaultImportEquals = (
+export const addClientDefaultImportEquals = (
   j: JSCodeshift,
   source: Collection<unknown>,
   { v2ClientLocalName, v2ClientName, v2GlobalName, v3ClientPackageName }: V3ClientModulesOptions

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
@@ -37,13 +37,13 @@ export const addClientDefaultImportEquals = (
     v2GlobalName,
   }).at(0);
 
-  const importDeclaration = j.tsImportEqualsDeclaration(
+  const v3importEqualsDeclaration = j.tsImportEqualsDeclaration(
     j.identifier(v3ClientDefaultLocalName),
     j.tsExternalModuleReference(j.stringLiteral(v3ClientPackageName))
   );
 
   if (v2ImportEqualsDeclaration && v2ImportEqualsDeclaration.nodes().length > 0) {
-    v2ImportEqualsDeclaration.at(0).insertAfter(importDeclaration);
+    v2ImportEqualsDeclaration.at(0).insertAfter(v3importEqualsDeclaration);
   } else {
     // Unreachable code, throw error
     throw new Error(

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
@@ -4,12 +4,12 @@ import { getV3DefaultLocalName } from "../utils";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";
 import { getV2ImportEqualsDeclaration } from "./getV2ImportEqualsDeclaration";
-import { V3ClientModulesOptions } from "./types";
+import { ClientModulesOptions } from "./types";
 
 export const addClientDefaultImportEquals = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientLocalName, v2ClientName, v2GlobalName, v3ClientPackageName }: V3ClientModulesOptions
+  { v2ClientLocalName, v2ClientName, v2GlobalName, v3ClientPackageName }: ClientModulesOptions
 ) => {
   const localNameSuffix = getImportEqualsLocalNameSuffix(v2ClientName, v3ClientPackageName);
   const v3ClientDefaultLocalName = getV3DefaultLocalName(localNameSuffix);

--- a/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
@@ -5,7 +5,7 @@ import { getRequireDeclarators } from "./getRequireDeclarators";
 import { getV2RequireDeclarator } from "./getV2RequireDeclarator";
 import { V3ClientModulesOptions } from "./types";
 
-export const addV3ClientDefaultRequire = (
+export const addClientDefaultRequire = (
   j: JSCodeshift,
   source: Collection<unknown>,
   { v2ClientName, v2ClientLocalName, v3ClientPackageName, v2GlobalName }: V3ClientModulesOptions

--- a/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
@@ -3,12 +3,12 @@ import { Collection, JSCodeshift } from "jscodeshift";
 import { getV3DefaultLocalName } from "../utils";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 import { getV2RequireDeclarator } from "./getV2RequireDeclarator";
-import { V3ClientModulesOptions } from "./types";
+import { ClientModulesOptions } from "./types";
 
 export const addClientDefaultRequire = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientName, v2ClientLocalName, v3ClientPackageName, v2GlobalName }: V3ClientModulesOptions
+  { v2ClientName, v2ClientLocalName, v3ClientPackageName, v2GlobalName }: ClientModulesOptions
 ) => {
   const identifierName = getV3DefaultLocalName(v2ClientLocalName);
   const existingRequires = getRequireDeclarators(j, source, v3ClientPackageName);

--- a/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
@@ -31,13 +31,13 @@ export const addClientDefaultRequire = (
   const v2RequireDeclarator =
     getV2RequireDeclarator(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
 
-  const requireDeclarator = j.variableDeclarator(
+  const v3RequireDeclarator = j.variableDeclarator(
     j.identifier(identifierName),
     j.callExpression(j.identifier("require"), [j.literal(v3ClientPackageName)])
   );
 
   if (v2RequireDeclarator && v2RequireDeclarator.nodes().length > 0) {
-    v2RequireDeclarator.insertAfter(requireDeclarator);
+    v2RequireDeclarator.insertAfter(v3RequireDeclarator);
   } else {
     // Unreachable code, throw error
     throw new Error(

--- a/src/transforms/v2-to-v3/modules/addClientImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientImportEquals.ts
@@ -6,12 +6,12 @@ import { addClientDefaultImportEquals } from "./addClientDefaultImportEquals";
 import { addClientNamedImportEquals } from "./addClientNamedImportEquals";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
-import { V3ClientModulesOptions } from "./types";
+import { ClientModulesOptions } from "./types";
 
 export const addClientImportEquals = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: V3ClientModulesOptions
+  options: ClientModulesOptions
 ): void => {
   const v3ClientTypesCount = getV3ClientTypesCount(j, source, options);
   const newExpressionCount = getNewExpressionCount(j, source, options);

--- a/src/transforms/v2-to-v3/modules/addClientImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientImportEquals.ts
@@ -2,13 +2,13 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
 import { getV3ClientTypesCount } from "../ts-type";
-import { addV3ClientDefaultImportEquals } from "./addV3ClientDefaultImportEquals";
-import { addV3ClientNamedImportEquals } from "./addV3ClientNamedImportEquals";
+import { addClientDefaultImportEquals } from "./addClientDefaultImportEquals";
+import { addClientNamedImportEquals } from "./addClientNamedImportEquals";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
 import { V3ClientModulesOptions } from "./types";
 
-export const addV3ClientImportEquals = (
+export const addClientImportEquals = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: V3ClientModulesOptions
@@ -19,11 +19,11 @@ export const addV3ClientImportEquals = (
   const waiterStates = getClientWaiterStates(j, source, options);
 
   if (v3ClientTypesCount > 0) {
-    addV3ClientDefaultImportEquals(j, source, options);
+    addClientDefaultImportEquals(j, source, options);
   }
 
   if (newExpressionCount > 0 || clientTSTypeRefCount > 0) {
-    addV3ClientNamedImportEquals(j, source, {
+    addClientNamedImportEquals(j, source, {
       ...options,
       keyName: options.v3ClientName,
       valueName: options.v2ClientLocalName,
@@ -32,14 +32,14 @@ export const addV3ClientImportEquals = (
 
   for (const waiterState of waiterStates) {
     const v3WaiterApiName = getV3ClientWaiterApiName(waiterState);
-    addV3ClientNamedImportEquals(j, source, {
+    addClientNamedImportEquals(j, source, {
       ...options,
       keyName: v3WaiterApiName,
     });
   }
 
   if (isS3UploadApiUsed(j, source, options)) {
-    addV3ClientNamedImportEquals(j, source, {
+    addClientNamedImportEquals(j, source, {
       ...options,
       keyName: "Upload",
       v3ClientPackageName: "@aws-sdk/lib-storage",

--- a/src/transforms/v2-to-v3/modules/addClientImports.ts
+++ b/src/transforms/v2-to-v3/modules/addClientImports.ts
@@ -2,13 +2,13 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
 import { getV3ClientTypesCount } from "../ts-type";
-import { addV3ClientDefaultImport } from "./addV3ClientDefaultImport";
-import { addV3ClientNamedImport } from "./addV3ClientNamedImport";
+import { addClientDefaultImport } from "./addClientDefaultImport";
+import { addClientNamedImport } from "./addClientNamedImport";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
 import { V3ClientModulesOptions } from "./types";
 
-export const addV3ClientImports = (
+export const addClientImports = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: V3ClientModulesOptions
@@ -20,11 +20,11 @@ export const addV3ClientImports = (
 
   // Add default import for types, if needed.
   if (v3ClientTypesCount > 0) {
-    addV3ClientDefaultImport(j, source, options);
+    addClientDefaultImport(j, source, options);
   }
 
   if (newExpressionCount > 0 || clientTSTypeRefCount > 0) {
-    addV3ClientNamedImport(j, source, {
+    addClientNamedImport(j, source, {
       ...options,
       importedName: options.v3ClientName,
       localName: options.v2ClientLocalName,
@@ -33,14 +33,14 @@ export const addV3ClientImports = (
 
   for (const waiterState of waiterStates) {
     const v3WaiterApiName = getV3ClientWaiterApiName(waiterState);
-    addV3ClientNamedImport(j, source, {
+    addClientNamedImport(j, source, {
       ...options,
       importedName: v3WaiterApiName,
     });
   }
 
   if (isS3UploadApiUsed(j, source, options)) {
-    addV3ClientNamedImport(j, source, {
+    addClientNamedImport(j, source, {
       ...options,
       importedName: "Upload",
       v3ClientPackageName: "@aws-sdk/lib-storage",

--- a/src/transforms/v2-to-v3/modules/addClientImports.ts
+++ b/src/transforms/v2-to-v3/modules/addClientImports.ts
@@ -6,12 +6,12 @@ import { addClientDefaultImport } from "./addClientDefaultImport";
 import { addClientNamedImport } from "./addClientNamedImport";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
-import { V3ClientModulesOptions } from "./types";
+import { ClientModulesOptions } from "./types";
 
 export const addClientImports = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: V3ClientModulesOptions
+  options: ClientModulesOptions
 ): void => {
   const v3ClientTypesCount = getV3ClientTypesCount(j, source, options);
   const newExpressionCount = getNewExpressionCount(j, source, options);

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
+import { addClientImportEquals } from "./addClientImportEquals";
 import { addClientRequires } from "./addClientRequires";
-import { addV3ClientImportEquals } from "./addV3ClientImportEquals";
 import { addV3ClientImports } from "./addV3ClientImports";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
@@ -15,5 +15,5 @@ export const addClientModules = (
   hasRequire(j, source)
     ? addClientRequires(j, source, options)
     : hasImportEquals(j, source)
-    ? addV3ClientImportEquals(j, source, options)
+    ? addClientImportEquals(j, source, options)
     : addV3ClientImports(j, source, options);

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -1,8 +1,8 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
+import { addClientRequires } from "./addClientRequires";
 import { addV3ClientImportEquals } from "./addV3ClientImportEquals";
 import { addV3ClientImports } from "./addV3ClientImports";
-import { addV3ClientRequires } from "./addV3ClientRequires";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { V3ClientModulesOptions } from "./types";
@@ -13,7 +13,7 @@ export const addClientModules = (
   options: V3ClientModulesOptions
 ): void =>
   hasRequire(j, source)
-    ? addV3ClientRequires(j, source, options)
+    ? addClientRequires(j, source, options)
     : hasImportEquals(j, source)
     ? addV3ClientImportEquals(j, source, options)
     : addV3ClientImports(j, source, options);

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -7,7 +7,7 @@ import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { V3ClientModulesOptions } from "./types";
 
-export const addV3ClientModules = (
+export const addClientModules = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: V3ClientModulesOptions

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -5,12 +5,12 @@ import { addClientImports } from "./addClientImports";
 import { addClientRequires } from "./addClientRequires";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
-import { V3ClientModulesOptions } from "./types";
+import { ClientModulesOptions } from "./types";
 
 export const addClientModules = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: V3ClientModulesOptions
+  options: ClientModulesOptions
 ): void =>
   hasRequire(j, source)
     ? addClientRequires(j, source, options)

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -1,8 +1,8 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { addClientImportEquals } from "./addClientImportEquals";
+import { addClientImports } from "./addClientImports";
 import { addClientRequires } from "./addClientRequires";
-import { addV3ClientImports } from "./addV3ClientImports";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { V3ClientModulesOptions } from "./types";
@@ -16,4 +16,4 @@ export const addClientModules = (
     ? addClientRequires(j, source, options)
     : hasImportEquals(j, source)
     ? addClientImportEquals(j, source, options)
-    : addV3ClientImports(j, source, options);
+    : addClientImports(j, source, options);

--- a/src/transforms/v2-to-v3/modules/addClientNamedImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImport.ts
@@ -1,8 +1,8 @@
 import { Collection, ImportSpecifier, JSCodeshift } from "jscodeshift";
 
+import { getImportSpecifier } from "./getImportSpecifier";
 import { getImportSpecifiers } from "./getImportSpecifiers";
 import { getV2ImportDeclaration } from "./getV2ImportDeclaration";
-import { getV3ClientImportSpecifier } from "./getV3ClientImportSpecifier";
 import { importSpecifierCompareFn } from "./importSpecifierCompareFn";
 import { ClientModulesOptions, ImportSpecifierOptions } from "./types";
 
@@ -34,7 +34,7 @@ export const addClientNamedImport = (
 
     const firstImportDeclSpecifiers = importDeclarations.nodes()[0].specifiers;
     if (firstImportDeclSpecifiers) {
-      firstImportDeclSpecifiers.push(getV3ClientImportSpecifier(j, { importedName, localName }));
+      firstImportDeclSpecifiers.push(getImportSpecifier(j, { importedName, localName }));
       firstImportDeclSpecifiers.sort(importSpecifierCompareFn);
       return;
     }
@@ -47,7 +47,7 @@ export const addClientNamedImport = (
   });
 
   const importDeclaration = j.importDeclaration(
-    [getV3ClientImportSpecifier(j, { importedName, localName })],
+    [getImportSpecifier(j, { importedName, localName })],
     j.stringLiteral(v3ClientPackageName)
   );
 

--- a/src/transforms/v2-to-v3/modules/addClientNamedImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImport.ts
@@ -6,7 +6,7 @@ import { getV3ClientImportSpecifier } from "./getV3ClientImportSpecifier";
 import { importSpecifierCompareFn } from "./importSpecifierCompareFn";
 import { V3ClientImportSpecifierOptions, V3ClientModulesOptions } from "./types";
 
-export const addV3ClientNamedImport = (
+export const addClientNamedImport = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: V3ClientModulesOptions & V3ClientImportSpecifierOptions

--- a/src/transforms/v2-to-v3/modules/addClientNamedImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImport.ts
@@ -46,13 +46,13 @@ export const addClientNamedImport = (
     v2ClientLocalName,
   });
 
-  const importDeclaration = j.importDeclaration(
+  const v3ImportDeclaration = j.importDeclaration(
     [getImportSpecifier(j, { importedName, localName })],
     j.stringLiteral(v3ClientPackageName)
   );
 
   if (v2ImportDeclaration && v2ImportDeclaration.nodes().length > 0) {
-    v2ImportDeclaration.at(0).insertAfter(importDeclaration);
+    v2ImportDeclaration.at(0).insertAfter(v3ImportDeclaration);
   } else {
     // Unreachable code, throw error
     throw new Error(

--- a/src/transforms/v2-to-v3/modules/addClientNamedImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImport.ts
@@ -4,12 +4,12 @@ import { getImportSpecifiers } from "./getImportSpecifiers";
 import { getV2ImportDeclaration } from "./getV2ImportDeclaration";
 import { getV3ClientImportSpecifier } from "./getV3ClientImportSpecifier";
 import { importSpecifierCompareFn } from "./importSpecifierCompareFn";
-import { ClientModulesOptions, V3ClientImportSpecifierOptions } from "./types";
+import { ClientModulesOptions, ImportSpecifierOptions } from "./types";
 
 export const addClientNamedImport = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: ClientModulesOptions & V3ClientImportSpecifierOptions
+  options: ClientModulesOptions & ImportSpecifierOptions
 ) => {
   const { importedName, v2ClientName, v2ClientLocalName, v3ClientPackageName } = options;
   const localName = options.localName ?? importedName;

--- a/src/transforms/v2-to-v3/modules/addClientNamedImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImport.ts
@@ -4,12 +4,12 @@ import { getImportSpecifiers } from "./getImportSpecifiers";
 import { getV2ImportDeclaration } from "./getV2ImportDeclaration";
 import { getV3ClientImportSpecifier } from "./getV3ClientImportSpecifier";
 import { importSpecifierCompareFn } from "./importSpecifierCompareFn";
-import { V3ClientImportSpecifierOptions, V3ClientModulesOptions } from "./types";
+import { ClientModulesOptions, V3ClientImportSpecifierOptions } from "./types";
 
 export const addClientNamedImport = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: V3ClientModulesOptions & V3ClientImportSpecifierOptions
+  options: ClientModulesOptions & V3ClientImportSpecifierOptions
 ) => {
   const { importedName, v2ClientName, v2ClientLocalName, v3ClientPackageName } = options;
   const localName = options.localName ?? importedName;

--- a/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
@@ -1,14 +1,14 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getV3DefaultLocalName } from "../utils";
-import { addV3ClientDefaultImportEquals } from "./addV3ClientDefaultImportEquals";
+import { addClientDefaultImportEquals } from "./addClientDefaultImportEquals";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";
 import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
 import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
 import { V3ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types";
 
-export const addV3ClientNamedImportEquals = (
+export const addClientNamedImportEquals = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: V3ClientModulesOptions & V3ClientRequirePropertyOptions
@@ -34,7 +34,7 @@ export const addV3ClientNamedImportEquals = (
 
   const importEqualsDeclaration = getImportEqualsDeclaration(v3ClientPackageName);
   if (source.find(j.TSImportEqualsDeclaration, importEqualsDeclaration).size() === 0) {
-    addV3ClientDefaultImportEquals(j, source, v3ClientModulesOptions);
+    addClientDefaultImportEquals(j, source, v3ClientModulesOptions);
   }
 
   const varDeclaration = j.variableDeclaration("const", [

--- a/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
@@ -6,12 +6,12 @@ import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";
 import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
 import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
-import { ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types";
+import { ClientModulesOptions, RequirePropertyOptions } from "./types";
 
 export const addClientNamedImportEquals = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: ClientModulesOptions & V3ClientRequirePropertyOptions
+  options: ClientModulesOptions & RequirePropertyOptions
 ) => {
   const { keyName, valueName, ...v3ClientModulesOptions } = options;
   const { v2ClientName, v3ClientPackageName } = v3ClientModulesOptions;

--- a/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
@@ -6,12 +6,12 @@ import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";
 import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
 import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
-import { V3ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types";
+import { ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types";
 
 export const addClientNamedImportEquals = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: V3ClientModulesOptions & V3ClientRequirePropertyOptions
+  options: ClientModulesOptions & V3ClientRequirePropertyOptions
 ) => {
   const { keyName, valueName, ...v3ClientModulesOptions } = options;
   const { v2ClientName, v3ClientPackageName } = v3ClientModulesOptions;

--- a/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
@@ -4,7 +4,7 @@ import { getV3DefaultLocalName } from "../utils";
 import { addClientDefaultImportEquals } from "./addClientDefaultImportEquals";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";
-import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
+import { getRequireProperty } from "./getRequireProperty";
 import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
 import { ClientModulesOptions, RequirePropertyOptions } from "./types";
 
@@ -18,7 +18,7 @@ export const addClientNamedImportEquals = (
 
   const localNameSuffix = getImportEqualsLocalNameSuffix(v2ClientName, v3ClientPackageName);
   const v3ClientDefaultLocalName = getV3DefaultLocalName(localNameSuffix);
-  const namedImportObjectProperty = getV3ClientRequireProperty(j, { keyName, valueName });
+  const namedImportObjectProperty = getRequireProperty(j, { keyName, valueName });
 
   const existingVarDeclarator = source.find(j.VariableDeclarator, {
     type: "VariableDeclarator",

--- a/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
@@ -68,7 +68,7 @@ export const addClientNamedRequire = (
     }
   }
 
-  const requireDeclarator = j.variableDeclarator(
+  const v3RequireDeclarator = j.variableDeclarator(
     j.objectPattern([v3ClientObjectProperty]),
     j.callExpression(j.identifier("require"), [j.literal(v3ClientPackageName)])
   );
@@ -78,7 +78,7 @@ export const addClientNamedRequire = (
     getV2RequireDeclarator(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
 
   if (v2RequireDeclarator && v2RequireDeclarator.nodes().length > 0) {
-    v2RequireDeclarator.insertAfter(requireDeclarator);
+    v2RequireDeclarator.insertAfter(v3RequireDeclarator);
   } else {
     // Unreachable code, throw error
     throw new Error(

--- a/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
@@ -9,7 +9,7 @@ import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
 import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
 import { V3ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types";
 
-export const addV3ClientNamedRequire = (
+export const addClientNamedRequire = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: V3ClientModulesOptions & V3ClientRequirePropertyOptions

--- a/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
@@ -7,12 +7,12 @@ import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWith
 import { getV2RequireDeclarator } from "./getV2RequireDeclarator";
 import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
 import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
-import { V3ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types";
+import { ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types";
 
 export const addClientNamedRequire = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: V3ClientModulesOptions & V3ClientRequirePropertyOptions
+  options: ClientModulesOptions & V3ClientRequirePropertyOptions
 ) => {
   const { keyName, v2ClientName, v2ClientLocalName, v2GlobalName, v3ClientPackageName } = options;
   const valueName = options.valueName ?? keyName;

--- a/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
@@ -4,8 +4,8 @@ import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 import { getV3DefaultLocalName } from "../utils";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";
+import { getRequireProperty } from "./getRequireProperty";
 import { getV2RequireDeclarator } from "./getV2RequireDeclarator";
-import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
 import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
 import { ClientModulesOptions, RequirePropertyOptions } from "./types";
 
@@ -18,7 +18,7 @@ export const addClientNamedRequire = (
   const valueName = options.valueName ?? keyName;
 
   const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientLocalName);
-  const v3ClientObjectProperty = getV3ClientRequireProperty(j, { keyName, valueName });
+  const v3ClientObjectProperty = getRequireProperty(j, { keyName, valueName });
   const existingRequires = getRequireDeclarators(j, source, v3ClientPackageName);
 
   if (existingRequires && existingRequires.nodes().length > 0) {

--- a/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
@@ -7,12 +7,12 @@ import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWith
 import { getV2RequireDeclarator } from "./getV2RequireDeclarator";
 import { getV3ClientRequireProperty } from "./getV3ClientRequireProperty";
 import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
-import { ClientModulesOptions, V3ClientRequirePropertyOptions } from "./types";
+import { ClientModulesOptions, RequirePropertyOptions } from "./types";
 
 export const addClientNamedRequire = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: ClientModulesOptions & V3ClientRequirePropertyOptions
+  options: ClientModulesOptions & RequirePropertyOptions
 ) => {
   const { keyName, v2ClientName, v2ClientLocalName, v2GlobalName, v3ClientPackageName } = options;
   const valueName = options.valueName ?? keyName;

--- a/src/transforms/v2-to-v3/modules/addClientRequires.ts
+++ b/src/transforms/v2-to-v3/modules/addClientRequires.ts
@@ -6,12 +6,12 @@ import { addClientDefaultRequire } from "./addClientDefaultRequire";
 import { addClientNamedRequire } from "./addClientNamedRequire";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
-import { V3ClientModulesOptions } from "./types";
+import { ClientModulesOptions } from "./types";
 
 export const addClientRequires = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: V3ClientModulesOptions
+  options: ClientModulesOptions
 ): void => {
   const v3ClientTypesCount = getV3ClientTypesCount(j, source, options);
   const newExpressionCount = getNewExpressionCount(j, source, options);

--- a/src/transforms/v2-to-v3/modules/addClientRequires.ts
+++ b/src/transforms/v2-to-v3/modules/addClientRequires.ts
@@ -2,13 +2,13 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
 import { getV3ClientTypesCount } from "../ts-type";
-import { addV3ClientDefaultRequire } from "./addV3ClientDefaultRequire";
-import { addV3ClientNamedRequire } from "./addV3ClientNamedRequire";
+import { addClientDefaultRequire } from "./addClientDefaultRequire";
+import { addClientNamedRequire } from "./addClientNamedRequire";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
 import { V3ClientModulesOptions } from "./types";
 
-export const addV3ClientRequires = (
+export const addClientRequires = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: V3ClientModulesOptions
@@ -19,11 +19,11 @@ export const addV3ClientRequires = (
   const waiterStates = getClientWaiterStates(j, source, options);
 
   if (v3ClientTypesCount > 0) {
-    addV3ClientDefaultRequire(j, source, options);
+    addClientDefaultRequire(j, source, options);
   }
 
   if (newExpressionCount > 0 || clientTSTypeRefCount > 0) {
-    addV3ClientNamedRequire(j, source, {
+    addClientNamedRequire(j, source, {
       ...options,
       keyName: options.v3ClientName,
       valueName: options.v2ClientLocalName,
@@ -32,14 +32,14 @@ export const addV3ClientRequires = (
 
   for (const waiterState of waiterStates) {
     const v3WaiterApiName = getV3ClientWaiterApiName(waiterState);
-    addV3ClientNamedRequire(j, source, {
+    addClientNamedRequire(j, source, {
       ...options,
       keyName: v3WaiterApiName,
     });
   }
 
   if (isS3UploadApiUsed(j, source, options)) {
-    addV3ClientNamedRequire(j, source, {
+    addClientNamedRequire(j, source, {
       ...options,
       keyName: "Upload",
       v3ClientPackageName: "@aws-sdk/lib-storage",

--- a/src/transforms/v2-to-v3/modules/getClientTSTypeRefCount.ts
+++ b/src/transforms/v2-to-v3/modules/getClientTSTypeRefCount.ts
@@ -1,12 +1,12 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getV2ClientTSTypeRef } from "../utils";
-import { V3ClientModulesOptions } from "./types";
+import { ClientModulesOptions } from "./types";
 
 export const getClientTSTypeRefCount = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientName, v2ClientLocalName, v2GlobalName }: V3ClientModulesOptions
+  { v2ClientName, v2ClientLocalName, v2GlobalName }: ClientModulesOptions
 ): number => {
   let clientTSTypeRefCount = 0;
 

--- a/src/transforms/v2-to-v3/modules/getImportSpecifier.ts
+++ b/src/transforms/v2-to-v3/modules/getImportSpecifier.ts
@@ -2,7 +2,7 @@ import { JSCodeshift } from "jscodeshift";
 
 import { ImportSpecifierOptions } from "./types";
 
-export const getV3ClientImportSpecifier = (
+export const getImportSpecifier = (
   j: JSCodeshift,
   { importedName, localName }: ImportSpecifierOptions
 ) =>

--- a/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
@@ -1,12 +1,12 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getV2ClientNewExpression } from "../utils";
-import { V3ClientModulesOptions } from "./types";
+import { ClientModulesOptions } from "./types";
 
 export const getNewExpressionCount = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientName, v2ClientLocalName, v2GlobalName }: V3ClientModulesOptions
+  { v2ClientName, v2ClientLocalName, v2GlobalName }: ClientModulesOptions
 ): number => {
   let newExpressionCount = 0;
 

--- a/src/transforms/v2-to-v3/modules/getRequireProperty.ts
+++ b/src/transforms/v2-to-v3/modules/getRequireProperty.ts
@@ -2,7 +2,7 @@ import { JSCodeshift } from "jscodeshift";
 
 import { RequirePropertyOptions } from "./types";
 
-export const getV3ClientRequireProperty = (
+export const getRequireProperty = (
   j: JSCodeshift,
   { keyName, valueName }: RequirePropertyOptions
 ) =>

--- a/src/transforms/v2-to-v3/modules/getV3ClientImportSpecifier.ts
+++ b/src/transforms/v2-to-v3/modules/getV3ClientImportSpecifier.ts
@@ -1,10 +1,10 @@
 import { JSCodeshift } from "jscodeshift";
 
-import { V3ClientImportSpecifierOptions } from "./types";
+import { ImportSpecifierOptions } from "./types";
 
 export const getV3ClientImportSpecifier = (
   j: JSCodeshift,
-  { importedName, localName }: V3ClientImportSpecifierOptions
+  { importedName, localName }: ImportSpecifierOptions
 ) =>
   localName
     ? j.importSpecifier(j.identifier(importedName), j.identifier(localName))

--- a/src/transforms/v2-to-v3/modules/getV3ClientRequireProperty.ts
+++ b/src/transforms/v2-to-v3/modules/getV3ClientRequireProperty.ts
@@ -1,10 +1,10 @@
 import { JSCodeshift } from "jscodeshift";
 
-import { V3ClientRequirePropertyOptions } from "./types";
+import { RequirePropertyOptions } from "./types";
 
 export const getV3ClientRequireProperty = (
   j: JSCodeshift,
-  { keyName, valueName }: V3ClientRequirePropertyOptions
+  { keyName, valueName }: RequirePropertyOptions
 ) =>
   j.objectProperty.from({
     key: j.identifier(keyName),

--- a/src/transforms/v2-to-v3/modules/index.ts
+++ b/src/transforms/v2-to-v3/modules/index.ts
@@ -1,4 +1,4 @@
-export * from "./addV3ClientModules";
+export * from "./addClientModules";
 export * from "./getImportEqualsDeclaration";
 export * from "./getImportSpecifiers";
 export * from "./getRequireDeclaratorsWithProperty";

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -6,7 +6,7 @@ export interface ClientModulesOptions {
   v3ClientPackageName: string;
 }
 
-export interface V3ClientRequirePropertyOptions {
+export interface RequirePropertyOptions {
   keyName: string;
   valueName?: string;
 }

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -1,4 +1,4 @@
-export interface V3ClientModulesOptions {
+export interface ClientModulesOptions {
   v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -11,7 +11,7 @@ export interface RequirePropertyOptions {
   valueName?: string;
 }
 
-export interface V3ClientImportSpecifierOptions {
+export interface ImportSpecifierOptions {
   importedName: string;
   localName?: string;
 }

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -9,7 +9,7 @@ import {
   getV2ClientNamesRecord,
 } from "./client-names";
 import {
-  addV3ClientModules,
+  addClientModules,
   getV2GlobalNameFromModule,
   removeV2ClientModule,
   removeV2GlobalModule,
@@ -53,7 +53,7 @@ const transformer = async (file: FileInfo, api: API) => {
     const v2Options = { v2ClientName, v2ClientLocalName, v2GlobalName };
     const v3Options = { v3ClientName, v3ClientPackageName };
 
-    addV3ClientModules(j, source, { ...v2Options, ...v3Options });
+    addClientModules(j, source, { ...v2Options, ...v3Options });
     replaceTSTypeReference(j, source, { ...v2Options, v3ClientName });
     removeV2ClientModule(j, source, v2Options);
     replaceS3UploadApi(j, source, v2Options);


### PR DESCRIPTION
### Issue

Refs: https://github.com/awslabs/aws-sdk-js-codemod/issues/451

### Description

Remove v2 and v3 from utility names

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
