### PR TITLE
Rename getV2ClientTypeNames to getClientTypeNames

### DIFF
--- a/src/transforms/v2-to-v3/apis/getClientWaiterCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getClientWaiterCallExpression.ts
@@ -3,13 +3,13 @@ import { CallExpression } from "jscodeshift";
 import { ClientIdentifier } from "./getClientIdentifiers";
 
 export const getClientWaiterCallExpression = (
-  v2ClientId: ClientIdentifier,
+  clientId: ClientIdentifier,
   waiterState: string
 ): CallExpression => ({
   type: "CallExpression",
   callee: {
     type: "MemberExpression",
-    object: v2ClientId,
+    object: clientId,
     property: { type: "Identifier", name: "waitFor" },
   },
   // @ts-expect-error Type 'string' is not assignable to type 'RegExp'

--- a/src/transforms/v2-to-v3/modules/removeV2ClientModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeV2ClientModule.ts
@@ -39,10 +39,10 @@ export const removeV2ClientModule = (
     removeImportDefault(j, source, defaultOptions);
     removeImportNamed(j, source, namedOptions);
 
-    const v2ClientTypeNames = getClientTypeNames(j, source, options);
-    for (const v2ClientTypeName of v2ClientTypeNames) {
+    const clientTypeNames = getClientTypeNames(j, source, options);
+    for (const clientTypeName of clientTypeNames) {
       removeImportNamed(j, source, {
-        localName: v2ClientTypeName,
+        localName: clientTypeName,
         sourceValue: deepImportPath,
       });
     }

--- a/src/transforms/v2-to-v3/modules/removeV2ClientModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeV2ClientModule.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
-import { getV2ClientTypeNames } from "../ts-type";
+import { getClientTypeNames } from "../ts-type";
 import { getClientDeepImportPath } from "../utils";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
@@ -39,7 +39,7 @@ export const removeV2ClientModule = (
     removeImportDefault(j, source, defaultOptions);
     removeImportNamed(j, source, namedOptions);
 
-    const v2ClientTypeNames = getV2ClientTypeNames(j, source, options);
+    const v2ClientTypeNames = getClientTypeNames(j, source, options);
     for (const v2ClientTypeName of v2ClientTypeNames) {
       removeImportNamed(j, source, {
         localName: v2ClientTypeName,

--- a/src/transforms/v2-to-v3/ts-type/getClientTypeNames.ts
+++ b/src/transforms/v2-to-v3/ts-type/getClientTypeNames.ts
@@ -26,7 +26,7 @@ export const getClientTypeNames = (
   source: Collection<unknown>,
   { v2ClientLocalName, v2ClientName, v2GlobalName }: GetClientTypeNamesOptions
 ): string[] => {
-  const v2ClientTypeNames = [];
+  const clientTypeNames = [];
 
   if (v2GlobalName) {
     const globalTSTypeRef = getClientTSTypeRef({
@@ -34,13 +34,13 @@ export const getClientTypeNames = (
       v2GlobalName,
       withoutRightSection: true,
     });
-    v2ClientTypeNames.push(...getRightIdentifierName(j, source, globalTSTypeRef));
+    clientTypeNames.push(...getRightIdentifierName(j, source, globalTSTypeRef));
   }
 
   const clientTSTypeRef = getClientTSTypeRef({ v2ClientLocalName, withoutRightSection: true });
-  v2ClientTypeNames.push(...getRightIdentifierName(j, source, clientTSTypeRef));
+  clientTypeNames.push(...getRightIdentifierName(j, source, clientTSTypeRef));
 
-  v2ClientTypeNames.push(
+  clientTypeNames.push(
     ...getImportSpecifiers(j, source, getClientDeepImportPath(v2ClientName))
       .filter(
         (importSpecifier) =>
@@ -51,5 +51,5 @@ export const getClientTypeNames = (
       .map((importSpecifier) => (importSpecifier.local as Identifier).name)
   );
 
-  return [...new Set(v2ClientTypeNames)];
+  return [...new Set(clientTypeNames)];
 };

--- a/src/transforms/v2-to-v3/ts-type/getClientTypeNames.ts
+++ b/src/transforms/v2-to-v3/ts-type/getClientTypeNames.ts
@@ -3,7 +3,7 @@ import { Collection, Identifier, JSCodeshift, TSQualifiedName, TSTypeReference }
 import { getImportSpecifiers } from "../modules";
 import { getClientDeepImportPath, getClientTSTypeRef } from "../utils";
 
-export interface GetV2ClientTypeNamesOptions {
+export interface GetClientTypeNamesOptions {
   v2ClientName: string;
   v2GlobalName?: string;
   v2ClientLocalName: string;
@@ -21,10 +21,10 @@ const getRightIdentifierName = (
     .filter((node) => node.type === "Identifier")
     .map((node) => (node as Identifier).name);
 
-export const getV2ClientTypeNames = (
+export const getClientTypeNames = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientLocalName, v2ClientName, v2GlobalName }: GetV2ClientTypeNamesOptions
+  { v2ClientLocalName, v2ClientName, v2GlobalName }: GetClientTypeNamesOptions
 ): string[] => {
   const v2ClientTypeNames = [];
 

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypesCount.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypesCount.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { CLIENT_TYPES_MAP } from "../config";
-import { getV2ClientTypeNames, GetV2ClientTypeNamesOptions } from "./getV2ClientTypeNames";
+import { getClientTypeNames, GetClientTypeNamesOptions } from "./getClientTypeNames";
 
 const arrayBracketRegex = /<([\w]+)>/g;
 const recordBracketRegex = /<string, ([\w]+)>/g;
@@ -17,11 +17,11 @@ const getTypesFromString = (str: string): string[] => {
 export const getV3ClientTypesCount = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: GetV2ClientTypeNamesOptions
+  options: GetClientTypeNamesOptions
 ) => {
   const { v2ClientName } = options;
 
-  const v2ClientTypeNames = getV2ClientTypeNames(j, source, options);
+  const v2ClientTypeNames = getClientTypeNames(j, source, options);
   const clientTypesMap = CLIENT_TYPES_MAP[v2ClientName];
   const v3ClientUnavailableTypes = Object.keys(clientTypesMap);
 

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypesCount.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypesCount.ts
@@ -21,15 +21,15 @@ export const getV3ClientTypesCount = (
 ) => {
   const { v2ClientName } = options;
 
-  const v2ClientTypeNames = getClientTypeNames(j, source, options);
+  const clientTypeNames = getClientTypeNames(j, source, options);
   const clientTypesMap = CLIENT_TYPES_MAP[v2ClientName];
   const v3ClientUnavailableTypes = Object.keys(clientTypesMap);
 
-  return v2ClientTypeNames.filter((v2ClientTypeName) => {
-    if (!v3ClientUnavailableTypes.includes(v2ClientTypeName)) {
+  return clientTypeNames.filter((clientTypeName) => {
+    if (!v3ClientUnavailableTypes.includes(clientTypeName)) {
       return true;
     }
-    const typesFromString = getTypesFromString(clientTypesMap[v2ClientTypeName]);
+    const typesFromString = getTypesFromString(clientTypesMap[clientTypeName]);
     return typesFromString.some((type) => !nativeTypes.includes(type));
   }).length;
 };

--- a/src/transforms/v2-to-v3/ts-type/index.ts
+++ b/src/transforms/v2-to-v3/ts-type/index.ts
@@ -1,4 +1,4 @@
-export * from "./getV2ClientTypeNames";
+export * from "./getClientTypeNames";
 export * from "./getV3ClientTypeReference";
 export * from "./getV3ClientTypesCount";
 export * from "./replaceTSTypeReference";

--- a/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
@@ -1,7 +1,7 @@
 import { Collection, Identifier, JSCodeshift, TSQualifiedName, TSTypeReference } from "jscodeshift";
 
 import { getClientTSTypeRef } from "../utils";
-import { getV2ClientTypeNames } from "./getV2ClientTypeNames";
+import { getClientTypeNames } from "./getClientTypeNames";
 import { getV3ClientTypeReference } from "./getV3ClientTypeReference";
 
 export interface ReplaceTSTypeReferenceOptions {
@@ -56,7 +56,7 @@ export const replaceTSTypeReference = (
     });
 
   // Replace type reference to client type with modules.
-  const v2ClientTypeNames = getV2ClientTypeNames(j, source, {
+  const v2ClientTypeNames = getClientTypeNames(j, source, {
     v2ClientLocalName,
     v2ClientName,
     v2GlobalName,

--- a/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
@@ -56,15 +56,15 @@ export const replaceTSTypeReference = (
     });
 
   // Replace type reference to client type with modules.
-  const v2ClientTypeNames = getClientTypeNames(j, source, {
+  const clientTypeNames = getClientTypeNames(j, source, {
     v2ClientLocalName,
     v2ClientName,
     v2GlobalName,
   });
 
-  for (const v2ClientTypeName of v2ClientTypeNames) {
+  for (const clientTypeName of clientTypeNames) {
     source
-      .find(j.TSTypeReference, { typeName: { type: "Identifier", name: v2ClientTypeName } })
+      .find(j.TSTypeReference, { typeName: { type: "Identifier", name: clientTypeName } })
       .replaceWith((v2ClientType) => {
         const v2ClientTypeName = getIdentifierName(v2ClientType.node);
         return getV3ClientTypeReference(j, { v2ClientName, v2ClientTypeName, v2ClientLocalName });


### PR DESCRIPTION
### Issue

Refs: https://github.com/awslabs/aws-sdk-js-codemod/issues/451

### Description

Rename getV2ClientTypeNames to getClientTypeNames

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
