### PR TITLE
Remove v2 and v3 from utility names in apis folder

### DIFF
--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -2,8 +2,8 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { FUNCTION_TYPE_LIST } from "../config";
 import { getClientIdentifiers } from "./getClientIdentifiers";
+import { getClientS3UploadCallExpression } from "./getClientS3UploadCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";
-import { getV2ClientS3UploadCallExpression } from "./getV2ClientS3UploadCallExpression";
 import { getV2ClientWaiterCallExpression } from "./getV2ClientWaiterCallExpression";
 
 export interface CommentsForUnsupportedAPIsOptions {
@@ -49,7 +49,7 @@ export const addNotSupportedComments = (
   if (options.v2ClientName === "S3") {
     for (const clientId of clientIdentifiers) {
       source
-        .find(j.CallExpression, getV2ClientS3UploadCallExpression(clientId))
+        .find(j.CallExpression, getClientS3UploadCallExpression(clientId))
         .forEach((callExpression) => {
           const args = callExpression.node.arguments;
 

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -1,8 +1,8 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { FUNCTION_TYPE_LIST } from "../config";
+import { getClientIdentifiers } from "./getClientIdentifiers";
 import { getClientWaiterStates } from "./getClientWaiterStates";
-import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
 import { getV2ClientS3UploadCallExpression } from "./getV2ClientS3UploadCallExpression";
 import { getV2ClientWaiterCallExpression } from "./getV2ClientWaiterCallExpression";
 
@@ -17,14 +17,14 @@ export const addNotSupportedComments = (
   source: Collection<unknown>,
   options: CommentsForUnsupportedAPIsOptions
 ): void => {
-  const v2ClientIdentifiers = getV2ClientIdentifiers(j, source, options);
+  const clientIdentifiers = getClientIdentifiers(j, source, options);
 
-  for (const v2ClientId of v2ClientIdentifiers) {
+  for (const clientId of clientIdentifiers) {
     const waiterStates = getClientWaiterStates(j, source, options);
 
     for (const waiterState of waiterStates) {
       source
-        .find(j.CallExpression, getV2ClientWaiterCallExpression(v2ClientId, waiterState))
+        .find(j.CallExpression, getV2ClientWaiterCallExpression(clientId, waiterState))
         .forEach((callExpression) => {
           const args = callExpression.node.arguments;
 
@@ -47,9 +47,9 @@ export const addNotSupportedComments = (
   }
 
   if (options.v2ClientName === "S3") {
-    for (const v2ClientId of v2ClientIdentifiers) {
+    for (const clientId of clientIdentifiers) {
       source
-        .find(j.CallExpression, getV2ClientS3UploadCallExpression(v2ClientId))
+        .find(j.CallExpression, getV2ClientS3UploadCallExpression(clientId))
         .forEach((callExpression) => {
           const args = callExpression.node.arguments;
 

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -2,9 +2,9 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { FUNCTION_TYPE_LIST } from "../config";
 import { getClientIdentifiers } from "./getClientIdentifiers";
+import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";
 import { getS3UploadCallExpression } from "./getS3UploadCallExpression";
-import { getV2ClientWaiterCallExpression } from "./getV2ClientWaiterCallExpression";
 
 export interface CommentsForUnsupportedAPIsOptions {
   v2ClientName: string;
@@ -24,7 +24,7 @@ export const addNotSupportedComments = (
 
     for (const waiterState of waiterStates) {
       source
-        .find(j.CallExpression, getV2ClientWaiterCallExpression(clientId, waiterState))
+        .find(j.CallExpression, getClientWaiterCallExpression(clientId, waiterState))
         .forEach((callExpression) => {
           const args = callExpression.node.arguments;
 

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -2,8 +2,8 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { FUNCTION_TYPE_LIST } from "../config";
 import { getClientIdentifiers } from "./getClientIdentifiers";
-import { getClientS3UploadCallExpression } from "./getClientS3UploadCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";
+import { getS3UploadCallExpression } from "./getS3UploadCallExpression";
 import { getV2ClientWaiterCallExpression } from "./getV2ClientWaiterCallExpression";
 
 export interface CommentsForUnsupportedAPIsOptions {
@@ -49,7 +49,7 @@ export const addNotSupportedComments = (
   if (options.v2ClientName === "S3") {
     for (const clientId of clientIdentifiers) {
       source
-        .find(j.CallExpression, getClientS3UploadCallExpression(clientId))
+        .find(j.CallExpression, getS3UploadCallExpression(clientId))
         .forEach((callExpression) => {
           const args = callExpression.node.arguments;
 

--- a/src/transforms/v2-to-v3/apis/getClientIdNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdNamesFromNewExpr.ts
@@ -2,7 +2,7 @@ import { Collection, Identifier, JSCodeshift, NewExpression } from "jscodeshift"
 
 import { getClientNewExpression } from "../utils";
 
-export interface GetV2ClientIdNamesFromNewExprOptions {
+export interface GetClientIdNamesFromNewExprOptions {
   v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;
@@ -34,10 +34,10 @@ const getNamesFromAssignmentPattern = (
     .nodes()
     .map((assignmentPattern) => (assignmentPattern.left as Identifier).name);
 
-export const getV2ClientIdNamesFromNewExpr = (
+export const getClientIdNamesFromNewExpr = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientName, v2ClientLocalName, v2GlobalName }: GetV2ClientIdNamesFromNewExprOptions
+  { v2ClientName, v2ClientLocalName, v2GlobalName }: GetClientIdNamesFromNewExprOptions
 ): string[] => {
   const namesFromGlobalModule = [];
   const namesFromServiceModule = [];

--- a/src/transforms/v2-to-v3/apis/getClientIdNamesFromTSTypeRef.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdNamesFromTSTypeRef.ts
@@ -1,14 +1,14 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-export interface GetV2ClientIdNamesFromTSTypeRefOptions {
+export interface GetClientIdNamesFromTSTypeRefOptions {
   v2ClientName: string;
   v2GlobalName?: string;
 }
 
-export const getV2ClientIdNamesFromTSTypeRef = (
+export const getClientIdNamesFromTSTypeRef = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2GlobalName, v2ClientName }: GetV2ClientIdNamesFromTSTypeRefOptions
+  { v2GlobalName, v2ClientName }: GetClientIdNamesFromTSTypeRefOptions
 ): string[] => {
   const namesFromGlobalName = v2GlobalName
     ? source

--- a/src/transforms/v2-to-v3/apis/getClientIdThisExpressions.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdThisExpressions.ts
@@ -8,16 +8,16 @@ export interface ThisMemberExpression {
 
 const thisMemberExpression = { type: "MemberExpression", object: { type: "ThisExpression" } };
 
-export const getV2ClientIdThisExpressions = (
+export const getClientIdThisExpressions = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  v2ClientIdentifiers: Identifier[]
+  clientIdentifiers: Identifier[]
 ): ThisMemberExpression[] =>
-  v2ClientIdentifiers.flatMap((v2ClientIdentifier) =>
+  clientIdentifiers.flatMap((clientIdentifier) =>
     source
       .find(j.AssignmentExpression, {
         left: thisMemberExpression as MemberExpression,
-        right: v2ClientIdentifier,
+        right: clientIdentifier,
       })
       .nodes()
       .map(

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
@@ -1,8 +1,8 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 import { getClientIdNamesFromNewExpr } from "./getClientIdNamesFromNewExpr";
+import { getClientIdNamesFromTSTypeRef } from "./getClientIdNamesFromTSTypeRef";
 import { getClientIdThisExpressions, ThisMemberExpression } from "./getClientIdThisExpressions";
-import { getV2ClientIdNamesFromTSTypeRef } from "./getV2ClientIdNamesFromTSTypeRef";
 
 export interface GetClientIdentifiersOptions {
   v2ClientName: string;
@@ -18,7 +18,7 @@ export const getClientIdentifiers = (
   options: GetClientIdentifiersOptions
 ): ClientIdentifier[] => {
   const namesFromNewExpr = getClientIdNamesFromNewExpr(j, source, options);
-  const namesFromTSTypeRef = getV2ClientIdNamesFromTSTypeRef(j, source, options);
+  const namesFromTSTypeRef = getClientIdNamesFromTSTypeRef(j, source, options);
   const clientIdNames = [...new Set([...namesFromNewExpr, ...namesFromTSTypeRef])];
 
   const clientIdentifiers: Identifier[] = clientIdNames.map((clientidName) => ({

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
@@ -1,8 +1,8 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
+import { getClientIdThisExpressions, ThisMemberExpression } from "./getClientIdThisExpressions";
 import { getV2ClientIdNamesFromNewExpr } from "./getV2ClientIdNamesFromNewExpr";
 import { getV2ClientIdNamesFromTSTypeRef } from "./getV2ClientIdNamesFromTSTypeRef";
-import { getV2ClientIdThisExpressions, ThisMemberExpression } from "./getV2ClientIdThisExpressions";
 
 export interface GetClientIdentifiersOptions {
   v2ClientName: string;
@@ -25,7 +25,7 @@ export const getClientIdentifiers = (
     type: "Identifier",
     name: clientidName,
   }));
-  const clientIdThisExpressions = getV2ClientIdThisExpressions(j, source, clientIdentifiers);
+  const clientIdThisExpressions = getClientIdThisExpressions(j, source, clientIdentifiers);
 
   return [...clientIdentifiers, ...clientIdThisExpressions];
 };

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
@@ -4,28 +4,28 @@ import { getV2ClientIdNamesFromNewExpr } from "./getV2ClientIdNamesFromNewExpr";
 import { getV2ClientIdNamesFromTSTypeRef } from "./getV2ClientIdNamesFromTSTypeRef";
 import { getV2ClientIdThisExpressions, ThisMemberExpression } from "./getV2ClientIdThisExpressions";
 
-export interface GetV2ClientIdentifiersOptions {
+export interface GetClientIdentifiersOptions {
   v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;
 }
 
-export type V2ClientIdentifier = Identifier | ThisMemberExpression;
+export type ClientIdentifier = Identifier | ThisMemberExpression;
 
-export const getV2ClientIdentifiers = (
+export const getClientIdentifiers = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: GetV2ClientIdentifiersOptions
-): V2ClientIdentifier[] => {
+  options: GetClientIdentifiersOptions
+): ClientIdentifier[] => {
   const namesFromNewExpr = getV2ClientIdNamesFromNewExpr(j, source, options);
   const namesFromTSTypeRef = getV2ClientIdNamesFromTSTypeRef(j, source, options);
   const clientIdNames = [...new Set([...namesFromNewExpr, ...namesFromTSTypeRef])];
 
-  const v2ClientIdentifiers: Identifier[] = clientIdNames.map((clientidName) => ({
+  const clientIdentifiers: Identifier[] = clientIdNames.map((clientidName) => ({
     type: "Identifier",
     name: clientidName,
   }));
-  const v2ClientIdThisExpressions = getV2ClientIdThisExpressions(j, source, v2ClientIdentifiers);
+  const clientIdThisExpressions = getV2ClientIdThisExpressions(j, source, clientIdentifiers);
 
-  return [...v2ClientIdentifiers, ...v2ClientIdThisExpressions];
+  return [...clientIdentifiers, ...clientIdThisExpressions];
 };

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
@@ -1,7 +1,7 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
+import { getClientIdNamesFromNewExpr } from "./getClientIdNamesFromNewExpr";
 import { getClientIdThisExpressions, ThisMemberExpression } from "./getClientIdThisExpressions";
-import { getV2ClientIdNamesFromNewExpr } from "./getV2ClientIdNamesFromNewExpr";
 import { getV2ClientIdNamesFromTSTypeRef } from "./getV2ClientIdNamesFromTSTypeRef";
 
 export interface GetClientIdentifiersOptions {
@@ -17,7 +17,7 @@ export const getClientIdentifiers = (
   source: Collection<unknown>,
   options: GetClientIdentifiersOptions
 ): ClientIdentifier[] => {
-  const namesFromNewExpr = getV2ClientIdNamesFromNewExpr(j, source, options);
+  const namesFromNewExpr = getClientIdNamesFromNewExpr(j, source, options);
   const namesFromTSTypeRef = getV2ClientIdNamesFromTSTypeRef(j, source, options);
   const clientIdNames = [...new Set([...namesFromNewExpr, ...namesFromTSTypeRef])];
 

--- a/src/transforms/v2-to-v3/apis/getClientS3UploadCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getClientS3UploadCallExpression.ts
@@ -2,14 +2,12 @@ import { CallExpression } from "jscodeshift";
 
 import { ClientIdentifier } from "./getClientIdentifiers";
 
-export const getV2ClientS3UploadCallExpression = (
-  v2ClientId: ClientIdentifier
-  // @ts-expect-error Property 'arguments' is missing in type
-): CallExpression => ({
+// @ts-expect-error Property 'arguments' is missing in type
+export const getClientS3UploadCallExpression = (clientId: ClientIdentifier): CallExpression => ({
   type: "CallExpression",
   callee: {
     type: "MemberExpression",
-    object: v2ClientId,
+    object: clientId,
     property: { type: "Identifier", name: "upload" },
   },
 });

--- a/src/transforms/v2-to-v3/apis/getClientWaiterCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getClientWaiterCallExpression.ts
@@ -2,7 +2,7 @@ import { CallExpression } from "jscodeshift";
 
 import { ClientIdentifier } from "./getClientIdentifiers";
 
-export const getV2ClientWaiterCallExpression = (
+export const getClientWaiterCallExpression = (
   v2ClientId: ClientIdentifier,
   waiterState: string
 ): CallExpression => ({

--- a/src/transforms/v2-to-v3/apis/getClientWaiterStates.ts
+++ b/src/transforms/v2-to-v3/apis/getClientWaiterStates.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
+import { getClientIdentifiers } from "./getClientIdentifiers";
 
 export interface GetClientWaiterStatesOptions {
   v2ClientName: string;
@@ -15,14 +15,14 @@ export const getClientWaiterStates = (
 ): Set<string> => {
   const waiterStates: string[] = [];
 
-  const v2ClientIdentifiers = getV2ClientIdentifiers(j, source, options);
+  const clientIdentifiers = getClientIdentifiers(j, source, options);
 
-  for (const v2ClientId of v2ClientIdentifiers) {
+  for (const clientId of clientIdentifiers) {
     source
       .find(j.CallExpression, {
         callee: {
           type: "MemberExpression",
-          object: v2ClientId,
+          object: clientId,
           property: { type: "Identifier", name: "waitFor" },
         },
       })

--- a/src/transforms/v2-to-v3/apis/getS3UploadCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getS3UploadCallExpression.ts
@@ -3,7 +3,7 @@ import { CallExpression } from "jscodeshift";
 import { ClientIdentifier } from "./getClientIdentifiers";
 
 // @ts-expect-error Property 'arguments' is missing in type
-export const getClientS3UploadCallExpression = (clientId: ClientIdentifier): CallExpression => ({
+export const getS3UploadCallExpression = (clientId: ClientIdentifier): CallExpression => ({
   type: "CallExpression",
   callee: {
     type: "MemberExpression",

--- a/src/transforms/v2-to-v3/apis/getV2ClientS3UploadCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getV2ClientS3UploadCallExpression.ts
@@ -1,9 +1,9 @@
 import { CallExpression } from "jscodeshift";
 
-import { V2ClientIdentifier } from "./getV2ClientIdentifiers";
+import { ClientIdentifier } from "./getClientIdentifiers";
 
 export const getV2ClientS3UploadCallExpression = (
-  v2ClientId: V2ClientIdentifier
+  v2ClientId: ClientIdentifier
   // @ts-expect-error Property 'arguments' is missing in type
 ): CallExpression => ({
   type: "CallExpression",

--- a/src/transforms/v2-to-v3/apis/getV2ClientWaiterCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getV2ClientWaiterCallExpression.ts
@@ -1,9 +1,9 @@
 import { CallExpression } from "jscodeshift";
 
-import { V2ClientIdentifier } from "./getV2ClientIdentifiers";
+import { ClientIdentifier } from "./getClientIdentifiers";
 
 export const getV2ClientWaiterCallExpression = (
-  v2ClientId: V2ClientIdentifier,
+  v2ClientId: ClientIdentifier,
   waiterState: string
 ): CallExpression => ({
   type: "CallExpression",

--- a/src/transforms/v2-to-v3/apis/isS3UploadApiUsed.ts
+++ b/src/transforms/v2-to-v3/apis/isS3UploadApiUsed.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
+import { getClientIdentifiers } from "./getClientIdentifiers";
 
 export interface IsS3UploadApiUsedOptions {
   v2ClientName: string;
@@ -15,13 +15,13 @@ export const isS3UploadApiUsed = (
 ) => {
   if (options.v2ClientName !== "S3") return false;
 
-  const v2ClientIdentifiers = getV2ClientIdentifiers(j, source, options);
+  const clientIdentifiers = getClientIdentifiers(j, source, options);
 
-  for (const v2ClientId of v2ClientIdentifiers) {
+  for (const clientId of clientIdentifiers) {
     const s3UploadCallExpressions = source.find(j.CallExpression, {
       callee: {
         type: "MemberExpression",
-        object: v2ClientId,
+        object: clientId,
         property: { type: "Identifier", name: "upload" },
       },
     });

--- a/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
-import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
+import { getClientIdentifiers } from "./getClientIdentifiers";
 import { removePromiseForCallExpression } from "./removePromiseForCallExpression";
 
 export interface RemovePromiseCallsOptions {
@@ -15,9 +15,9 @@ export const removePromiseCalls = (
   source: Collection<unknown>,
   options: RemovePromiseCallsOptions
 ): void => {
-  const v2ClientIdentifiers = getV2ClientIdentifiers(j, source, options);
+  const clientIdentifiers = getClientIdentifiers(j, source, options);
 
-  for (const v2ClientId of v2ClientIdentifiers) {
+  for (const clientId of clientIdentifiers) {
     // Remove .promise() from client API calls.
     source
       .find(j.CallExpression, {
@@ -27,7 +27,7 @@ export const removePromiseCalls = (
             type: "CallExpression",
             callee: {
               type: "MemberExpression",
-              object: v2ClientId,
+              object: clientId,
             },
           },
           property: { type: "Identifier", name: "promise" },
@@ -45,7 +45,7 @@ export const removePromiseCalls = (
           type: "CallExpression",
           callee: {
             type: "MemberExpression",
-            object: v2ClientId,
+            object: clientId,
           },
         },
       })

--- a/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
@@ -1,7 +1,7 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 import { getClientIdentifiers } from "./getClientIdentifiers";
-import { getClientS3UploadCallExpression } from "./getClientS3UploadCallExpression";
+import { getS3UploadCallExpression } from "./getS3UploadCallExpression";
 
 export interface ReplaceS3UploadApiOptions {
   v2ClientName: string;
@@ -21,7 +21,7 @@ export const replaceS3UploadApi = (
 
   for (const clientId of clientIdentifiers) {
     source
-      .find(j.CallExpression, getClientS3UploadCallExpression(clientId))
+      .find(j.CallExpression, getS3UploadCallExpression(clientId))
       .replaceWith((callExpression) => {
         const params = callExpression.node.arguments[0];
 

--- a/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
-import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
+import { getClientIdentifiers } from "./getClientIdentifiers";
 import { getV2ClientS3UploadCallExpression } from "./getV2ClientS3UploadCallExpression";
 
 export interface ReplaceS3UploadApiOptions {
@@ -17,11 +17,11 @@ export const replaceS3UploadApi = (
 ): void => {
   if (options.v2ClientName !== "S3") return;
 
-  const v2ClientIdentifiers = getV2ClientIdentifiers(j, source, options);
+  const clientIdentifiers = getClientIdentifiers(j, source, options);
 
-  for (const v2ClientId of v2ClientIdentifiers) {
+  for (const clientId of clientIdentifiers) {
     source
-      .find(j.CallExpression, getV2ClientS3UploadCallExpression(v2ClientId))
+      .find(j.CallExpression, getV2ClientS3UploadCallExpression(clientId))
       .replaceWith((callExpression) => {
         const params = callExpression.node.arguments[0];
 
@@ -29,7 +29,7 @@ export const replaceS3UploadApi = (
         properties.push(
           j.objectProperty.from({
             key: j.identifier("client"),
-            value: v2ClientId,
+            value: clientId,
             shorthand: true,
           })
         );

--- a/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
@@ -1,7 +1,7 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 import { getClientIdentifiers } from "./getClientIdentifiers";
-import { getV2ClientS3UploadCallExpression } from "./getV2ClientS3UploadCallExpression";
+import { getClientS3UploadCallExpression } from "./getClientS3UploadCallExpression";
 
 export interface ReplaceS3UploadApiOptions {
   v2ClientName: string;
@@ -21,7 +21,7 @@ export const replaceS3UploadApi = (
 
   for (const clientId of clientIdentifiers) {
     source
-      .find(j.CallExpression, getV2ClientS3UploadCallExpression(clientId))
+      .find(j.CallExpression, getClientS3UploadCallExpression(clientId))
       .replaceWith((callExpression) => {
         const params = callExpression.node.arguments[0];
 

--- a/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
@@ -2,8 +2,8 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getArgsWithoutWaiterConfig } from "./getArgsWithoutWaiterConfig";
 import { getClientIdentifiers } from "./getClientIdentifiers";
+import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";
-import { getV2ClientWaiterCallExpression } from "./getV2ClientWaiterCallExpression";
 import { getV3ClientWaiterApiName } from "./getV3ClientWaiterApiName";
 import { getWaiterConfig } from "./getWaiterConfig";
 import { getWaiterConfigValue } from "./getWaiterConfigValue";
@@ -28,7 +28,7 @@ export const replaceWaiterApi = (
     for (const waiterState of waiterStates) {
       const v3WaiterApiName = getV3ClientWaiterApiName(waiterState);
       source
-        .find(j.CallExpression, getV2ClientWaiterCallExpression(clientId, waiterState))
+        .find(j.CallExpression, getClientWaiterCallExpression(clientId, waiterState))
         .replaceWith((callExpression) => {
           const waiterConfig = getWaiterConfig(callExpression.node.arguments[1]);
           const delay = getWaiterConfigValue(waiterConfig, "delay");

--- a/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
@@ -1,8 +1,8 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getArgsWithoutWaiterConfig } from "./getArgsWithoutWaiterConfig";
+import { getClientIdentifiers } from "./getClientIdentifiers";
 import { getClientWaiterStates } from "./getClientWaiterStates";
-import { getV2ClientIdentifiers } from "./getV2ClientIdentifiers";
 import { getV2ClientWaiterCallExpression } from "./getV2ClientWaiterCallExpression";
 import { getV3ClientWaiterApiName } from "./getV3ClientWaiterApiName";
 import { getWaiterConfig } from "./getWaiterConfig";
@@ -20,15 +20,15 @@ export const replaceWaiterApi = (
   source: Collection<unknown>,
   options: ReplaceWaiterApiOptions
 ): void => {
-  const v2ClientIdentifiers = getV2ClientIdentifiers(j, source, options);
+  const clientIdentifiers = getClientIdentifiers(j, source, options);
 
-  for (const v2ClientId of v2ClientIdentifiers) {
+  for (const clientId of clientIdentifiers) {
     const waiterStates = getClientWaiterStates(j, source, options);
 
     for (const waiterState of waiterStates) {
       const v3WaiterApiName = getV3ClientWaiterApiName(waiterState);
       source
-        .find(j.CallExpression, getV2ClientWaiterCallExpression(v2ClientId, waiterState))
+        .find(j.CallExpression, getV2ClientWaiterCallExpression(clientId, waiterState))
         .replaceWith((callExpression) => {
           const waiterConfig = getWaiterConfig(callExpression.node.arguments[1]);
           const delay = getWaiterConfigValue(waiterConfig, "delay");
@@ -38,7 +38,7 @@ export const replaceWaiterApi = (
           properties.push(
             j.objectProperty.from({
               key: j.identifier("client"),
-              value: v2ClientId,
+              value: clientId,
               shorthand: true,
             })
           );


### PR DESCRIPTION
### Issue

Refs: https://github.com/awslabs/aws-sdk-js-codemod/issues/451

### Description

Remove v2 and v3 from utility names in apis folder

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
