### PR TITLE
Rename getV3DefaultLocalName to getDefaultLocalName

### DIFF
--- a/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
@@ -10,8 +10,8 @@ export const addClientDefaultImport = (
   source: Collection<unknown>,
   { v2ClientLocalName, v2ClientName, v3ClientPackageName }: ClientModulesOptions
 ) => {
-  const localName = getDefaultLocalName(v2ClientLocalName);
-  const defaultImportSpecifier = j.importDefaultSpecifier(j.identifier(localName));
+  const defaultLocalName = getDefaultLocalName(v2ClientLocalName);
+  const defaultImportSpecifier = j.importDefaultSpecifier(j.identifier(defaultLocalName));
 
   const importDeclarations = source.find(j.ImportDeclaration, {
     source: { value: v3ClientPackageName },
@@ -22,7 +22,7 @@ export const addClientDefaultImport = (
   ) as ImportDefaultSpecifier[];
 
   if (importDeclarations.length) {
-    if (!importDefaultSpecifiers.find((specifier) => specifier?.local?.name === localName)) {
+    if (!importDefaultSpecifiers.find((specifier) => specifier?.local?.name === defaultLocalName)) {
       importDeclarations.nodes()[0].specifiers?.push(defaultImportSpecifier);
       return;
     }

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
@@ -1,6 +1,6 @@
 import { Collection, ImportDefaultSpecifier, JSCodeshift } from "jscodeshift";
 
-import { getV3DefaultLocalName } from "../utils";
+import { getDefaultLocalName } from "../utils";
 import { getImportSpecifiers } from "./getImportSpecifiers";
 import { getV2ImportDeclaration } from "./getV2ImportDeclaration";
 import { ClientModulesOptions } from "./types";
@@ -10,7 +10,7 @@ export const addClientDefaultImport = (
   source: Collection<unknown>,
   { v2ClientLocalName, v2ClientName, v3ClientPackageName }: ClientModulesOptions
 ) => {
-  const localName = getV3DefaultLocalName(v2ClientLocalName);
+  const localName = getDefaultLocalName(v2ClientLocalName);
   const defaultImportSpecifier = j.importDefaultSpecifier(j.identifier(localName));
 
   const importDeclarations = source.find(j.ImportDeclaration, {

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV3DefaultLocalName } from "../utils";
+import { getDefaultLocalName } from "../utils";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";
 import { getV2ImportEqualsDeclaration } from "./getV2ImportEqualsDeclaration";
@@ -12,7 +12,7 @@ export const addClientDefaultImportEquals = (
   { v2ClientLocalName, v2ClientName, v2GlobalName, v3ClientPackageName }: ClientModulesOptions
 ) => {
   const localNameSuffix = getImportEqualsLocalNameSuffix(v2ClientName, v3ClientPackageName);
-  const v3ClientDefaultLocalName = getV3DefaultLocalName(localNameSuffix);
+  const v3ClientDefaultLocalName = getDefaultLocalName(localNameSuffix);
   const existingImportEquals = source.find(
     j.TSImportEqualsDeclaration,
     getImportEqualsDeclaration(v3ClientPackageName)

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
@@ -12,7 +12,7 @@ export const addClientDefaultImportEquals = (
   { v2ClientLocalName, v2ClientName, v2GlobalName, v3ClientPackageName }: ClientModulesOptions
 ) => {
   const localNameSuffix = getImportEqualsLocalNameSuffix(v2ClientName, v3ClientPackageName);
-  const v3ClientDefaultLocalName = getDefaultLocalName(localNameSuffix);
+  const defaultLocalName = getDefaultLocalName(localNameSuffix);
   const existingImportEquals = source.find(
     j.TSImportEqualsDeclaration,
     getImportEqualsDeclaration(v3ClientPackageName)
@@ -22,9 +22,7 @@ export const addClientDefaultImportEquals = (
     if (
       existingImportEquals
         .nodes()
-        .some(
-          (importEqualsDeclaration) => importEqualsDeclaration.id.name === v3ClientDefaultLocalName
-        )
+        .some((importEqualsDeclaration) => importEqualsDeclaration.id.name === defaultLocalName)
     ) {
       return;
     }
@@ -38,7 +36,7 @@ export const addClientDefaultImportEquals = (
   }).at(0);
 
   const v3importEqualsDeclaration = j.tsImportEqualsDeclaration(
-    j.identifier(v3ClientDefaultLocalName),
+    j.identifier(defaultLocalName),
     j.tsExternalModuleReference(j.stringLiteral(v3ClientPackageName))
   );
 

--- a/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
@@ -10,7 +10,7 @@ export const addClientDefaultRequire = (
   source: Collection<unknown>,
   { v2ClientName, v2ClientLocalName, v3ClientPackageName, v2GlobalName }: ClientModulesOptions
 ) => {
-  const identifierName = getDefaultLocalName(v2ClientLocalName);
+  const defaultLocalName = getDefaultLocalName(v2ClientLocalName);
   const existingRequires = getRequireDeclarators(j, source, v3ClientPackageName);
 
   if (
@@ -21,7 +21,7 @@ export const addClientDefaultRequire = (
       .find(
         (variableDeclarator) =>
           variableDeclarator.id.type === "Identifier" &&
-          variableDeclarator.id.name === identifierName
+          variableDeclarator.id.name === defaultLocalName
       )
   ) {
     return;
@@ -32,7 +32,7 @@ export const addClientDefaultRequire = (
     getV2RequireDeclarator(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
 
   const v3RequireDeclarator = j.variableDeclarator(
-    j.identifier(identifierName),
+    j.identifier(defaultLocalName),
     j.callExpression(j.identifier("require"), [j.literal(v3ClientPackageName)])
   );
 

--- a/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV3DefaultLocalName } from "../utils";
+import { getDefaultLocalName } from "../utils";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 import { getV2RequireDeclarator } from "./getV2RequireDeclarator";
 import { ClientModulesOptions } from "./types";
@@ -10,7 +10,7 @@ export const addClientDefaultRequire = (
   source: Collection<unknown>,
   { v2ClientName, v2ClientLocalName, v3ClientPackageName, v2GlobalName }: ClientModulesOptions
 ) => {
-  const identifierName = getV3DefaultLocalName(v2ClientLocalName);
+  const identifierName = getDefaultLocalName(v2ClientLocalName);
   const existingRequires = getRequireDeclarators(j, source, v3ClientPackageName);
 
   if (

--- a/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getV3DefaultLocalName } from "../utils";
+import { getDefaultLocalName } from "../utils";
 import { addClientDefaultImportEquals } from "./addClientDefaultImportEquals";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";
@@ -17,7 +17,7 @@ export const addClientNamedImportEquals = (
   const { v2ClientName, v3ClientPackageName } = v3ClientModulesOptions;
 
   const localNameSuffix = getImportEqualsLocalNameSuffix(v2ClientName, v3ClientPackageName);
-  const v3ClientDefaultLocalName = getV3DefaultLocalName(localNameSuffix);
+  const v3ClientDefaultLocalName = getDefaultLocalName(localNameSuffix);
   const namedImportObjectProperty = getRequireProperty(j, { keyName, valueName });
 
   const existingVarDeclarator = source.find(j.VariableDeclarator, {

--- a/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
@@ -17,12 +17,12 @@ export const addClientNamedImportEquals = (
   const { v2ClientName, v3ClientPackageName } = v3ClientModulesOptions;
 
   const localNameSuffix = getImportEqualsLocalNameSuffix(v2ClientName, v3ClientPackageName);
-  const v3ClientDefaultLocalName = getDefaultLocalName(localNameSuffix);
+  const defaultLocalName = getDefaultLocalName(localNameSuffix);
   const namedImportObjectProperty = getRequireProperty(j, { keyName, valueName });
 
   const existingVarDeclarator = source.find(j.VariableDeclarator, {
     type: "VariableDeclarator",
-    init: { type: "Identifier", name: v3ClientDefaultLocalName },
+    init: { type: "Identifier", name: defaultLocalName },
   });
 
   if (existingVarDeclarator.size()) {
@@ -40,15 +40,14 @@ export const addClientNamedImportEquals = (
   const varDeclaration = j.variableDeclaration("const", [
     j.variableDeclarator(
       j.objectPattern([namedImportObjectProperty]),
-      j.identifier(v3ClientDefaultLocalName)
+      j.identifier(defaultLocalName)
     ),
   ]);
 
   const v3ClientImportEquals = source
     .find(j.TSImportEqualsDeclaration, importEqualsDeclaration)
     .filter(
-      (importEqualsDeclaration) =>
-        importEqualsDeclaration.value.id.name === v3ClientDefaultLocalName
+      (importEqualsDeclaration) => importEqualsDeclaration.value.id.name === defaultLocalName
     );
 
   if (v3ClientImportEquals.size() > 0) {

--- a/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift, ObjectPattern, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
-import { getV3DefaultLocalName } from "../utils";
+import { getDefaultLocalName } from "../utils";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";
 import { getRequireProperty } from "./getRequireProperty";
@@ -17,7 +17,7 @@ export const addClientNamedRequire = (
   const { keyName, v2ClientName, v2ClientLocalName, v2GlobalName, v3ClientPackageName } = options;
   const valueName = options.valueName ?? keyName;
 
-  const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientLocalName);
+  const v3ClientDefaultLocalName = getDefaultLocalName(v2ClientLocalName);
   const v3ClientObjectProperty = getRequireProperty(j, { keyName, valueName });
   const existingRequires = getRequireDeclarators(j, source, v3ClientPackageName);
 

--- a/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
@@ -17,8 +17,8 @@ export const addClientNamedRequire = (
   const { keyName, v2ClientName, v2ClientLocalName, v2GlobalName, v3ClientPackageName } = options;
   const valueName = options.valueName ?? keyName;
 
-  const v3ClientDefaultLocalName = getDefaultLocalName(v2ClientLocalName);
-  const v3ClientObjectProperty = getRequireProperty(j, { keyName, valueName });
+  const defaultLocalName = getDefaultLocalName(v2ClientLocalName);
+  const clientObjectProperty = getRequireProperty(j, { keyName, valueName });
   const existingRequires = getRequireDeclarators(j, source, v3ClientPackageName);
 
   if (existingRequires && existingRequires.nodes().length > 0) {
@@ -46,15 +46,15 @@ export const addClientNamedRequire = (
     }
 
     const requireDeclaratorsWithIdentifier = getRequireDeclaratorsWithIdentifier(j, source, {
-      identifierName: v3ClientDefaultLocalName,
+      identifierName: defaultLocalName,
       sourceValue: v3ClientPackageName,
     });
 
     if (requireDeclaratorsWithIdentifier && requireDeclaratorsWithIdentifier.nodes().length > 0) {
       requireDeclaratorsWithIdentifier.at(0).insertAfter(
-        j.variableDeclarator(j.objectPattern([v3ClientObjectProperty]), {
+        j.variableDeclarator(j.objectPattern([clientObjectProperty]), {
           type: "Identifier",
-          name: v3ClientDefaultLocalName,
+          name: defaultLocalName,
         })
       );
       return;
@@ -62,14 +62,14 @@ export const addClientNamedRequire = (
 
     if (existingRequireProperties.length > 0) {
       const firstRequireProperties = (existingRequireProperties[0].id as ObjectPattern).properties;
-      firstRequireProperties.push(v3ClientObjectProperty);
+      firstRequireProperties.push(clientObjectProperty);
       firstRequireProperties.sort(objectPatternPropertyCompareFn);
       return;
     }
   }
 
   const v3RequireDeclarator = j.variableDeclarator(
-    j.objectPattern([v3ClientObjectProperty]),
+    j.objectPattern([clientObjectProperty]),
     j.callExpression(j.identifier("require"), [j.literal(v3ClientPackageName)])
   );
 

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypeReference.ts
@@ -25,17 +25,17 @@ export const getV3ClientTypeReference = (
   { v2ClientLocalName, v2ClientName, v2ClientTypeName }: GetV3ClientTypeReferenceOptions
 ): TSType => {
   const clientTypesMap = CLIENT_TYPES_MAP[v2ClientName];
-  const v3ClientDefaultLocalName = getDefaultLocalName(v2ClientLocalName);
+  const defaultLocalName = getDefaultLocalName(v2ClientLocalName);
 
   if (Object.keys(clientTypesMap).includes(v2ClientTypeName)) {
-    return getTypeRefForString(j, v3ClientDefaultLocalName, clientTypesMap[v2ClientTypeName]);
+    return getTypeRefForString(j, defaultLocalName, clientTypesMap[v2ClientTypeName]);
   }
 
   for (const inputSuffix of V2_CLIENT_INPUT_SUFFIX_LIST) {
     if (v2ClientTypeName.endsWith(inputSuffix)) {
       return getTypeRefWithV3ClientDefaultLocalName(
         j,
-        v3ClientDefaultLocalName,
+        defaultLocalName,
         v2ClientTypeName.replace(new RegExp(`${inputSuffix}$`), "CommandInput")
       );
     }
@@ -45,11 +45,11 @@ export const getV3ClientTypeReference = (
     if (v2ClientTypeName.endsWith(outputSuffix)) {
       return getTypeRefWithV3ClientDefaultLocalName(
         j,
-        v3ClientDefaultLocalName,
+        defaultLocalName,
         v2ClientTypeName.replace(new RegExp(`${outputSuffix}$`), "CommandOutput")
       );
     }
   }
 
-  return getTypeRefWithV3ClientDefaultLocalName(j, v3ClientDefaultLocalName, v2ClientTypeName);
+  return getTypeRefWithV3ClientDefaultLocalName(j, defaultLocalName, v2ClientTypeName);
 };

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypeReference.ts
@@ -5,7 +5,7 @@ import {
   V2_CLIENT_INPUT_SUFFIX_LIST,
   V2_CLIENT_OUTPUT_SUFFIX_LIST,
 } from "../config";
-import { getV3DefaultLocalName } from "../utils";
+import { getDefaultLocalName } from "../utils";
 import { getTypeRefForString } from "./getTypeRefForString";
 
 export interface GetV3ClientTypeReferenceOptions {
@@ -25,7 +25,7 @@ export const getV3ClientTypeReference = (
   { v2ClientLocalName, v2ClientName, v2ClientTypeName }: GetV3ClientTypeReferenceOptions
 ): TSType => {
   const clientTypesMap = CLIENT_TYPES_MAP[v2ClientName];
-  const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientLocalName);
+  const v3ClientDefaultLocalName = getDefaultLocalName(v2ClientLocalName);
 
   if (Object.keys(clientTypesMap).includes(v2ClientTypeName)) {
     return getTypeRefForString(j, v3ClientDefaultLocalName, clientTypesMap[v2ClientTypeName]);

--- a/src/transforms/v2-to-v3/utils/getDefaultLocalName.ts
+++ b/src/transforms/v2-to-v3/utils/getDefaultLocalName.ts
@@ -1,0 +1,1 @@
+export const getDefaultLocalName = (localNameSuffix: string) => `AWS_${localNameSuffix}`;

--- a/src/transforms/v2-to-v3/utils/getV3DefaultLocalName.ts
+++ b/src/transforms/v2-to-v3/utils/getV3DefaultLocalName.ts
@@ -1,1 +1,0 @@
-export const getV3DefaultLocalName = (localNameSuffix: string) => `AWS_${localNameSuffix}`;

--- a/src/transforms/v2-to-v3/utils/index.ts
+++ b/src/transforms/v2-to-v3/utils/index.ts
@@ -1,5 +1,5 @@
 export * from "./getClientDeepImportPath";
 export * from "./getClientNewExpression";
 export * from "./getClientTSTypeRef";
-export * from "./getV3DefaultLocalName";
+export * from "./getDefaultLocalName";
 export * from "./isTypeScriptFile";


### PR DESCRIPTION
### Issue

Refs: https://github.com/awslabs/aws-sdk-js-codemod/issues/451

### Description

Rename getV3DefaultLocalName to getDefaultLocalName

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
