### PR TITLE
Combine parent and sibling groups in import/order groups

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,13 @@
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
-    "import/order": ["error", { "alphabetize": { "order": "asc" } }],
+    "import/order": [
+      "error",
+      {
+        "alphabetize": { "order": "asc" },
+        "groups": ["builtin", "external", ["parent", "sibling"]]
+      }
+    ],
     "import/first": "error",
     "import/no-mutable-exports": "error",
     "import/no-unresolved": "off",

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -1,10 +1,10 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { FUNCTION_TYPE_LIST } from "../config";
 import { getClientIdentifiers } from "./getClientIdentifiers";
 import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";
 import { getS3UploadCallExpression } from "./getS3UploadCallExpression";
+import { FUNCTION_TYPE_LIST } from "../config";
 
 export interface CommentsForUnsupportedAPIsOptions {
   v2ClientName: string;

--- a/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getDocClientNewExpression } from "../utils";
 import { getDynamoDBForDocClient } from "./getDynamoDBForDocClient";
+import { getDocClientNewExpression } from "../utils";
 
 export interface ReplaceDocClientCreationOptions {
   v2ClientLocalName: string;

--- a/src/transforms/v2-to-v3/client-names/getClientMetadataRecord.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientMetadataRecord.ts
@@ -1,6 +1,6 @@
-import { ClientMetadataRecord } from "../types";
 import { getV3ClientName } from "./getV3ClientName";
 import { getV3ClientPackageName } from "./getV3ClientPackageName";
+import { ClientMetadataRecord } from "../types";
 
 export const getClientMetadataRecord = (
   v2ClientNamesRecord: Record<string, string>

--- a/src/transforms/v2-to-v3/client-names/getClientNamesFromGlobal.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesFromGlobal.ts
@@ -1,8 +1,8 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { CLIENT_NAMES } from "../config";
 import { getNamesFromNewExpr } from "./getNamesFromNewExpr";
 import { getNamesFromTSQualifiedName } from "./getNamesFromTSQualifiedName";
+import { CLIENT_NAMES } from "../config";
 
 export const getClientNamesFromGlobal = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
@@ -1,9 +1,9 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { hasRequire } from "../modules";
 import { getClientNamesFromDeepImport } from "./getClientNamesFromDeepImport";
 import { getClientNamesRecordFromImport } from "./getClientNamesRecordFromImport";
 import { getClientNamesRecordFromRequire } from "./getClientNamesRecordFromRequire";
+import { hasRequire } from "../modules";
 
 export const getClientNamesRecord = (j: JSCodeshift, source: Collection<unknown>) => {
   const clientNamesFromDeepImport = getClientNamesFromDeepImport(source.toSource());

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
@@ -7,10 +7,10 @@ import {
   Property,
 } from "jscodeshift";
 
+import { getRequireIds } from "./getRequireIds";
 import { CLIENT_NAMES, OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME } from "../config";
 import { getRequireDeclaratorsWithProperty } from "../modules";
 import { getClientDeepImportPath } from "../utils";
-import { getRequireIds } from "./getRequireIds";
 
 export const getClientNamesRecordFromRequire = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/client-names/getV3ClientName.spec.ts
+++ b/src/transforms/v2-to-v3/client-names/getV3ClientName.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { CLIENT_NAMES_MAP } from "../config";
 import { getV3ClientName } from "./getV3ClientName";
+import { CLIENT_NAMES_MAP } from "../config";
 
 describe(getV3ClientName.name, () => {
   it.each(Object.entries(CLIENT_NAMES_MAP))("getV3ClientName('%s') === '%s'", (input, output) => {

--- a/src/transforms/v2-to-v3/client-names/getV3ClientPackageName.spec.ts
+++ b/src/transforms/v2-to-v3/client-names/getV3ClientPackageName.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { CLIENT_PACKAGE_NAMES_MAP } from "../config";
 import { getV3ClientPackageName } from "./getV3ClientPackageName";
+import { CLIENT_PACKAGE_NAMES_MAP } from "../config";
 
 describe(getV3ClientPackageName.name, () => {
   it.each(Object.entries(CLIENT_PACKAGE_NAMES_MAP))(

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImport.ts
@@ -1,9 +1,9 @@
 import { Collection, ImportDefaultSpecifier, JSCodeshift } from "jscodeshift";
 
-import { getDefaultLocalName } from "../utils";
 import { getImportDeclaration } from "./getImportDeclaration";
 import { getImportSpecifiers } from "./getImportSpecifiers";
 import { ClientModulesOptions } from "./types";
+import { getDefaultLocalName } from "../utils";
 
 export const addClientDefaultImport = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultImportEquals.ts
@@ -1,10 +1,10 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getDefaultLocalName } from "../utils";
 import { getImportEqualsDeclaration } from "./getImportEqualsDeclaration";
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";
 import { ClientModulesOptions } from "./types";
+import { getDefaultLocalName } from "../utils";
 
 export const addClientDefaultImportEquals = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientDefaultRequire.ts
@@ -1,9 +1,9 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getDefaultLocalName } from "../utils";
 import { getRequireDeclarator } from "./getRequireDeclarator";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 import { ClientModulesOptions } from "./types";
+import { getDefaultLocalName } from "../utils";
 
 export const addClientDefaultRequire = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/addClientImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientImportEquals.ts
@@ -1,13 +1,13 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
-import { getV3ClientTypesCount } from "../ts-type";
 import { addClientDefaultImportEquals } from "./addClientDefaultImportEquals";
 import { addClientNamedImportEquals } from "./addClientNamedImportEquals";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getDocClientNewExpressionCount } from "./getDocClientNewExpressionCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
 import { ClientModulesOptions } from "./types";
+import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
+import { getV3ClientTypesCount } from "../ts-type";
 
 export const addClientImportEquals = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/addClientImports.ts
+++ b/src/transforms/v2-to-v3/modules/addClientImports.ts
@@ -1,13 +1,13 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
-import { getV3ClientTypesCount } from "../ts-type";
 import { addClientDefaultImport } from "./addClientDefaultImport";
 import { addClientNamedImport } from "./addClientNamedImport";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getDocClientNewExpressionCount } from "./getDocClientNewExpressionCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
 import { ClientModulesOptions } from "./types";
+import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
+import { getV3ClientTypesCount } from "../ts-type";
 
 export const addClientImports = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedImportEquals.ts
@@ -1,12 +1,12 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getDefaultLocalName } from "../utils";
 import { addClientDefaultImportEquals } from "./addClientDefaultImportEquals";
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 import { getImportEqualsLocalNameSuffix } from "./getImportEqualsLocalNameSuffix";
 import { getRequireProperty } from "./getRequireProperty";
 import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
 import { ClientModulesOptions, RequirePropertyOptions } from "./types";
+import { getDefaultLocalName } from "../utils";
 
 export const addClientNamedImportEquals = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
+++ b/src/transforms/v2-to-v3/modules/addClientNamedRequire.ts
@@ -1,13 +1,13 @@
 import { Collection, JSCodeshift, ObjectPattern, ObjectProperty, Property } from "jscodeshift";
 
-import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
-import { getDefaultLocalName } from "../utils";
 import { getRequireDeclarator } from "./getRequireDeclarator";
 import { getRequireDeclarators } from "./getRequireDeclarators";
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";
 import { getRequireProperty } from "./getRequireProperty";
 import { objectPatternPropertyCompareFn } from "./objectPatternPropertyCompareFn";
 import { ClientModulesOptions, RequirePropertyOptions } from "./types";
+import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
+import { getDefaultLocalName } from "../utils";
 
 export const addClientNamedRequire = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/addClientRequires.ts
+++ b/src/transforms/v2-to-v3/modules/addClientRequires.ts
@@ -1,13 +1,13 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
-import { getV3ClientTypesCount } from "../ts-type";
 import { addClientDefaultRequire } from "./addClientDefaultRequire";
 import { addClientNamedRequire } from "./addClientNamedRequire";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getDocClientNewExpressionCount } from "./getDocClientNewExpressionCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
 import { ClientModulesOptions } from "./types";
+import { getClientWaiterStates, getV3ClientWaiterApiName, isS3UploadApiUsed } from "../apis";
+import { getV3ClientTypesCount } from "../ts-type";
 
 export const addClientRequires = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/getDocClientNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getDocClientNewExpressionCount.ts
@@ -1,8 +1,8 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
+import { ClientModulesOptions } from "./types";
 import { DYNAMODB } from "../config";
 import { getDocClientNewExpression } from "../utils";
-import { ClientModulesOptions } from "./types";
 
 export const getDocClientNewExpressionCount = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
+++ b/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
@@ -1,9 +1,9 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 import { getImportSpecifiers } from "./getImportSpecifiers";
 import { hasRequire } from "./hasRequire";
+import { PACKAGE_NAME } from "../config";
 
 export const getGlobalNameFromModule = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/getImportEqualsDeclaration.ts
+++ b/src/transforms/v2-to-v3/modules/getImportEqualsDeclaration.ts
@@ -1,8 +1,8 @@
 import { Collection, JSCodeshift, TSExternalModuleReference } from "jscodeshift";
 
+import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 import { PACKAGE_NAME } from "../config";
 import { getClientDeepImportPath } from "../utils";
-import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 
 export interface GetImportEqualsDeclarationOptions {
   v2ClientName: string;

--- a/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
+++ b/src/transforms/v2-to-v3/modules/getNewExpressionCount.ts
@@ -1,8 +1,8 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getClientNewExpression } from "../utils";
 import { getDocClientNewExpressionCount } from "./getDocClientNewExpressionCount";
 import { ClientModulesOptions } from "./types";
+import { getClientNewExpression } from "../utils";
 
 export const getNewExpressionCount = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/getRequireDeclarator.ts
+++ b/src/transforms/v2-to-v3/modules/getRequireDeclarator.ts
@@ -1,10 +1,10 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
-import { getClientDeepImportPath } from "../utils";
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";
 import { getRequireDeclaratorsWithObjectPattern } from "./getRequireDeclaratorsWithObjectPattern";
 import { getRequireDeclaratorsWithProperty } from "./getRequireDeclaratorsWithProperty";
+import { PACKAGE_NAME } from "../config";
+import { getClientDeepImportPath } from "../utils";
 
 export interface GetRequireDeclaratorOptions {
   v2ClientName: string;

--- a/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithObjectPattern.ts
+++ b/src/transforms/v2-to-v3/modules/getRequireDeclaratorsWithObjectPattern.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift, ObjectProperty, Property } from "jscodeshift";
 
-import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 import { getRequireDeclarators } from "./getRequireDeclarators";
+import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 
 export interface GetRequireDeclaratorsWithObjectPattern {
   identifierName: string;

--- a/src/transforms/v2-to-v3/modules/removeClientModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeClientModule.ts
@@ -1,8 +1,5 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
-import { getClientTypeNames } from "../ts-type";
-import { getClientDeepImportPath } from "../utils";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { removeImportDefault } from "./removeImportDefault";
@@ -11,6 +8,9 @@ import { removeImportNamed } from "./removeImportNamed";
 import { removeRequireIdentifier } from "./removeRequireIdentifier";
 import { removeRequireObjectProperty } from "./removeRequireObjectProperty";
 import { removeRequireProperty } from "./removeRequireProperty";
+import { PACKAGE_NAME } from "../config";
+import { getClientTypeNames } from "../ts-type";
+import { getClientDeepImportPath } from "../utils";
 
 export interface RemoveClientModuleOptions {
   v2ClientName: string;

--- a/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
@@ -1,11 +1,11 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
 import { hasImportEquals } from "./hasImportEquals";
 import { hasRequire } from "./hasRequire";
 import { removeImportDefault } from "./removeImportDefault";
 import { removeImportEquals } from "./removeImportEquals";
 import { removeRequireIdentifier } from "./removeRequireIdentifier";
+import { PACKAGE_NAME } from "../config";
 
 export const removeGlobalModule = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/modules/removeRequireObjectProperty.ts
+++ b/src/transforms/v2-to-v3/modules/removeRequireObjectProperty.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift, ObjectPattern, ObjectProperty, Property } from "jscodeshift";
 
-import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 import { getRequireDeclaratorsWithObjectPattern } from "./getRequireDeclaratorsWithObjectPattern";
+import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 
 export interface RemoveRequireObjectPropertyOptions {
   localName: string;

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypeReference.ts
@@ -1,12 +1,12 @@
 import { JSCodeshift, TSType } from "jscodeshift";
 
+import { getTypeRefForString } from "./getTypeRefForString";
 import {
   CLIENT_TYPES_MAP,
   V2_CLIENT_INPUT_SUFFIX_LIST,
   V2_CLIENT_OUTPUT_SUFFIX_LIST,
 } from "../config";
 import { getDefaultLocalName } from "../utils";
-import { getTypeRefForString } from "./getTypeRefForString";
 
 export interface GetV3ClientTypeReferenceOptions {
   v2ClientLocalName: string;

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypesCount.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypesCount.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { CLIENT_TYPES_MAP } from "../config";
 import { getClientTypeNames, GetClientTypeNamesOptions } from "./getClientTypeNames";
+import { CLIENT_TYPES_MAP } from "../config";
 
 const arrayBracketRegex = /<([\w]+)>/g;
 const recordBracketRegex = /<string, ([\w]+)>/g;

--- a/src/utils/getHelpParagraph.ts
+++ b/src/utils/getHelpParagraph.ts
@@ -1,5 +1,5 @@
-import { AwsSdkJsCodemodTransform } from "../transforms";
 import { getTransformDescription } from "./getTransformDescription";
+import { AwsSdkJsCodemodTransform } from "../transforms";
 
 const separator = "-".repeat(95);
 


### PR DESCRIPTION
### Issue

Docs: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#groups-array

### Description

Combine parent and sibling groups in import/order groups

### Testing

The code changes were made in source code by running:
```console
$ yarn eslint --fix src/**/*.ts --quiet
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
