### PR TITLE
Support require-property from deep import path for DocumentClient

### DIFF
--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-property-deep-with-name.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-property-deep-with-name.input.js
@@ -1,0 +1,4 @@
+const DocumentClient = require("aws-sdk/clients/dynamodb").DocumentClient;
+
+const documentClient = new DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-property-deep-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-property-deep-with-name.output.js
@@ -1,0 +1,9 @@
+const {
+        DynamoDBDocument
+      } = require("@aws-sdk/lib-dynamodb"),
+      {
+        DynamoDB: DynamoDBClient
+      } = require("@aws-sdk/client-dynamodb");
+
+const documentClient = DynamoDBDocument.from(new DynamoDBClient({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-property-deep-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-property-deep-with-name.output.js
@@ -2,8 +2,8 @@ const {
         DynamoDBDocument
       } = require("@aws-sdk/lib-dynamodb"),
       {
-        DynamoDB: DynamoDBClient
+        DynamoDB
       } = require("@aws-sdk/client-dynamodb");
 
-const documentClient = DynamoDBDocument.from(new DynamoDBClient({ region: "us-west-2" }));
+const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
 const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
@@ -7,7 +7,7 @@ import {
   Property,
 } from "jscodeshift";
 
-import { CLIENT_NAMES, OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME } from "../config";
+import { CLIENT_NAMES, DYNAMODB, OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME } from "../config";
 import { getRequireDeclaratorsWithProperty } from "../modules";
 import { getClientDeepImportPath } from "../utils";
 import { getRequireIds } from "./getRequireIds";
@@ -59,11 +59,21 @@ export const getClientNamesRecordFromRequire = (
 
   for (const clientName of clientNamesFromDeepImport) {
     const deepImportPath = getClientDeepImportPath(clientName);
+
     const idsFromDefaultImport = getRequireIds(j, source, deepImportPath).filter(
       (id) => id.type === "Identifier"
     );
     if (idsFromDefaultImport.length) {
       clientNamesRecord[clientName] = (idsFromDefaultImport[0] as Identifier).name;
+    }
+
+    if (clientName === DYNAMODB && !clientNamesRecord[clientName]) {
+      const declaratorsWithDdbProperty = getRequireDeclaratorsWithProperty(j, source, {
+        sourceValue: deepImportPath,
+      }).nodes();
+      if (declaratorsWithDdbProperty.length) {
+        clientNamesRecord[DYNAMODB] = DYNAMODB;
+      }
     }
   }
 


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/471

### Description

Support require-property from deep import path for DocumentClient

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
