### PR TITLE
Move DynamoDB clientName check inside replaceDocClientCreation

### DIFF
--- a/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
@@ -1,9 +1,11 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
+import { DYNAMODB } from "../config";
 import { getDocClientNewExpression } from "../utils";
 import { getDynamoDBForDocClient } from "./getDynamoDBForDocClient";
 
 export interface ReplaceDocClientCreationOptions {
+  v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;
 }
@@ -11,8 +13,10 @@ export interface ReplaceDocClientCreationOptions {
 export const replaceDocClientCreation = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientLocalName, v2GlobalName }: ReplaceDocClientCreationOptions
+  { v2ClientName, v2ClientLocalName, v2GlobalName }: ReplaceDocClientCreationOptions
 ): void => {
+  if (v2ClientName !== DYNAMODB) return;
+
   if (v2GlobalName) {
     source
       .find(j.NewExpression, getDocClientNewExpression({ v2GlobalName }))

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -64,7 +64,7 @@ const transformer = async (file: FileInfo, api: API) => {
       replaceClientCreation(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
     }
 
-    replaceDocClientCreation(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
+    replaceDocClientCreation(j, source, v2Options);
   }
 
   if (v2GlobalName) {

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -8,7 +8,6 @@ import {
   getClientNamesFromGlobal,
   getClientNamesRecord,
 } from "./client-names";
-import { DYNAMODB } from "./config";
 import {
   addClientModules,
   getGlobalNameFromModule,
@@ -65,9 +64,7 @@ const transformer = async (file: FileInfo, api: API) => {
       replaceClientCreation(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
     }
 
-    if (v2ClientName === DYNAMODB) {
-      replaceDocClientCreation(j, source, { v2ClientLocalName, v2GlobalName });
-    }
+    replaceDocClientCreation(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
   }
 
   if (v2GlobalName) {


### PR DESCRIPTION
### Issue

Noticed while working on https://github.com/awslabs/aws-sdk-js-codemod/pull/517

### Description

Move DynamoDB clientName check inside replaceDocClientCreation, similar to https://github.com/awslabs/aws-sdk-js-codemod/blob/e0677f01525a0e027ba5580765ac88c5a0065a2c/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts#L18

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
