### PR TITLE
Alphabetize import order in eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
-    "import/order": "error",
+    "import/order": ["error", { "alphabetize": { "order": "asc" } }],
     "import/first": "error",
     "import/no-mutable-exports": "error",
     "import/no-unresolved": "off",


### PR DESCRIPTION
### Issue

Docs: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#alphabetize-order-ascdescignore-orderimportkind-ascdescignore-caseinsensitive-truefalse

### Description

Alphabetizes import order in eslint.

### Testing

Verified that imports were sorted in alphabetized order

```console
$ git diff
diff --git a/src/utils/getJsCodeshiftParser.ts b/src/utils/getJsCodeshiftParser.ts
index 2a765ee..aa81041 100644
--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -4,8 +4,8 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 
-import { readFileSync } from "fs";
 import { dirname, join } from "path";
+import { readFileSync } from "fs";
 import argsParser from "jscodeshift/dist/argsParser";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 
 $ yarn eslint --fix src/**/*.ts --quiet

$ git diff
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
