### PR TITLE
Add comments for unsupported named deep import of DocumentClient

### DIFF
--- a/.changeset/khaki-zebras-relax.md
+++ b/.changeset/khaki-zebras-relax.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Add comments for unsupported named deep import of DocumentClient

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-named.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-named.input.js
@@ -1,0 +1,4 @@
+import { DocumentClient } from "aws-sdk/clients/dynamodb";
+
+const documentClient = new DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-named.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-named.output.js
@@ -1,4 +1,4 @@
-// Transformation DocumentClient named import is unsupported in aws-sdk-js-codemod.
+// Transformation of DocumentClient named import from deep path is unsupported in aws-sdk-js-codemod.
 // Please convert to a default import, and rerun codemod.
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
 

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-named.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-named.output.js
@@ -1,5 +1,5 @@
 // Transformation of DocumentClient named import from deep path is unsupported in aws-sdk-js-codemod.
-// Please convert to a default import, and rerun codemod.
+// Please convert to a default import, and re-run aws-sdk-js-codemod.
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
 
 const documentClient = new DocumentClient({ region: "us-west-2" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-named.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-named.output.js
@@ -1,5 +1,6 @@
-import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
-import { DynamoDB } from "@aws-sdk/client-dynamodb";
+// Transformation DocumentClient named import is unsupported in aws-sdk-js-codemod.
+// Please convert to a default import, and rerun codemod.
+import { DocumentClient } from "aws-sdk/clients/dynamodb";
 
-const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
-const response = await documentClient.scan({ TableName: "TABLE_NAME" });
+const documentClient = new DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-named.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-deep-named.output.js
@@ -1,0 +1,5 @@
+import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+
+const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep-named.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep-named.input.js
@@ -1,0 +1,4 @@
+const { DocumentClient } = require("aws-sdk/clients/dynamodb");
+
+const documentClient = new DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep-named.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep-named.output.js
@@ -1,0 +1,6 @@
+// Transformation of DocumentClient named import from deep path is unsupported in aws-sdk-js-codemod.
+// Please convert to a default import, and re-run aws-sdk-js-codemod.
+const { DocumentClient } = require("aws-sdk/clients/dynamodb");
+
+const documentClient = new DocumentClient({ region: "us-west-2" });
+const response = await documentClient.scan({ TableName: "TABLE_NAME" }).promise();

--- a/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
@@ -12,7 +12,7 @@ export interface CommentsForUnsupportedAPIsOptions {
   v2GlobalName?: string;
 }
 
-export const addNotSupportedComments = (
+export const addNotSupportedClientComments = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: CommentsForUnsupportedAPIsOptions

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -1,15 +1,12 @@
-import { Collection, JSCodeshift, Property, ObjectProperty } from "jscodeshift";
+import { Collection, JSCodeshift } from "jscodeshift";
 import { getClientNamesFromDeepImport } from "../client-names";
-import { DOCUMENT_CLIENT, DYNAMODB, OBJECT_PROPERTY_TYPE_LIST } from "../config";
-import { hasRequire } from "../modules";
-import { getClientDeepImportPath } from "../utils";
+import { DYNAMODB } from "../config";
+import { getNodesWithDocClientNamedImportFromDeepPath } from "./getNodesWithDocClientNamedImportFromDeepPath";
 
 export const addNotSupportedComments = (j: JSCodeshift, source: Collection<unknown>) => {
   const clientNamesFromDeepImport = getClientNamesFromDeepImport(source.toSource());
 
   if (clientNamesFromDeepImport.includes(DYNAMODB)) {
-    const deepImportPath = getClientDeepImportPath(DYNAMODB);
-
     const documentClientDeepNamedImportUnsupportedComments = [
       j.commentLine(
         " Transformation of DocumentClient named import from deep path is unsupported in aws-sdk-js-codemod."
@@ -17,53 +14,9 @@ export const addNotSupportedComments = (j: JSCodeshift, source: Collection<unkno
       j.commentLine(" Please convert to a default import, and re-run aws-sdk-js-codemod."),
     ];
 
-    if (hasRequire(j, source)) {
-      source
-        .find(j.VariableDeclarator, {
-          init: {
-            type: "CallExpression",
-            callee: { type: "Identifier", name: "require" },
-            arguments: [{ value: deepImportPath }],
-          },
-        })
-        .filter(
-          (variableDeclarator) =>
-            variableDeclarator.value.id.type === "ObjectPattern" &&
-            (variableDeclarator.value.id.properties || []).some((property) => {
-              if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) {
-                return false;
-              }
-              const propertyKey = (property as Property | ObjectProperty).key;
-              return propertyKey.type === "Identifier" && propertyKey.name === DOCUMENT_CLIENT;
-            })
-        )
-        .forEach((variableDeclarator) => {
-          const comments = variableDeclarator.parentPath.parentPath.value.comments || [];
-          variableDeclarator.parentPath.parentPath.value.comments = [
-            ...comments,
-            ...documentClientDeepNamedImportUnsupportedComments,
-          ];
-        });
-    } else {
-      source
-        .find(j.ImportDeclaration, {
-          type: "ImportDeclaration",
-          source: { value: deepImportPath },
-        })
-        .filter((importDeclaration) =>
-          (importDeclaration.value.specifiers || []).some(
-            (importDeclaration) =>
-              importDeclaration.type === "ImportSpecifier" &&
-              importDeclaration.imported.name === DOCUMENT_CLIENT
-          )
-        )
-        .forEach((importDeclaration) => {
-          const comments = importDeclaration.value.comments || [];
-          importDeclaration.value.comments = [
-            ...comments,
-            ...documentClientDeepNamedImportUnsupportedComments,
-          ];
-        });
-    }
+    getNodesWithDocClientNamedImportFromDeepPath(j, source).forEach((node) => {
+      const comments = node.value.comments || [];
+      node.value.comments = [...comments, ...documentClientDeepNamedImportUnsupportedComments];
+    });
   }
 };

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -44,6 +44,7 @@ export const addNotSupportedComments = (j: JSCodeshift, source: Collection<unkno
             ...documentClientDeepNamedImportUnsupportedComments,
           ];
         });
+    } else {
       source
         .find(j.ImportDeclaration, {
           type: "ImportDeclaration",

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -1,0 +1,47 @@
+import { Collection, JSCodeshift } from "jscodeshift";
+import { getClientNamesFromDeepImport } from "../client-names";
+import { DOCUMENT_CLIENT, DYNAMODB } from "../config";
+import { hasRequire } from "../modules";
+import { getClientDeepImportPath } from "../utils";
+
+export const addNotSupportedComments = (j: JSCodeshift, source: Collection<unknown>) => {
+  const clientNamesFromDeepImport = getClientNamesFromDeepImport(source.toSource());
+
+  if (clientNamesFromDeepImport.includes(DYNAMODB)) {
+    const deepImportPath = getClientDeepImportPath(DYNAMODB);
+
+    const documentClientDeepNamedImportUnsupportedComments = [
+      j.commentLine(
+        " Transformation of DocumentClient named import from deep path is unsupported in aws-sdk-js-codemod."
+      ),
+      j.commentLine(" Please convert to a default import, and re-run aws-sdk-js-codemod."),
+    ];
+
+    if (hasRequire(j, source)) {
+      // const idsFromNamedImport = getRequireIds(j, source, deepImportPath).filter(
+      //   (id) => id.type === "ObjectPattern"
+      // );
+      // ToDo: Add comments.
+    } else {
+      source
+        .find(j.ImportDeclaration, {
+          type: "ImportDeclaration",
+          source: { value: deepImportPath },
+        })
+        .filter((importDeclaration) => {
+          return (importDeclaration.value.specifiers || []).some(
+            (importDeclaration) =>
+              importDeclaration.type === "ImportSpecifier" &&
+              importDeclaration.imported.name === DOCUMENT_CLIENT
+          );
+        })
+        .forEach((importDeclaration) => {
+          const comments = importDeclaration.value.comments || [];
+          importDeclaration.value.comments = [
+            ...comments,
+            ...documentClientDeepNamedImportUnsupportedComments,
+          ];
+        });
+    }
+  }
+};

--- a/src/transforms/v2-to-v3/apis/getNodesWithDocClientNamedImportFromDeepPath.ts
+++ b/src/transforms/v2-to-v3/apis/getNodesWithDocClientNamedImportFromDeepPath.ts
@@ -1,0 +1,54 @@
+import {
+  Collection,
+  JSCodeshift,
+  ObjectProperty,
+  Property,
+  VariableDeclaration,
+} from "jscodeshift";
+import { DOCUMENT_CLIENT, DYNAMODB, OBJECT_PROPERTY_TYPE_LIST } from "../config";
+import { hasRequire } from "../modules";
+import { getClientDeepImportPath } from "../utils";
+
+export const getNodesWithDocClientNamedImportFromDeepPath = (
+  j: JSCodeshift,
+  source: Collection<unknown>
+) => {
+  const deepImportPath = getClientDeepImportPath(DYNAMODB);
+  if (hasRequire(j, source)) {
+    return source
+      .find(j.VariableDeclarator, {
+        init: {
+          type: "CallExpression",
+          callee: { type: "Identifier", name: "require" },
+          arguments: [{ value: deepImportPath }],
+        },
+      })
+      .filter(
+        (variableDeclarator) =>
+          variableDeclarator.value.id.type === "ObjectPattern" &&
+          (variableDeclarator.value.id.properties || []).some((property) => {
+            if (!OBJECT_PROPERTY_TYPE_LIST.includes(property.type)) {
+              return false;
+            }
+            const propertyKey = (property as Property | ObjectProperty).key;
+            return propertyKey.type === "Identifier" && propertyKey.name === DOCUMENT_CLIENT;
+          })
+      )
+      .map(
+        (variableDeclarator) => variableDeclarator.parentPath.parentPath
+      ) as Collection<VariableDeclaration>;
+  } else {
+    return source
+      .find(j.ImportDeclaration, {
+        type: "ImportDeclaration",
+        source: { value: deepImportPath },
+      })
+      .filter((importDeclaration) =>
+        (importDeclaration.value.specifiers || []).some(
+          (importDeclaration) =>
+            importDeclaration.type === "ImportSpecifier" &&
+            importDeclaration.imported.name === DOCUMENT_CLIENT
+        )
+      );
+  }
+};

--- a/src/transforms/v2-to-v3/apis/index.ts
+++ b/src/transforms/v2-to-v3/apis/index.ts
@@ -1,3 +1,4 @@
+export * from "./addNotSupportedComments";
 export * from "./addNotSupportedClientComments";
 export * from "./getClientWaiterStates";
 export * from "./getV3ClientWaiterApiName";

--- a/src/transforms/v2-to-v3/apis/index.ts
+++ b/src/transforms/v2-to-v3/apis/index.ts
@@ -1,4 +1,4 @@
-export * from "./addNotSupportedComments";
+export * from "./addNotSupportedClientComments";
 export * from "./getClientWaiterStates";
 export * from "./getV3ClientWaiterApiName";
 export * from "./getS3SignedUrlApiNames";

--- a/src/transforms/v2-to-v3/client-names/index.ts
+++ b/src/transforms/v2-to-v3/client-names/index.ts
@@ -2,4 +2,3 @@ export * from "./getClientMetadataRecord";
 export * from "./getClientNamesFromGlobal";
 export * from "./getClientNamesRecord";
 export * from "./getClientNamesFromDeepImport";
-export * from "./getRequireIds";

--- a/src/transforms/v2-to-v3/client-names/index.ts
+++ b/src/transforms/v2-to-v3/client-names/index.ts
@@ -1,3 +1,5 @@
 export * from "./getClientMetadataRecord";
 export * from "./getClientNamesFromGlobal";
 export * from "./getClientNamesRecord";
+export * from "./getClientNamesFromDeepImport";
+export * from "./getRequireIds";

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -1,6 +1,7 @@
 import { API, FileInfo } from "jscodeshift";
 
 import {
+  addNotSupportedComments,
   addNotSupportedClientComments,
   removePromiseCalls,
   replaceWaiterApi,
@@ -25,6 +26,8 @@ import { isTypeScriptFile } from "./utils";
 const transformer = async (file: FileInfo, api: API) => {
   const j = isTypeScriptFile(file.path) ? api.jscodeshift.withParser("ts") : api.jscodeshift;
   const source = j(file.source);
+
+  addNotSupportedComments(j, source);
 
   const v2GlobalName = getGlobalNameFromModule(j, source);
   const v2ClientNamesRecord = getClientNamesRecord(j, source);

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -1,7 +1,7 @@
 import { API, FileInfo } from "jscodeshift";
 
 import {
-  addNotSupportedComments,
+  addNotSupportedClientComments,
   removePromiseCalls,
   replaceWaiterApi,
   replaceS3UploadApi,
@@ -45,7 +45,7 @@ const transformer = async (file: FileInfo, api: API) => {
 
   for (const [v2ClientName, v3ClientMetadata] of Object.entries(clientMetadataRecord)) {
     const { v2ClientLocalName } = v3ClientMetadata;
-    addNotSupportedComments(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
+    addNotSupportedClientComments(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
   }
 
   if (source.toSource() !== file.source) {


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/540

### Description

Supports transformation of DocumentClient from named deep import

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
