### PR TITLE
Remove VSCode settings/recommendations specific to yarn PnP

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["arcanis.vscode-zipfs"]
+  "recommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.rulers": [80, 120],
   "search.exclude": {
-    "**/.yarn": true,
-    "**/.pnp.*": true
+    "**/.yarn": true
   }
 }


### PR DESCRIPTION
### Issue

N/A

### Description

Remove VSCode settings/recommendations specific to yarn PnP.
The PnP was tried in the initial setup of codemod, but discontinued in favor of node_modules.

### Testing

Uninstalled vscode-zipfs, and restarted vscode. The recommendation did not appear.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
