### PR TITLE
Rename getV2ServiceModulePath to getClientDeepImportPath

### DIFF
--- a/src/transforms/v2-to-v3/client-names/getV2ClientNamesRecordFromImport.ts
+++ b/src/transforms/v2-to-v3/client-names/getV2ClientNamesRecordFromImport.ts
@@ -3,7 +3,7 @@ import { Collection, Identifier, ImportSpecifier, JSCodeshift } from "jscodeshif
 import { CLIENT_NAMES, PACKAGE_NAME } from "../config";
 import { getImportEqualsDeclaration } from "../modules";
 import { getImportSpecifiers } from "../modules";
-import { getV2ServiceModulePath } from "../utils";
+import { getClientDeepImportPath } from "../utils";
 
 export const getV2ClientNamesRecordFromImport = (
   j: JSCodeshift,
@@ -25,7 +25,7 @@ export const getV2ClientNamesRecordFromImport = (
   }
 
   for (const clientName of v2ClientNamesWithServiceModule) {
-    const deepImportPath = getV2ServiceModulePath(clientName);
+    const deepImportPath = getClientDeepImportPath(clientName);
 
     const specifiersFromDeepImport = getImportSpecifiers(j, source, deepImportPath).filter(
       (specifier) =>

--- a/src/transforms/v2-to-v3/client-names/getV2ClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/client-names/getV2ClientNamesRecordFromRequire.ts
@@ -58,8 +58,8 @@ export const getV2ClientNamesRecordFromRequire = (
   }
 
   for (const clientName of v2ClientNamesWithServiceModule) {
-    const deepRequirePath = getClientDeepImportPath(clientName);
-    const idsFromDefaultImport = getRequireIds(j, source, deepRequirePath).filter(
+    const deepImportPath = getClientDeepImportPath(clientName);
+    const idsFromDefaultImport = getRequireIds(j, source, deepImportPath).filter(
       (id) => id.type === "Identifier"
     );
     if (idsFromDefaultImport.length) {

--- a/src/transforms/v2-to-v3/client-names/getV2ClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/client-names/getV2ClientNamesRecordFromRequire.ts
@@ -9,7 +9,7 @@ import {
 
 import { CLIENT_NAMES, OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME } from "../config";
 import { getRequireDeclaratorsWithProperty } from "../modules";
-import { getV2ServiceModulePath } from "../utils";
+import { getClientDeepImportPath } from "../utils";
 import { getRequireIds } from "./getRequireIds";
 
 export const getV2ClientNamesRecordFromRequire = (
@@ -58,7 +58,7 @@ export const getV2ClientNamesRecordFromRequire = (
   }
 
   for (const clientName of v2ClientNamesWithServiceModule) {
-    const deepRequirePath = getV2ServiceModulePath(clientName);
+    const deepRequirePath = getClientDeepImportPath(clientName);
     const idsFromDefaultImport = getRequireIds(j, source, deepRequirePath).filter(
       (id) => id.type === "Identifier"
     );

--- a/src/transforms/v2-to-v3/modules/getV2ImportDeclaration.ts
+++ b/src/transforms/v2-to-v3/modules/getV2ImportDeclaration.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
-import { getV2ServiceModulePath } from "../utils";
+import { getClientDeepImportPath } from "../utils";
 
 export interface GetV2ImportDeclarationOptions {
   v2ClientName: string;
@@ -29,7 +29,7 @@ export const getV2ImportDeclaration = (
     }
 
     if (
-      sourceValue === getV2ServiceModulePath(v2ClientName) &&
+      sourceValue === getClientDeepImportPath(v2ClientName) &&
       importDeclaration.value.specifiers?.some(
         (specifier) =>
           ["ImportNamespaceSpecifier", "ImportDefaultSpecifier"].includes(specifier.type) &&

--- a/src/transforms/v2-to-v3/modules/getV2ImportEqualsDeclaration.ts
+++ b/src/transforms/v2-to-v3/modules/getV2ImportEqualsDeclaration.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift, TSExternalModuleReference } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
-import { getV2ServiceModulePath } from "../utils";
+import { getClientDeepImportPath } from "../utils";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 
 export interface GetV2ImportEqualsDeclarationOptions {
@@ -29,7 +29,7 @@ export const getV2ImportEqualsDeclaration = (
       }
 
       if (
-        expressionValue === getV2ServiceModulePath(v2ClientName) &&
+        expressionValue === getClientDeepImportPath(v2ClientName) &&
         identifierName === v2ClientLocalName
       ) {
         return true;

--- a/src/transforms/v2-to-v3/modules/getV2RequireDeclarator.ts
+++ b/src/transforms/v2-to-v3/modules/getV2RequireDeclarator.ts
@@ -46,10 +46,9 @@ export const getV2RequireDeclarator = (
     return requireDeclaratorsWithProperty;
   }
 
-  const v2ServiceModulePath = getClientDeepImportPath(v2ClientName);
   const requireDeclaratorsWithIdentifier = getRequireDeclaratorsWithIdentifier(j, source, {
     identifierName: v2ClientLocalName,
-    sourceValue: v2ServiceModulePath,
+    sourceValue: getClientDeepImportPath(v2ClientName),
   });
 
   if (requireDeclaratorsWithIdentifier.size() > 0) {

--- a/src/transforms/v2-to-v3/modules/getV2RequireDeclarator.ts
+++ b/src/transforms/v2-to-v3/modules/getV2RequireDeclarator.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
-import { getV2ServiceModulePath } from "../utils";
+import { getClientDeepImportPath } from "../utils";
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";
 import { getRequireDeclaratorsWithObjectPattern } from "./getRequireDeclaratorsWithObjectPattern";
 import { getRequireDeclaratorsWithProperty } from "./getRequireDeclaratorsWithProperty";
@@ -46,7 +46,7 @@ export const getV2RequireDeclarator = (
     return requireDeclaratorsWithProperty;
   }
 
-  const v2ServiceModulePath = getV2ServiceModulePath(v2ClientName);
+  const v2ServiceModulePath = getClientDeepImportPath(v2ClientName);
   const requireDeclaratorsWithIdentifier = getRequireDeclaratorsWithIdentifier(j, source, {
     identifierName: v2ClientLocalName,
     sourceValue: v2ServiceModulePath,

--- a/src/transforms/v2-to-v3/modules/removeV2ClientModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeV2ClientModule.ts
@@ -24,9 +24,9 @@ export const removeV2ClientModule = (
   options: RemoveV2ClientModuleOptions
 ) => {
   const { v2ClientName, v2ClientLocalName } = options;
-  const serviceModulePath = getClientDeepImportPath(v2ClientName);
+  const deepImportPath = getClientDeepImportPath(v2ClientName);
 
-  const defaultOptions = { localName: v2ClientLocalName, sourceValue: serviceModulePath };
+  const defaultOptions = { localName: v2ClientLocalName, sourceValue: deepImportPath };
   const namedOptions = { localName: v2ClientLocalName, sourceValue: PACKAGE_NAME };
 
   if (hasRequire(j, source)) {
@@ -43,7 +43,7 @@ export const removeV2ClientModule = (
     for (const v2ClientTypeName of v2ClientTypeNames) {
       removeImportNamed(j, source, {
         localName: v2ClientTypeName,
-        sourceValue: serviceModulePath,
+        sourceValue: deepImportPath,
       });
     }
   }

--- a/src/transforms/v2-to-v3/modules/removeV2ClientModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeV2ClientModule.ts
@@ -2,7 +2,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
 import { getV2ClientTypeNames } from "../ts-type";
-import { getV2ServiceModulePath } from "../utils";
+import { getClientDeepImportPath } from "../utils";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { removeImportDefault } from "./removeImportDefault";
@@ -24,7 +24,7 @@ export const removeV2ClientModule = (
   options: RemoveV2ClientModuleOptions
 ) => {
   const { v2ClientName, v2ClientLocalName } = options;
-  const serviceModulePath = getV2ServiceModulePath(v2ClientName);
+  const serviceModulePath = getClientDeepImportPath(v2ClientName);
 
   const defaultOptions = { localName: v2ClientLocalName, sourceValue: serviceModulePath };
   const namedOptions = { localName: v2ClientLocalName, sourceValue: PACKAGE_NAME };

--- a/src/transforms/v2-to-v3/ts-type/getV2ClientTypeNames.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV2ClientTypeNames.ts
@@ -1,7 +1,7 @@
 import { Collection, Identifier, JSCodeshift, TSQualifiedName, TSTypeReference } from "jscodeshift";
 
 import { getImportSpecifiers } from "../modules";
-import { getClientTSTypeRef, getV2ServiceModulePath } from "../utils";
+import { getClientDeepImportPath, getClientTSTypeRef } from "../utils";
 
 export interface GetV2ClientTypeNamesOptions {
   v2ClientName: string;
@@ -41,7 +41,7 @@ export const getV2ClientTypeNames = (
   v2ClientTypeNames.push(...getRightIdentifierName(j, source, clientTSTypeRef));
 
   v2ClientTypeNames.push(
-    ...getImportSpecifiers(j, source, getV2ServiceModulePath(v2ClientName))
+    ...getImportSpecifiers(j, source, getClientDeepImportPath(v2ClientName))
       .filter(
         (importSpecifier) =>
           importSpecifier.type === "ImportSpecifier" &&

--- a/src/transforms/v2-to-v3/utils/getClientDeepImportPath.ts
+++ b/src/transforms/v2-to-v3/utils/getClientDeepImportPath.ts
@@ -1,4 +1,4 @@
 import { PACKAGE_NAME } from "../config";
 
-export const getV2ServiceModulePath = (v2ClientName: string) =>
+export const getClientDeepImportPath = (v2ClientName: string) =>
   `${PACKAGE_NAME}/clients/${v2ClientName.toLowerCase()}`;

--- a/src/transforms/v2-to-v3/utils/index.ts
+++ b/src/transforms/v2-to-v3/utils/index.ts
@@ -1,5 +1,5 @@
+export * from "./getClientDeepImportPath";
 export * from "./getClientNewExpression";
 export * from "./getClientTSTypeRef";
-export * from "./getV2ServiceModulePath";
 export * from "./getV3DefaultLocalName";
 export * from "./isTypeScriptFile";


### PR DESCRIPTION
### Issue

Refs: https://github.com/awslabs/aws-sdk-js-codemod/issues/451

### Description

Rename getV2ServiceModulePath to getClientDeepImportPath

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
