### PR TITLE
Remove v2 from remove*Module utilities

### DIFF
--- a/src/transforms/v2-to-v3/modules/index.ts
+++ b/src/transforms/v2-to-v3/modules/index.ts
@@ -4,5 +4,5 @@ export * from "./getImportSpecifiers";
 export * from "./getRequireDeclaratorsWithProperty";
 export * from "./getV2GlobalNameFromModule";
 export * from "./hasRequire";
-export * from "./removeV2ClientModule";
+export * from "./removeClientModule";
 export * from "./removeV2GlobalModule";

--- a/src/transforms/v2-to-v3/modules/index.ts
+++ b/src/transforms/v2-to-v3/modules/index.ts
@@ -5,4 +5,4 @@ export * from "./getRequireDeclaratorsWithProperty";
 export * from "./getV2GlobalNameFromModule";
 export * from "./hasRequire";
 export * from "./removeClientModule";
-export * from "./removeV2GlobalModule";
+export * from "./removeGlobalModule";

--- a/src/transforms/v2-to-v3/modules/removeClientModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeClientModule.ts
@@ -12,16 +12,16 @@ import { removeRequireIdentifier } from "./removeRequireIdentifier";
 import { removeRequireObjectProperty } from "./removeRequireObjectProperty";
 import { removeRequireProperty } from "./removeRequireProperty";
 
-export interface RemoveV2ClientModuleOptions {
+export interface RemoveClientModuleOptions {
   v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;
 }
 
-export const removeV2ClientModule = (
+export const removeClientModule = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: RemoveV2ClientModuleOptions
+  options: RemoveClientModuleOptions
 ) => {
   const { v2ClientName, v2ClientLocalName } = options;
   const deepImportPath = getClientDeepImportPath(v2ClientName);

--- a/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
@@ -7,7 +7,7 @@ import { removeImportDefault } from "./removeImportDefault";
 import { removeImportEquals } from "./removeImportEquals";
 import { removeRequireIdentifier } from "./removeRequireIdentifier";
 
-export const removeV2GlobalModule = (
+export const removeGlobalModule = (
   j: JSCodeshift,
   source: Collection<unknown>,
   v2GlobalName: string

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -11,7 +11,7 @@ import {
 import {
   addClientModules,
   getV2GlobalNameFromModule,
-  removeV2ClientModule,
+  removeClientModule,
   removeV2GlobalModule,
 } from "./modules";
 import { replaceTSTypeReference } from "./ts-type";
@@ -55,7 +55,7 @@ const transformer = async (file: FileInfo, api: API) => {
 
     addClientModules(j, source, { ...v2Options, ...v3Options });
     replaceTSTypeReference(j, source, { ...v2Options, v3ClientName });
-    removeV2ClientModule(j, source, v2Options);
+    removeClientModule(j, source, v2Options);
     replaceS3UploadApi(j, source, v2Options);
     removePromiseCalls(j, source, v2Options);
     replaceWaiterApi(j, source, v2Options);

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -12,7 +12,7 @@ import {
   addClientModules,
   getV2GlobalNameFromModule,
   removeClientModule,
-  removeV2GlobalModule,
+  removeGlobalModule,
 } from "./modules";
 import { replaceTSTypeReference } from "./ts-type";
 import { isTypeScriptFile } from "./utils";
@@ -66,7 +66,7 @@ const transformer = async (file: FileInfo, api: API) => {
   }
 
   if (v2GlobalName) {
-    removeV2GlobalModule(j, source, v2GlobalName);
+    removeGlobalModule(j, source, v2GlobalName);
   }
 
   return source.toSource();


### PR DESCRIPTION
### Issue

Refs: https://github.com/awslabs/aws-sdk-js-codemod/issues/451

### Description

Remove v2 from remove*Module utilities

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
