### PR TITLE
Populate clientIdentifiers in ClientMetadata

### DIFF
--- a/src/transforms/v2-to-v3/apis/index.ts
+++ b/src/transforms/v2-to-v3/apis/index.ts
@@ -10,3 +10,4 @@ export * from "./replaceS3GetSignedUrlApi";
 export * from "./replaceS3UploadApi";
 export * from "./replaceWaiterApi";
 export * from "./getCommandName";
+export * from "./getClientIdentifiers";

--- a/src/transforms/v2-to-v3/client-names/getClientMetadataRecord.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientMetadataRecord.ts
@@ -1,8 +1,11 @@
+import { Collection, JSCodeshift } from "jscodeshift";
 import { ClientMetadataRecord } from "../types";
 import { getV3ClientName } from "./getV3ClientName";
 import { getV3ClientPackageName } from "./getV3ClientPackageName";
 
 export const getClientMetadataRecord = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
   v2ClientNamesRecord: Record<string, string>
 ): ClientMetadataRecord =>
   Object.entries(

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -44,7 +44,7 @@ const transformer = async (file: FileInfo, api: API) => {
     }
   }
 
-  const clientMetadataRecord = getClientMetadataRecord(v2ClientNamesRecord);
+  const clientMetadataRecord = getClientMetadataRecord(j, source, v2ClientNamesRecord);
 
   for (const [v2ClientName, v3ClientMetadata] of Object.entries(clientMetadataRecord)) {
     const { v2ClientLocalName } = v3ClientMetadata;

--- a/src/transforms/v2-to-v3/types.ts
+++ b/src/transforms/v2-to-v3/types.ts
@@ -1,6 +1,9 @@
+import { ClientIdentifier } from "./apis";
+
 export type ClientMetadataRecord = Record<string, ClientMetadata>;
 
 export interface ClientMetadata {
+  clientIdentifiers: ClientIdentifier[];
   v2ClientLocalName: string;
   v3ClientName: string;
   v3ClientPackageName: string;


### PR DESCRIPTION
### Issue

Alternative to https://github.com/awslabs/aws-sdk-js-codemod/pull/551

### Description

Populate clientIdentifiers in ClientMetadata

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
