### PR TITLE
Move v2GlobalName undefined check inside removeGlobalModule

### DIFF
--- a/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
@@ -7,11 +7,14 @@ import { removeImportDefault } from "./removeImportDefault";
 import { removeImportEquals } from "./removeImportEquals";
 import { removeRequireIdentifier } from "./removeRequireIdentifier";
 
+// Removes the import of "aws-sdk" if it's not used.
 export const removeGlobalModule = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  v2GlobalName: string
+  v2GlobalName?: string
 ) => {
+  if (!v2GlobalName) return;
+
   const identifierUsages = source.find(j.Identifier, { name: v2GlobalName });
 
   // Only usage is import/require.

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -63,10 +63,7 @@ const transformer = async (file: FileInfo, api: API) => {
     replaceClientCreation(j, source, v2Options);
     replaceDocClientCreation(j, source, v2Options);
   }
-
-  if (v2GlobalName) {
-    removeGlobalModule(j, source, v2GlobalName);
-  }
+  removeGlobalModule(j, source, v2GlobalName);
 
   return source.toSource();
 };


### PR DESCRIPTION
### Issue

Similar to https://github.com/awslabs/aws-sdk-js-codemod/pull/520

### Description

Move v2GlobalName undefined check inside removeGlobalModule

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
