### PR TITLE
Cache output of getClientIdentifiers

### DIFF
--- a/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
@@ -13,15 +13,17 @@ export interface GetClientIdentifiersOptions {
 export type ClientIdentifier = Identifier | ThisMemberExpression;
 
 // Cache value from clientIdentifiers from first call.
-const clientIdentifiersCache: ClientIdentifier[] = [];
+const clientIdentifiersCache: Record<string, ClientIdentifier[]> = {};
 
 export const getClientIdentifiers = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: GetClientIdentifiersOptions
 ): ClientIdentifier[] => {
-  if (clientIdentifiersCache.length > 0) {
-    return clientIdentifiersCache;
+  const { v2ClientName } = options;
+
+  if (clientIdentifiersCache[v2ClientName]) {
+    return clientIdentifiersCache[v2ClientName];
   }
 
   const namesFromNewExpr = getClientIdNamesFromNewExpr(j, source, options);
@@ -34,8 +36,7 @@ export const getClientIdentifiers = (
   }));
   const clientIdThisExpressions = getClientIdThisExpressions(j, source, clientIdentifiers);
 
-  clientIdentifiersCache.push(...clientIdentifiers);
-  clientIdentifiersCache.push(...clientIdThisExpressions);
+  clientIdentifiersCache[v2ClientName] = [...clientIdentifiers, ...clientIdThisExpressions];
 
-  return clientIdentifiersCache;
+  return clientIdentifiersCache[v2ClientName];
 };

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
@@ -12,11 +12,18 @@ export interface GetClientIdentifiersOptions {
 
 export type ClientIdentifier = Identifier | ThisMemberExpression;
 
+// Cache value from clientIdentifiers from first call.
+const clientIdentifiersCache: ClientIdentifier[] = [];
+
 export const getClientIdentifiers = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: GetClientIdentifiersOptions
 ): ClientIdentifier[] => {
+  if (clientIdentifiersCache.length > 0) {
+    return clientIdentifiersCache;
+  }
+
   const namesFromNewExpr = getClientIdNamesFromNewExpr(j, source, options);
   const namesFromTSTypeRef = getClientIdNamesFromTSTypeRef(j, source, options);
   const clientIdNames = [...new Set([...namesFromNewExpr, ...namesFromTSTypeRef])];
@@ -27,5 +34,8 @@ export const getClientIdentifiers = (
   }));
   const clientIdThisExpressions = getClientIdThisExpressions(j, source, clientIdentifiers);
 
-  return [...clientIdentifiers, ...clientIdThisExpressions];
+  clientIdentifiersCache.push(...clientIdentifiers);
+  clientIdentifiersCache.push(...clientIdThisExpressions);
+
+  return clientIdentifiersCache;
 };


### PR DESCRIPTION
### Issue

Moving out of https://github.com/awslabs/aws-sdk-js-codemod/pull/550

### Description

Caches output of getClientIdentifiers.

This improves the performance of the codemod, and ensures if there's any unstable intermediate state of the code does not impact the output.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
