### PR TITLE
chore(deps-dev): bump typescript to ~5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prettier": "2.8.3",
     "simple-git-hooks": "^2.8.1",
     "tsx": "^3.12.1",
-    "typescript": "~4.9.4",
+    "typescript": "~5.0.2",
     "vitest": "^0.29.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1781,7 +1781,7 @@ __metadata:
     prettier: 2.8.3
     simple-git-hooks: ^2.8.1
     tsx: ^3.12.1
-    typescript: ~4.9.4
+    typescript: ~5.0.2
     vitest: ^0.29.1
   bin:
     aws-sdk-js-codemod: bin/aws-sdk-js-codemod
@@ -5892,23 +5892,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.9.4":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:~5.0.2":
+  version: 5.0.2
+  resolution: "typescript@npm:5.0.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: bef1dcd166acfc6934b2ec4d72f93edb8961a5fab36b8dd2aaf6f4f4cd5c0210f2e0850aef4724f3b4913d5aef203a94a28ded731b370880c8bcff7e4ff91fc1
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.9.4#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
+"typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
+  version: 5.0.2
+  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  checksum: b63cb742fbb9aeb3085e002ad8f10d5fd963606aa4d6b3b65b4e76c396ff09739f03b5dbae08e1698c3bce9d5619d3f67aeb7ee470ed4016bd345b3cfe37b54a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/

### Description

Bump typescript to ~5.0.2

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
