### PR TITLE
Run linter on file save in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,11 @@
 {
-  "editor.tabSize": 2,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.rulers": [80, 120],
+  "editor.tabSize": 2,
   "search.exclude": {
     "**/.yarn": true,
     "**/.pnp.*": true


### PR DESCRIPTION
### Issue

N/A

### Description

Runs linter on file save in VSCode

### Testing

Verified that linter is run on file save

<details>
<summary>Screen recording</summary>

https://user-images.githubusercontent.com/16024985/235710951-da2a90c5-ca69-4c69-9c0f-1eba71751f7b.mov

</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
