### PR TITLE
Use utility name getDefaultLocalName in generateNewClientTests

### DIFF
--- a/scripts/generateNewClientTests/getV3PackageImportEqualsCode.ts
+++ b/scripts/generateNewClientTests/getV3PackageImportEqualsCode.ts
@@ -3,7 +3,7 @@ import {
   CLIENT_NAMES_MAP,
   CLIENT_PACKAGE_NAMES_MAP,
 } from "../../src/transforms/v2-to-v3/config";
-import { getV3DefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
+import { getDefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
 import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 
 export interface V3PackageImportEqualsCodeOptions {
@@ -18,7 +18,7 @@ export const getV3PackageImportEqualsCode = (
   const { useLocalSuffix = false } = options || {};
 
   for (const v2ClientName of clientsToTest) {
-    const v3ClientDefaultLocalName = getV3DefaultLocalName(v2ClientName);
+    const v3ClientDefaultLocalName = getDefaultLocalName(v2ClientName);
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
     content += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
 
@@ -30,7 +30,7 @@ export const getV3PackageImportEqualsCode = (
     const v3ObjectPattern =
       v3ClientName === v2ClientLocalName ? v3ClientName : `${v3ClientName}: ${v2ClientLocalName}`;
     content +=
-      `const {\n` + `  ${v3ObjectPattern}\n` + `} = ${getV3DefaultLocalName(v2ClientName)};\n\n`;
+      `const {\n` + `  ${v3ObjectPattern}\n` + `} = ${getDefaultLocalName(v2ClientName)};\n\n`;
   }
 
   return content;


### PR DESCRIPTION
### Issue

Noticed in https://github.com/awslabs/aws-sdk-js-codemod/pull/508

### Description

Uses updated utility name getDefaultLocalName in generateNewClientTests

### Testing

Verified that new client tests are generated without any errors

```console
$ yarn tsx scripts/generateNewClientTests/index.ts

$ git status
On branch fix-generateNewClientTests
Your branch is up to date with 'origin/fix-generateNewClientTests'.

nothing to commit, working tree clean
```
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
