### PR TITLE
Remove v2 and v3 from utility names in utils folder

### DIFF
--- a/src/transforms/v2-to-v3/apis/getV2ClientIdNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/apis/getV2ClientIdNamesFromNewExpr.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, JSCodeshift, NewExpression } from "jscodeshift";
 
-import { getV2ClientNewExpression } from "../utils";
+import { getClientNewExpression } from "../utils";
 
 export interface GetV2ClientIdNamesFromNewExprOptions {
   v2ClientName: string;
@@ -45,11 +45,11 @@ export const getV2ClientIdNamesFromNewExpr = (
   for (const getNames of [getNamesFromVariableDeclarator, getNamesFromAssignmentPattern]) {
     if (v2GlobalName) {
       namesFromGlobalModule.push(
-        ...getNames(j, source, getV2ClientNewExpression({ v2GlobalName, v2ClientName }))
+        ...getNames(j, source, getClientNewExpression({ v2GlobalName, v2ClientName }))
       );
     }
     namesFromServiceModule.push(
-      ...getNames(j, source, getV2ClientNewExpression({ v2ClientLocalName }))
+      ...getNames(j, source, getClientNewExpression({ v2ClientLocalName }))
     );
   }
 

--- a/src/transforms/v2-to-v3/client-instances/replaceClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceClientCreation.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV2ClientNewExpression } from "../utils";
+import { getClientNewExpression } from "../utils";
 
 export interface ReplaceClientCreationOptions {
   v2ClientName: string;
@@ -15,7 +15,7 @@ export const replaceClientCreation = (
   { v2ClientName, v2ClientLocalName, v2GlobalName }: ReplaceClientCreationOptions
 ): void => {
   source
-    .find(j.NewExpression, getV2ClientNewExpression({ v2GlobalName, v2ClientName }))
+    .find(j.NewExpression, getClientNewExpression({ v2GlobalName, v2ClientName }))
     .replaceWith((v2ClientNewExpression) =>
       j.newExpression(j.identifier(v2ClientLocalName), v2ClientNewExpression.node.arguments)
     );

--- a/src/transforms/v2-to-v3/client-names/getNamesFromNewExpr.ts
+++ b/src/transforms/v2-to-v3/client-names/getNamesFromNewExpr.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, JSCodeshift, MemberExpression } from "jscodeshift";
 
-import { getV2ClientNewExpression } from "../utils";
+import { getClientNewExpression } from "../utils";
 
 export const getNamesFromNewExpr = (
   j: JSCodeshift,
@@ -8,7 +8,7 @@ export const getNamesFromNewExpr = (
   v2GlobalName: string
 ): string[] =>
   source
-    .find(j.NewExpression, getV2ClientNewExpression({ v2GlobalName }))
+    .find(j.NewExpression, getClientNewExpression({ v2GlobalName }))
     .nodes()
     .map(
       (newExpression) => ((newExpression.callee as MemberExpression).property as Identifier).name

--- a/src/transforms/v2-to-v3/modules/getClientTSTypeRefCount.ts
+++ b/src/transforms/v2-to-v3/modules/getClientTSTypeRefCount.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV2ClientTSTypeRef } from "../utils";
+import { getClientTSTypeRef } from "../utils";
 import { ClientModulesOptions } from "./types";
 
 export const getClientTSTypeRefCount = (
@@ -13,14 +13,14 @@ export const getClientTSTypeRefCount = (
   if (v2GlobalName) {
     const clienTSTypeRefFromGlobalName = source.find(
       j.TSTypeReference,
-      getV2ClientTSTypeRef({ v2ClientName, v2GlobalName })
+      getClientTSTypeRef({ v2ClientName, v2GlobalName })
     );
     clientTSTypeRefCount += clienTSTypeRefFromGlobalName.length;
   }
 
   const clienTSTypeRefFromClientLocalName = source.find(
     j.TSTypeReference,
-    getV2ClientTSTypeRef({ v2ClientLocalName })
+    getClientTSTypeRef({ v2ClientLocalName })
   );
   clientTSTypeRefCount += clienTSTypeRefFromClientLocalName.length;
 

--- a/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV2ClientNewExpression } from "../utils";
+import { getClientNewExpression } from "../utils";
 import { ClientModulesOptions } from "./types";
 
 export const getNewExpressionCount = (
@@ -13,14 +13,14 @@ export const getNewExpressionCount = (
   if (v2GlobalName) {
     const newExpressionsFromGlobalName = source.find(
       j.NewExpression,
-      getV2ClientNewExpression({ v2ClientName, v2GlobalName })
+      getClientNewExpression({ v2ClientName, v2GlobalName })
     );
     newExpressionCount += newExpressionsFromGlobalName.length;
   }
 
   const newExpressionsFromClientLocalName = source.find(
     j.NewExpression,
-    getV2ClientNewExpression({ v2ClientLocalName })
+    getClientNewExpression({ v2ClientLocalName })
   );
   newExpressionCount += newExpressionsFromClientLocalName.length;
 

--- a/src/transforms/v2-to-v3/ts-type/getV2ClientTypeNames.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV2ClientTypeNames.ts
@@ -1,7 +1,7 @@
 import { Collection, Identifier, JSCodeshift, TSQualifiedName, TSTypeReference } from "jscodeshift";
 
 import { getImportSpecifiers } from "../modules";
-import { getV2ClientTSTypeRef, getV2ServiceModulePath } from "../utils";
+import { getClientTSTypeRef, getV2ServiceModulePath } from "../utils";
 
 export interface GetV2ClientTypeNamesOptions {
   v2ClientName: string;
@@ -29,7 +29,7 @@ export const getV2ClientTypeNames = (
   const v2ClientTypeNames = [];
 
   if (v2GlobalName) {
-    const v2GlobalTSTypeRef = getV2ClientTSTypeRef({
+    const v2GlobalTSTypeRef = getClientTSTypeRef({
       v2ClientName,
       v2GlobalName,
       withoutRightSection: true,
@@ -37,7 +37,7 @@ export const getV2ClientTypeNames = (
     v2ClientTypeNames.push(...getRightIdentifierName(j, source, v2GlobalTSTypeRef));
   }
 
-  const v2ClientTSTypeRef = getV2ClientTSTypeRef({ v2ClientLocalName, withoutRightSection: true });
+  const v2ClientTSTypeRef = getClientTSTypeRef({ v2ClientLocalName, withoutRightSection: true });
   v2ClientTypeNames.push(...getRightIdentifierName(j, source, v2ClientTSTypeRef));
 
   v2ClientTypeNames.push(

--- a/src/transforms/v2-to-v3/ts-type/getV2ClientTypeNames.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV2ClientTypeNames.ts
@@ -29,16 +29,16 @@ export const getV2ClientTypeNames = (
   const v2ClientTypeNames = [];
 
   if (v2GlobalName) {
-    const v2GlobalTSTypeRef = getClientTSTypeRef({
+    const globalTSTypeRef = getClientTSTypeRef({
       v2ClientName,
       v2GlobalName,
       withoutRightSection: true,
     });
-    v2ClientTypeNames.push(...getRightIdentifierName(j, source, v2GlobalTSTypeRef));
+    v2ClientTypeNames.push(...getRightIdentifierName(j, source, globalTSTypeRef));
   }
 
-  const v2ClientTSTypeRef = getClientTSTypeRef({ v2ClientLocalName, withoutRightSection: true });
-  v2ClientTypeNames.push(...getRightIdentifierName(j, source, v2ClientTSTypeRef));
+  const clientTSTypeRef = getClientTSTypeRef({ v2ClientLocalName, withoutRightSection: true });
+  v2ClientTypeNames.push(...getRightIdentifierName(j, source, clientTSTypeRef));
 
   v2ClientTypeNames.push(
     ...getImportSpecifiers(j, source, getV2ServiceModulePath(v2ClientName))

--- a/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, JSCodeshift, TSQualifiedName, TSTypeReference } from "jscodeshift";
 
-import { getV2ClientTSTypeRef } from "../utils";
+import { getClientTSTypeRef } from "../utils";
 import { getV2ClientTypeNames } from "./getV2ClientTypeNames";
 import { getV3ClientTypeReference } from "./getV3ClientTypeReference";
 
@@ -28,7 +28,7 @@ export const replaceTSTypeReference = (
   // Replace type reference to client created with global name.
   if (v2GlobalName) {
     source
-      .find(j.TSTypeReference, getV2ClientTSTypeRef({ v2ClientName, v2GlobalName }))
+      .find(j.TSTypeReference, getClientTSTypeRef({ v2ClientName, v2GlobalName }))
       .replaceWith((v2ClientType) =>
         j.tsTypeReference(j.identifier(v3ClientName), v2ClientType.node.typeParameters)
       );
@@ -37,7 +37,7 @@ export const replaceTSTypeReference = (
     source
       .find(
         j.TSTypeReference,
-        getV2ClientTSTypeRef({ v2ClientName, v2GlobalName, withoutRightSection: true })
+        getClientTSTypeRef({ v2ClientName, v2GlobalName, withoutRightSection: true })
       )
       .filter((v2ClientType) => isRightSectionIdentifier(v2ClientType.node))
       .replaceWith((v2ClientType) => {
@@ -48,7 +48,7 @@ export const replaceTSTypeReference = (
 
   // Replace reference to client types created with client module.
   source
-    .find(j.TSTypeReference, getV2ClientTSTypeRef({ v2ClientLocalName, withoutRightSection: true }))
+    .find(j.TSTypeReference, getClientTSTypeRef({ v2ClientLocalName, withoutRightSection: true }))
     .filter((v2ClientType) => isRightSectionIdentifier(v2ClientType.node))
     .replaceWith((v2ClientType) => {
       const v2ClientTypeName = getRightIdentifierName(v2ClientType.node);

--- a/src/transforms/v2-to-v3/utils/getClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/getClientNewExpression.ts
@@ -6,7 +6,7 @@ export interface ClientNewExpressionOptions {
   v2GlobalName?: string;
 }
 
-export const getV2ClientNewExpression = ({
+export const getClientNewExpression = ({
   v2ClientLocalName,
   v2ClientName,
   v2GlobalName,

--- a/src/transforms/v2-to-v3/utils/getClientNewExpression.ts
+++ b/src/transforms/v2-to-v3/utils/getClientNewExpression.ts
@@ -1,6 +1,6 @@
 import { NewExpression } from "jscodeshift";
 
-export interface ClientNewExpressionOptions {
+export interface GetClientNewExpressionOptions {
   v2ClientLocalName?: string;
   v2ClientName?: string;
   v2GlobalName?: string;
@@ -10,7 +10,7 @@ export const getClientNewExpression = ({
   v2ClientLocalName,
   v2ClientName,
   v2GlobalName,
-}: ClientNewExpressionOptions): NewExpression => {
+}: GetClientNewExpressionOptions): NewExpression => {
   if (!v2GlobalName && !v2ClientLocalName) {
     throw new Error(
       `One of the following options must be provided: v2ClientLocalName, v2GlobalName`

--- a/src/transforms/v2-to-v3/utils/getClientTSTypeRef.ts
+++ b/src/transforms/v2-to-v3/utils/getClientTSTypeRef.ts
@@ -1,18 +1,18 @@
 import { Identifier, TSQualifiedName, TSTypeReference } from "jscodeshift";
 
-export interface V2ClientTsTypeRefOptions {
+export interface GetClientTsTypeRefOptions {
   v2ClientLocalName?: string;
   v2ClientName?: string;
   v2GlobalName?: string;
   withoutRightSection?: boolean;
 }
 
-export const getV2ClientTSTypeRef = ({
+export const getClientTSTypeRef = ({
   v2ClientLocalName,
   v2ClientName,
   v2GlobalName,
   withoutRightSection = false,
-}: V2ClientTsTypeRefOptions): TSTypeReference => {
+}: GetClientTsTypeRefOptions): TSTypeReference => {
   if (!v2GlobalName && !v2ClientLocalName) {
     throw new Error(
       `One of the following options must be provided: v2ClientLocalName, v2GlobalName`

--- a/src/transforms/v2-to-v3/utils/index.ts
+++ b/src/transforms/v2-to-v3/utils/index.ts
@@ -1,5 +1,5 @@
 export * from "./getClientNewExpression";
-export * from "./getV2ClientTSTypeRef";
+export * from "./getClientTSTypeRef";
 export * from "./getV2ServiceModulePath";
 export * from "./getV3DefaultLocalName";
 export * from "./isTypeScriptFile";

--- a/src/transforms/v2-to-v3/utils/index.ts
+++ b/src/transforms/v2-to-v3/utils/index.ts
@@ -1,4 +1,4 @@
-export * from "./getV2ClientNewExpression";
+export * from "./getClientNewExpression";
 export * from "./getV2ClientTSTypeRef";
 export * from "./getV2ServiceModulePath";
 export * from "./getV3DefaultLocalName";


### PR DESCRIPTION
### Issue

Refs: https://github.com/awslabs/aws-sdk-js-codemod/issues/451

### Description

Remove v2 and v3 from utility names in utils folder

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
