### PR TITLE
chore(deps-dev): bump prettier to 3.0.0

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "printWidth": 100
+  "printWidth": 100,
+  "trailingComma": "es5"
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^8.45.0",
     "eslint-plugin-import": "^2.27.5",
     "lint-staged": "^13.0.3",
-    "prettier": "2.8.3",
+    "prettier": "3.0.0",
     "simple-git-hooks": "^2.8.1",
     "tsx": "^3.12.1",
     "typescript": "~5.0.2",

--- a/src/transforms/v2-to-v3/apis/getClientIdThisExpressions.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdThisExpressions.ts
@@ -28,6 +28,6 @@ export const getClientIdThisExpressions = (
               type: "Identifier",
               name: ((assignmentExpression.left as MemberExpression).property as Identifier).name,
             },
-          } as ThisMemberExpression)
+          }) as ThisMemberExpression
       )
   );

--- a/src/transforms/v2-to-v3/modules/getImportEqualsDeclarationType.ts
+++ b/src/transforms/v2-to-v3/modules/getImportEqualsDeclarationType.ts
@@ -7,4 +7,4 @@ export const getImportEqualsDeclarationType = (expressionValue?: string) =>
       type: "TSExternalModuleReference",
       expression: { type: "StringLiteral", ...(expressionValue && { value: expressionValue }) },
     },
-  } as TSImportEqualsDeclaration);
+  }) as TSImportEqualsDeclaration;

--- a/src/transforms/v2-to-v3/modules/getImportEqualsLocalNameSuffix.ts
+++ b/src/transforms/v2-to-v3/modules/getImportEqualsLocalNameSuffix.ts
@@ -1,4 +1,7 @@
-export const getImportEqualsLocalNameSuffix = (v2ClientName: string, v3ClientPackageName: string) =>
+export const getImportEqualsLocalNameSuffix = (
+  v2ClientName: string,
+  v3ClientPackageName: string
+) =>
   v3ClientPackageName.startsWith("@aws-sdk/client-")
     ? v2ClientName
     : v3ClientPackageName.substring(9).replace(/-/g, "_");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,7 +1871,7 @@ __metadata:
     eslint-plugin-import: ^2.27.5
     jscodeshift: 0.15.0
     lint-staged: ^13.0.3
-    prettier: 2.8.3
+    prettier: 3.0.0
     simple-git-hooks: ^2.8.1
     tsx: ^3.12.1
     typescript: ~5.0.2
@@ -5184,12 +5184,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.8.3":
-  version: 2.8.3
-  resolution: "prettier@npm:2.8.3"
+"prettier@npm:3.0.0":
+  version: 3.0.0
+  resolution: "prettier@npm:3.0.0"
   bin:
-    prettier: bin-prettier.js
-  checksum: 92f2ceb522d454370e02082aa74ad27388672f7cee8975028b59517c069fe643bdc73e322675c8faf2ff173d7a626d1a6389f26b474000308e793aa25fff46e5
+    prettier: bin/prettier.cjs
+  checksum: 6a832876a1552dc58330d2467874e5a0b46b9ccbfc5d3531eb69d15684743e7f83dc9fbd202db6270446deba9c82b79d24383d09924c462b457136a759425e33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Refs: https://prettier.io/blog/2023/07/05/3.0.0.html

### Description

Bumps prettier to 3.0.0

### Testing

Updated prettier config to use v2 setting, and merged other updates from prettier run in source code.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
