### PR TITLE
Move v2GlobalName undefined check inside replaceClientCreation

### DIFF
--- a/src/transforms/v2-to-v3/client-instances/replaceClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceClientCreation.ts
@@ -5,7 +5,7 @@ import { getClientNewExpression } from "../utils";
 export interface ReplaceClientCreationOptions {
   v2ClientName: string;
   v2ClientLocalName: string;
-  v2GlobalName: string;
+  v2GlobalName?: string;
 }
 
 // Replace v2 client creation with v3 client creation.
@@ -14,6 +14,8 @@ export const replaceClientCreation = (
   source: Collection<unknown>,
   { v2ClientName, v2ClientLocalName, v2GlobalName }: ReplaceClientCreationOptions
 ): void => {
+  if (!v2GlobalName) return;
+
   source
     .find(j.NewExpression, getClientNewExpression({ v2GlobalName, v2ClientName }))
     .replaceWith((v2ClientNewExpression) =>

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -60,10 +60,7 @@ const transformer = async (file: FileInfo, api: API) => {
     removePromiseCalls(j, source, v2Options);
     replaceWaiterApi(j, source, v2Options);
 
-    if (v2GlobalName) {
-      replaceClientCreation(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
-    }
-
+    replaceClientCreation(j, source, v2Options);
     replaceDocClientCreation(j, source, v2Options);
   }
 


### PR DESCRIPTION
### Issue

Similar to https://github.com/awslabs/aws-sdk-js-codemod/pull/518

### Description

Move v2GlobalName undefined check inside replaceClientCreation

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
