### PR TITLE
await prettier.format in generateClientTypesMap

### DIFF
--- a/scripts/generateClientTypesMap/index.ts
+++ b/scripts/generateClientTypesMap/index.ts
@@ -26,5 +26,8 @@ const relativeFilePath = join(__dirname, "..", "..", filePath);
   fileContent += JSON.stringify(clientTypesMap);
   fileContent += `;\n`;
 
-  await writeFile(relativeFilePath, format(fileContent, { parser: "typescript", printWidth: 100 }));
+  await writeFile(
+    relativeFilePath,
+    await format(fileContent, { parser: "typescript", printWidth: 100 })
+  );
 })();


### PR DESCRIPTION
### Issue

Noticed in https://github.com/awslabs/aws-sdk-js-codemod/pull/508

### Description

The prettier.format now returns a promise after bumping to prettier 3.x

This was missed in https://github.com/awslabs/aws-sdk-js-codemod/pull/505

### Testing

Verified that client types map is generated.

```console
$ yarn tsx scripts/generateClientTypesMap/index.ts

$ git status
On branch await-prettier-format
Your branch is up to date with 'origin/await-prettier-format'.

nothing to commit, working tree clean
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
