### PR TITLE
Add newlines-between in eslint import/order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,13 @@
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
-    "import/order": ["error", { "alphabetize": { "order": "asc" } }],
+    "import/order": [
+      "error",
+      {
+        "alphabetize": { "order": "asc" },
+        "newlines-between": "always"
+      }
+    ],
     "import/first": "error",
     "import/no-mutable-exports": "error",
     "import/no-unresolved": "off",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import path from "path";
+
 import Runner from "jscodeshift/dist/Runner";
 
 import {

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { FUNCTION_TYPE_LIST } from "../config";
+
 import { getClientIdentifiers } from "./getClientIdentifiers";
 import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -1,4 +1,5 @@
 import { emitWarning } from "process";
+
 import { ASTPath, CallExpression, JSCodeshift, MemberExpression } from "jscodeshift";
 
 export const removePromiseForCallExpression = (

--- a/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getDocClientNewExpression } from "../utils";
+
 import { getDynamoDBForDocClient } from "./getDynamoDBForDocClient";
 
 export interface ReplaceDocClientCreationOptions {

--- a/src/transforms/v2-to-v3/client-names/getClientMetadataRecord.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientMetadataRecord.ts
@@ -1,4 +1,5 @@
 import { ClientMetadataRecord } from "../types";
+
 import { getV3ClientName } from "./getV3ClientName";
 import { getV3ClientPackageName } from "./getV3ClientPackageName";
 

--- a/src/transforms/v2-to-v3/client-names/getClientNamesFromGlobal.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesFromGlobal.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { CLIENT_NAMES } from "../config";
+
 import { getNamesFromNewExpr } from "./getNamesFromNewExpr";
 import { getNamesFromTSQualifiedName } from "./getNamesFromTSQualifiedName";
 

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { hasRequire } from "../modules";
+
 import { getClientNamesFromDeepImport } from "./getClientNamesFromDeepImport";
 import { getClientNamesRecordFromImport } from "./getClientNamesRecordFromImport";
 import { getClientNamesRecordFromRequire } from "./getClientNamesRecordFromRequire";

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
@@ -10,6 +10,7 @@ import {
 import { CLIENT_NAMES, OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME } from "../config";
 import { getRequireDeclaratorsWithProperty } from "../modules";
 import { getClientDeepImportPath } from "../utils";
+
 import { getRequireIds } from "./getRequireIds";
 
 export const getClientNamesRecordFromRequire = (

--- a/src/transforms/v2-to-v3/client-names/getV3ClientName.spec.ts
+++ b/src/transforms/v2-to-v3/client-names/getV3ClientName.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { CLIENT_NAMES_MAP } from "../config";
+
 import { getV3ClientName } from "./getV3ClientName";
 
 describe(getV3ClientName.name, () => {

--- a/src/transforms/v2-to-v3/client-names/getV3ClientPackageName.spec.ts
+++ b/src/transforms/v2-to-v3/client-names/getV3ClientPackageName.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { CLIENT_PACKAGE_NAMES_MAP } from "../config";
+
 import { getV3ClientPackageName } from "./getV3ClientPackageName";
 
 describe(getV3ClientPackageName.name, () => {

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
@@ -1,6 +1,7 @@
 import { Collection, ImportDefaultSpecifier, JSCodeshift } from "jscodeshift";
 
 import { getDefaultLocalName } from "../utils";
+
 import { getImportDeclaration } from "./getImportDeclaration";
 import { getImportSpecifiers } from "./getImportSpecifiers";
 import { ClientModulesOptions } from "./types";

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getDefaultLocalName } from "../utils";
+
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";

--- a/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getDefaultLocalName } from "../utils";
+
 import { getRequireDeclarator } from "./getRequireDeclarator";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 import { ClientModulesOptions } from "./types";

--- a/src/transforms/v2-to-v3/modules/addClientImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientImportEquals.ts
@@ -2,6 +2,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
 import { getV3ClientTypesCount } from "../ts-type";
+
 import { addClientDefaultImportEquals } from "./addClientDefaultImportEquals";
 import { addClientNamedImportEquals } from "./addClientNamedImportEquals";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";

--- a/src/transforms/v2-to-v3/modules/addClientImports.ts
+++ b/src/transforms/v2-to-v3/modules/addClientImports.ts
@@ -2,6 +2,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
 import { getV3ClientTypesCount } from "../ts-type";
+
 import { addClientDefaultImport } from "./addClientDefaultImport";
 import { addClientNamedImport } from "./addClientNamedImport";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";

--- a/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getDefaultLocalName } from "../utils";
+
 import { addClientDefaultImportEquals } from "./addClientDefaultImportEquals";
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";

--- a/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
@@ -2,6 +2,7 @@ import { Collection, JSCodeshift, ObjectPattern, ObjectProperty, Property } from
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 import { getDefaultLocalName } from "../utils";
+
 import { getRequireDeclarator } from "./getRequireDeclarator";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";

--- a/src/transforms/v2-to-v3/modules/addClientRequires.ts
+++ b/src/transforms/v2-to-v3/modules/addClientRequires.ts
@@ -2,6 +2,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
 import { getV3ClientTypesCount } from "../ts-type";
+
 import { addClientDefaultRequire } from "./addClientDefaultRequire";
 import { addClientNamedRequire } from "./addClientNamedRequire";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";

--- a/src/transforms/v2-to-v3/modules/getDocClientNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getDocClientNewExpressionCount.ts
@@ -2,6 +2,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { DYNAMODB } from "../config";
 import { getDocClientNewExpression } from "../utils";
+
 import { ClientModulesOptions } from "./types";
 
 export const getDocClientNewExpressionCount = (

--- a/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
+++ b/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
@@ -1,6 +1,7 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
+
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 import { getImportSpecifiers } from "./getImportSpecifiers";
 import { hasRequire } from "./hasRequire";

--- a/src/transforms/v2-to-v3/modules/getImportEqualsDeclaration.ts
+++ b/src/transforms/v2-to-v3/modules/getImportEqualsDeclaration.ts
@@ -2,6 +2,7 @@ import { Collection, JSCodeshift, TSExternalModuleReference } from "jscodeshift"
 
 import { PACKAGE_NAME } from "../config";
 import { getClientDeepImportPath } from "../utils";
+
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 
 export interface GetImportEqualsDeclarationOptions {

--- a/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { getClientNewExpression } from "../utils";
+
 import { getDocClientNewExpressionCount } from "./getDocClientNewExpressionCount";
 import { ClientModulesOptions } from "./types";
 

--- a/src/transforms/v2-to-v3/modules/getRequireDeclarator.ts
+++ b/src/transforms/v2-to-v3/modules/getRequireDeclarator.ts
@@ -2,6 +2,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
 import { getClientDeepImportPath } from "../utils";
+
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";
 import { getRequireDeclaratorsWithObjectPattern } from "./getRequireDeclaratorsWithObjectPattern";
 import { getRequireDeclaratorsWithProperty } from "./getRequireDeclaratorsWithProperty";

--- a/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithObjectPattern.ts
+++ b/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithObjectPattern.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
+
 import { getRequireDeclarators } from "./getRequireDeclarators";
 
 export interface GetRequireDeclaratorsWithObjectPattern {

--- a/src/transforms/v2-to-v3/modules/removeClientModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeClientModule.ts
@@ -3,6 +3,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 import { PACKAGE_NAME } from "../config";
 import { getClientTypeNames } from "../ts-type";
 import { getClientDeepImportPath } from "../utils";
+
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { removeImportDefault } from "./removeImportDefault";

--- a/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
+
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { removeImportDefault } from "./removeImportDefault";

--- a/src/transforms/v2-to-v3/modules/removeRequireObjectProperty.ts
+++ b/src/transforms/v2-to-v3/modules/removeRequireObjectProperty.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift, ObjectPattern, ObjectProperty, Property } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
+
 import { getRequireDeclaratorsWithObjectPattern } from "./getRequireDeclaratorsWithObjectPattern";
 
 export interface RemoveRequireObjectPropertyOptions {

--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -1,6 +1,7 @@
 import { readdirSync } from "fs";
 import { readFile } from "fs/promises";
 import { join } from "path";
+
 import jscodeshift from "jscodeshift";
 import { describe, expect, it } from "vitest";
 

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypeReference.ts
@@ -6,6 +6,7 @@ import {
   V2_CLIENT_OUTPUT_SUFFIX_LIST,
 } from "../config";
 import { getDefaultLocalName } from "../utils";
+
 import { getTypeRefForString } from "./getTypeRefForString";
 
 export interface GetV3ClientTypeReferenceOptions {

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypesCount.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypesCount.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { CLIENT_TYPES_MAP } from "../config";
+
 import { getClientTypeNames, GetClientTypeNamesOptions } from "./getClientTypeNames";
 
 const arrayBracketRegex = /<([\w]+)>/g;

--- a/src/utils/getHelpParagraph.ts
+++ b/src/utils/getHelpParagraph.ts
@@ -1,4 +1,5 @@
 import { AwsSdkJsCodemodTransform } from "../transforms";
+
 import { getTransformDescription } from "./getTransformDescription";
 
 const separator = "-".repeat(95);

--- a/src/utils/getJsCodeshiftParser.ts
+++ b/src/utils/getJsCodeshiftParser.ts
@@ -6,6 +6,7 @@
 
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
+
 import argsParser from "jscodeshift/dist/argsParser";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
### Issue

Docs: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#newlines-between-ignorealwaysalways-and-inside-groupsnever

### Description

Adds newlines-between in eslint import/order

### Testing

The code changes were made in source code by running:
```console
$ yarn eslint --fix src/**/*.ts --quiet
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
