### PR TITLE
Import DynamoDB.DocumentClient types from client-dynamodb

### DIFF
--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-basic-type/global-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-basic-type/global-import.input.ts
@@ -1,0 +1,6 @@
+import AWS from "aws-sdk";
+
+const endpoint: AWS.DynamoDB.DocumentClient.Endpoint = {
+  Address: "string",
+  CachePeriodInMinutes: 5,
+};

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-basic-type/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-basic-type/global-import.output.ts
@@ -1,0 +1,6 @@
+import AWS_DynamoDB from "@aws-sdk/client-dynamodb";
+
+const endpoint: AWS_DynamoDB.Endpoint = {
+  Address: "string",
+  CachePeriodInMinutes: 5,
+};


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/530

### Description

Import DynamoDB.DocumentClient types from client-dynamodb

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
