### PR TITLE
Store clientIdentifiersRecord at transformer level

### DIFF
--- a/.changeset/eleven-lemons-eat.md
+++ b/.changeset/eleven-lemons-eat.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Store clientIdentifiersRecord at transformer level

--- a/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { FUNCTION_TYPE_LIST } from "../config";
+import { FUNCTION_TYPE_LIST, S3 } from "../config";
 import { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
 import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
@@ -45,7 +45,7 @@ export const addNotSupportedClientComments = (
     }
   }
 
-  if (v2ClientName === "S3") {
+  if (v2ClientName === S3) {
     for (const clientId of clientIdentifiers) {
       const apiMetadata = [
         {

--- a/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
@@ -2,11 +2,12 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 import { FUNCTION_TYPE_LIST } from "../config";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
-import { getClientIdentifiers } from "./getClientIdentifiers";
+import { ClientIdentifier } from "./getClientIdentifiers";
 import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";
 
 export interface CommentsForUnsupportedAPIsOptions {
+  clientIdentifiers: ClientIdentifier[];
   v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;
@@ -17,7 +18,7 @@ export const addNotSupportedClientComments = (
   source: Collection<unknown>,
   options: CommentsForUnsupportedAPIsOptions
 ): void => {
-  const clientIdentifiers = getClientIdentifiers(j, source, options);
+  const { clientIdentifiers } = options;
 
   for (const clientId of clientIdentifiers) {
     const waiterStates = getClientWaiterStates(j, source, options);

--- a/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
@@ -7,10 +7,8 @@ import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";
 
 export interface CommentsForUnsupportedAPIsOptions {
-  clientIdentifiers: ClientIdentifier[];
   v2ClientName: string;
-  v2ClientLocalName: string;
-  v2GlobalName?: string;
+  clientIdentifiers: ClientIdentifier[];
 }
 
 export const addNotSupportedClientComments = (
@@ -18,10 +16,10 @@ export const addNotSupportedClientComments = (
   source: Collection<unknown>,
   options: CommentsForUnsupportedAPIsOptions
 ): void => {
-  const { clientIdentifiers } = options;
+  const { v2ClientName, clientIdentifiers } = options;
 
   for (const clientId of clientIdentifiers) {
-    const waiterStates = getClientWaiterStates(j, source, options);
+    const waiterStates = getClientWaiterStates(j, source, clientIdentifiers);
 
     for (const waiterState of waiterStates) {
       source
@@ -47,7 +45,7 @@ export const addNotSupportedClientComments = (
     }
   }
 
-  if (options.v2ClientName === "S3") {
+  if (v2ClientName === "S3") {
     for (const clientId of clientIdentifiers) {
       const apiMetadata = [
         {

--- a/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedClientComments.ts
@@ -1,8 +1,8 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { FUNCTION_TYPE_LIST } from "../config";
+import { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
-import { ClientIdentifier } from "./getClientIdentifiers";
 import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";
 

--- a/src/transforms/v2-to-v3/apis/getClientApiCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getClientApiCallExpression.ts
@@ -1,6 +1,6 @@
 import { CallExpression } from "jscodeshift";
 
-import { ClientIdentifier } from "./getClientIdentifiers";
+import { ClientIdentifier } from "../types";
 
 export const getClientApiCallExpression = (
   clientId: ClientIdentifier,

--- a/src/transforms/v2-to-v3/apis/getClientIdThisExpressions.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdThisExpressions.ts
@@ -1,10 +1,5 @@
-import { Collection, Identifier, JSCodeshift, MemberExpression, ThisExpression } from "jscodeshift";
-
-export interface ThisMemberExpression {
-  type: "MemberExpression";
-  object: ThisExpression;
-  property: Identifier;
-}
+import { Collection, Identifier, JSCodeshift, MemberExpression } from "jscodeshift";
+import { ThisMemberExpression } from "../types";
 
 const thisMemberExpression = { type: "MemberExpression", object: { type: "ThisExpression" } };
 

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiers.ts
@@ -1,16 +1,15 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
+import { ClientIdentifier } from "../types";
 import { getClientIdNamesFromNewExpr } from "./getClientIdNamesFromNewExpr";
 import { getClientIdNamesFromTSTypeRef } from "./getClientIdNamesFromTSTypeRef";
-import { getClientIdThisExpressions, ThisMemberExpression } from "./getClientIdThisExpressions";
+import { getClientIdThisExpressions } from "./getClientIdThisExpressions";
 
 export interface GetClientIdentifiersOptions {
   v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;
 }
-
-export type ClientIdentifier = Identifier | ThisMemberExpression;
 
 export const getClientIdentifiers = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiersRecord.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiersRecord.ts
@@ -1,0 +1,24 @@
+import { Collection, JSCodeshift } from "jscodeshift";
+
+import { ClientIdentifier, getClientIdentifiers } from "./getClientIdentifiers";
+
+export interface GetClientIdentifiersRecordOptions {
+  v2GlobalName?: string;
+  v2ClientNamesRecord: Record<string, string>;
+}
+
+export const getClientIdentifiersRecord = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  { v2GlobalName, v2ClientNamesRecord }: GetClientIdentifiersRecordOptions
+): Record<string, ClientIdentifier[]> =>
+  Object.fromEntries(
+    Object.entries(v2ClientNamesRecord).map(([v2ClientName, v2ClientLocalName]) => [
+      v2ClientName,
+      getClientIdentifiers(j, source, {
+        v2ClientName,
+        v2ClientLocalName,
+        v2GlobalName,
+      }),
+    ])
+  );

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiersRecord.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiersRecord.ts
@@ -16,10 +16,6 @@ export const getClientIdentifiersRecord = (
   Object.fromEntries(
     Object.entries(v2ClientNamesRecord).map(([v2ClientName, v2ClientLocalName]) => [
       v2ClientName,
-      getClientIdentifiers(j, source, {
-        v2ClientName,
-        v2ClientLocalName,
-        v2GlobalName,
-      }),
+      getClientIdentifiers(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName }),
     ])
   );

--- a/src/transforms/v2-to-v3/apis/getClientIdentifiersRecord.ts
+++ b/src/transforms/v2-to-v3/apis/getClientIdentifiersRecord.ts
@@ -1,6 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier, getClientIdentifiers } from "./getClientIdentifiers";
+import { ClientIdentifiersRecord } from "../types";
+import { getClientIdentifiers } from "./getClientIdentifiers";
 
 export interface GetClientIdentifiersRecordOptions {
   v2GlobalName?: string;
@@ -11,7 +12,7 @@ export const getClientIdentifiersRecord = (
   j: JSCodeshift,
   source: Collection<unknown>,
   { v2GlobalName, v2ClientNamesRecord }: GetClientIdentifiersRecordOptions
-): Record<string, ClientIdentifier[]> =>
+): ClientIdentifiersRecord =>
   Object.fromEntries(
     Object.entries(v2ClientNamesRecord).map(([v2ClientName, v2ClientLocalName]) => [
       v2ClientName,

--- a/src/transforms/v2-to-v3/apis/getClientWaiterCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/getClientWaiterCallExpression.ts
@@ -1,6 +1,6 @@
 import { CallExpression } from "jscodeshift";
 
-import { ClientIdentifier } from "./getClientIdentifiers";
+import { ClientIdentifier } from "../types";
 
 export const getClientWaiterCallExpression = (
   clientId: ClientIdentifier,

--- a/src/transforms/v2-to-v3/apis/getClientWaiterStates.ts
+++ b/src/transforms/v2-to-v3/apis/getClientWaiterStates.ts
@@ -1,21 +1,12 @@
 import { Collection, JSCodeshift } from "jscodeshift";
-
-import { getClientIdentifiers } from "./getClientIdentifiers";
-
-export interface GetClientWaiterStatesOptions {
-  v2ClientName: string;
-  v2ClientLocalName: string;
-  v2GlobalName?: string;
-}
+import { ClientIdentifier } from "../types";
 
 export const getClientWaiterStates = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: GetClientWaiterStatesOptions
+  clientIdentifiers: ClientIdentifier[]
 ): Set<string> => {
   const waiterStates: string[] = [];
-
-  const clientIdentifiers = getClientIdentifiers(j, source, options);
 
   for (const clientId of clientIdentifiers) {
     source

--- a/src/transforms/v2-to-v3/apis/getS3SignedUrlApiNames.ts
+++ b/src/transforms/v2-to-v3/apis/getS3SignedUrlApiNames.ts
@@ -2,12 +2,6 @@ import { Collection, JSCodeshift, Literal } from "jscodeshift";
 
 import { ClientIdentifier } from "../types";
 
-export interface GetS3SignedUrlApiNameOptions {
-  v2ClientName: string;
-  v2ClientLocalName: string;
-  v2GlobalName?: string;
-}
-
 export const getS3SignedUrlApiNames = (
   j: JSCodeshift,
   source: Collection<unknown>,

--- a/src/transforms/v2-to-v3/apis/getS3SignedUrlApiNames.ts
+++ b/src/transforms/v2-to-v3/apis/getS3SignedUrlApiNames.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift, Literal } from "jscodeshift";
 
-import { getClientIdentifiers } from "./getClientIdentifiers";
+import { ClientIdentifier } from "../types";
 
 export interface GetS3SignedUrlApiNameOptions {
   v2ClientName: string;
@@ -11,12 +11,9 @@ export interface GetS3SignedUrlApiNameOptions {
 export const getS3SignedUrlApiNames = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: GetS3SignedUrlApiNameOptions
+  clientIdentifiers: ClientIdentifier[]
 ): string[] => {
-  if (options.v2ClientName !== "S3") return [];
-
   const apiNames: Set<string> = new Set();
-  const clientIdentifiers = getClientIdentifiers(j, source, options);
 
   for (const clientId of clientIdentifiers) {
     for (const apiName of ["getSignedUrl", "getSignedUrlPromise"]) {

--- a/src/transforms/v2-to-v3/apis/index.ts
+++ b/src/transforms/v2-to-v3/apis/index.ts
@@ -10,3 +10,4 @@ export * from "./replaceS3GetSignedUrlApi";
 export * from "./replaceS3UploadApi";
 export * from "./replaceWaiterApi";
 export * from "./getCommandName";
+export * from "./getClientIdentifiersRecord";

--- a/src/transforms/v2-to-v3/apis/isS3GetSignedUrlApiUsed.ts
+++ b/src/transforms/v2-to-v3/apis/isS3GetSignedUrlApiUsed.ts
@@ -1,22 +1,12 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getClientIdentifiers } from "./getClientIdentifiers";
-
-export interface IsS3GetSignedUrlApiUsedOptions {
-  v2ClientName: string;
-  v2ClientLocalName: string;
-  v2GlobalName?: string;
-}
+import { ClientIdentifier } from "../types";
 
 export const isS3GetSignedUrlApiUsed = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: IsS3GetSignedUrlApiUsedOptions
+  clientIdentifiers: ClientIdentifier[]
 ) => {
-  if (options.v2ClientName !== "S3") return false;
-
-  const clientIdentifiers = getClientIdentifiers(j, source, options);
-
   for (const clientId of clientIdentifiers) {
     for (const apiName of ["getSignedUrl", "getSignedUrlPromise"]) {
       const s3GetSignedUrlCallExpressions = source.find(j.CallExpression, {

--- a/src/transforms/v2-to-v3/apis/isS3UploadApiUsed.ts
+++ b/src/transforms/v2-to-v3/apis/isS3UploadApiUsed.ts
@@ -1,22 +1,12 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getClientIdentifiers } from "./getClientIdentifiers";
-
-export interface IsS3UploadApiUsedOptions {
-  v2ClientName: string;
-  v2ClientLocalName: string;
-  v2GlobalName?: string;
-}
+import { ClientIdentifier } from "../types";
 
 export const isS3UploadApiUsed = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: IsS3UploadApiUsedOptions
+  clientIdentifiers: ClientIdentifier[]
 ) => {
-  if (options.v2ClientName !== "S3") return false;
-
-  const clientIdentifiers = getClientIdentifiers(j, source, options);
-
   for (const clientId of clientIdentifiers) {
     const s3UploadCallExpressions = source.find(j.CallExpression, {
       callee: {

--- a/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
-import { ClientIdentifier } from "./getClientIdentifiers";
+import { ClientIdentifier } from "../types";
 import { removePromiseForCallExpression } from "./removePromiseForCallExpression";
 
 export interface RemovePromiseCallsOptions {

--- a/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
@@ -3,12 +3,6 @@ import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 import { ClientIdentifier } from "../types";
 import { removePromiseForCallExpression } from "./removePromiseForCallExpression";
 
-export interface RemovePromiseCallsOptions {
-  v2ClientName: string;
-  v2ClientLocalName: string;
-  v2GlobalName?: string;
-}
-
 // Removes .promise() from client API calls.
 export const removePromiseCalls = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseCalls.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
-import { getClientIdentifiers } from "./getClientIdentifiers";
+import { ClientIdentifier } from "./getClientIdentifiers";
 import { removePromiseForCallExpression } from "./removePromiseForCallExpression";
 
 export interface RemovePromiseCallsOptions {
@@ -13,10 +13,8 @@ export interface RemovePromiseCallsOptions {
 export const removePromiseCalls = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: RemovePromiseCallsOptions
+  clientIdentifiers: ClientIdentifier[]
 ): void => {
-  const clientIdentifiers = getClientIdentifiers(j, source, options);
-
   for (const clientId of clientIdentifiers) {
     // Remove .promise() from client API calls.
     source

--- a/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
@@ -9,8 +9,9 @@ import {
 } from "jscodeshift";
 
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
+import { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
-import { ClientIdentifier, getClientIdentifiers } from "./getClientIdentifiers";
+import { getClientIdentifiers } from "./getClientIdentifiers";
 import { getCommandName } from "./getCommandName";
 
 export interface ReplaceS3GetSignedUrlApiOptions {

--- a/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
@@ -11,7 +11,6 @@ import {
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
 import { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
-import { getClientIdentifiers } from "./getClientIdentifiers";
 import { getCommandName } from "./getCommandName";
 
 export interface ReplaceS3GetSignedUrlApiOptions {
@@ -24,12 +23,8 @@ export interface ReplaceS3GetSignedUrlApiOptions {
 export const replaceS3GetSignedUrlApi = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: ReplaceS3GetSignedUrlApiOptions
+  clientIdentifiers: ClientIdentifier[]
 ): void => {
-  if (options.v2ClientName !== "S3") return;
-
-  const clientIdentifiers = getClientIdentifiers(j, source, options);
-
   for (const clientId of clientIdentifiers) {
     for (const getSignedUrlApiName of ["getSignedUrl", "getSignedUrlPromise"]) {
       source

--- a/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3GetSignedUrlApi.ts
@@ -13,12 +13,6 @@ import { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
 import { getCommandName } from "./getCommandName";
 
-export interface ReplaceS3GetSignedUrlApiOptions {
-  v2ClientName: string;
-  v2ClientLocalName: string;
-  v2GlobalName?: string;
-}
-
 // Updates `s3.getSignedUrl()` API with `await getSignedUrl(s3, command)` API.
 export const replaceS3GetSignedUrlApi = (
   j: JSCodeshift,

--- a/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceS3UploadApi.ts
@@ -1,24 +1,14 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
+import { ClientIdentifier } from "../types";
 import { getClientApiCallExpression } from "./getClientApiCallExpression";
-import { getClientIdentifiers } from "./getClientIdentifiers";
-
-export interface ReplaceS3UploadApiOptions {
-  v2ClientName: string;
-  v2ClientLocalName: string;
-  v2GlobalName?: string;
-}
 
 // Updates `s3.upload()` API with `new Upload()` API.
 export const replaceS3UploadApi = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: ReplaceS3UploadApiOptions
+  clientIdentifiers: ClientIdentifier[]
 ): void => {
-  if (options.v2ClientName !== "S3") return;
-
-  const clientIdentifiers = getClientIdentifiers(j, source, options);
-
   for (const clientId of clientIdentifiers) {
     source
       .find(j.CallExpression, getClientApiCallExpression(clientId, "upload"))

--- a/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
@@ -23,7 +23,7 @@ export const replaceWaiterApi = (
   const clientIdentifiers = getClientIdentifiers(j, source, options);
 
   for (const clientId of clientIdentifiers) {
-    const waiterStates = getClientWaiterStates(j, source, options);
+    const waiterStates = getClientWaiterStates(j, source, clientIdentifiers);
 
     for (const waiterState of waiterStates) {
       const v3WaiterApiName = getV3ClientWaiterApiName(waiterState);

--- a/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
+++ b/src/transforms/v2-to-v3/apis/replaceWaiterApi.ts
@@ -1,27 +1,19 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
+import { ClientIdentifier } from "../types";
 import { getArgsWithoutWaiterConfig } from "./getArgsWithoutWaiterConfig";
-import { getClientIdentifiers } from "./getClientIdentifiers";
 import { getClientWaiterCallExpression } from "./getClientWaiterCallExpression";
 import { getClientWaiterStates } from "./getClientWaiterStates";
 import { getV3ClientWaiterApiName } from "./getV3ClientWaiterApiName";
 import { getWaiterConfig } from "./getWaiterConfig";
 import { getWaiterConfigValue } from "./getWaiterConfigValue";
 
-export interface ReplaceWaiterApiOptions {
-  v2ClientName: string;
-  v2ClientLocalName: string;
-  v2GlobalName?: string;
-}
-
 // Updates .waitFor() API with waitUntil* API.
 export const replaceWaiterApi = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: ReplaceWaiterApiOptions
+  clientIdentifiers: ClientIdentifier[]
 ): void => {
-  const clientIdentifiers = getClientIdentifiers(j, source, options);
-
   for (const clientId of clientIdentifiers) {
     const waiterStates = getClientWaiterStates(j, source, clientIdentifiers);
 

--- a/src/transforms/v2-to-v3/config/constants.ts
+++ b/src/transforms/v2-to-v3/config/constants.ts
@@ -1,5 +1,6 @@
 export const PACKAGE_NAME = "aws-sdk";
 
+export const S3 = "S3";
 export const DYNAMODB = "DynamoDB";
 export const DOCUMENT_CLIENT = "DocumentClient";
 export const DYNAMODB_DOCUMENT = "DynamoDBDocument";

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -65,25 +65,27 @@ export const addClientModules = (
     });
   }
 
-  if (isS3UploadApiUsed(j, source, options)) {
-    addClientNamedModule(j, source, {
-      ...options,
-      importedName: "Upload",
-      v3ClientPackageName: "@aws-sdk/lib-storage",
-    });
-  }
-
-  if (options.v2ClientName === S3 && isS3GetSignedUrlApiUsed(j, source, clientIdentifiers)) {
-    addClientNamedModule(j, source, {
-      ...options,
-      importedName: "getSignedUrl",
-      v3ClientPackageName: "@aws-sdk/s3-request-presigner",
-    });
-    for (const apiName of getS3SignedUrlApiNames(j, source, clientIdentifiers)) {
+  if (options.v2ClientName === S3) {
+    if (isS3UploadApiUsed(j, source, clientIdentifiers)) {
       addClientNamedModule(j, source, {
         ...options,
-        importedName: getCommandName(apiName),
+        importedName: "Upload",
+        v3ClientPackageName: "@aws-sdk/lib-storage",
       });
+    }
+
+    if (isS3GetSignedUrlApiUsed(j, source, clientIdentifiers)) {
+      addClientNamedModule(j, source, {
+        ...options,
+        importedName: "getSignedUrl",
+        v3ClientPackageName: "@aws-sdk/s3-request-presigner",
+      });
+      for (const apiName of getS3SignedUrlApiNames(j, source, clientIdentifiers)) {
+        addClientNamedModule(j, source, {
+          ...options,
+          importedName: getCommandName(apiName),
+        });
+      }
     }
   }
 

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -8,7 +8,13 @@ import {
   isS3GetSignedUrlApiUsed,
   isS3UploadApiUsed,
 } from "../apis";
-import { DOCUMENT_CLIENT, DYNAMODB, DYNAMODB_DOCUMENT, DYNAMODB_DOCUMENT_CLIENT } from "../config";
+import {
+  DOCUMENT_CLIENT,
+  DYNAMODB,
+  DYNAMODB_DOCUMENT,
+  DYNAMODB_DOCUMENT_CLIENT,
+  S3,
+} from "../config";
 import { getV3ClientTypesCount } from "../ts-type";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
@@ -67,13 +73,13 @@ export const addClientModules = (
     });
   }
 
-  if (isS3GetSignedUrlApiUsed(j, source, options)) {
+  if (options.v2ClientName === S3 && isS3GetSignedUrlApiUsed(j, source, clientIdentifiers)) {
     addClientNamedModule(j, source, {
       ...options,
       importedName: "getSignedUrl",
       v3ClientPackageName: "@aws-sdk/s3-request-presigner",
     });
-    for (const apiName of getS3SignedUrlApiNames(j, source, options)) {
+    for (const apiName of getS3SignedUrlApiNames(j, source, clientIdentifiers)) {
       addClientNamedModule(j, source, {
         ...options,
         importedName: getCommandName(apiName),

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -25,6 +25,8 @@ export const addClientModules = (
   source: Collection<unknown>,
   options: ClientModulesOptions
 ): void => {
+  const { clientIdentifiers } = options;
+
   const { addClientDefaultModule, addClientNamedModule } = hasRequire(j, source)
     ? requireModule
     : hasImportEquals(j, source)
@@ -34,7 +36,7 @@ export const addClientModules = (
   const v3ClientTypesCount = getV3ClientTypesCount(j, source, options);
   const newExpressionCount = getNewExpressionCount(j, source, options);
   const clientTSTypeRefCount = getClientTSTypeRefCount(j, source, options);
-  const waiterStates = getClientWaiterStates(j, source, options);
+  const waiterStates = getClientWaiterStates(j, source, clientIdentifiers);
 
   // Add default import for types, if needed.
   if (v3ClientTypesCount > 0) {

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -1,9 +1,12 @@
+import { ClientIdentifier } from "../types";
+
 export interface ClientModulesOptions {
   v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;
   v3ClientName: string;
   v3ClientPackageName: string;
+  clientIdentifiers: ClientIdentifier[];
 }
 
 export interface ImportSpecifierOptions {

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -78,7 +78,11 @@ const transformer = async (file: FileInfo, api: API) => {
     }
 
     removePromiseCalls(j, source, clientIdentifiers);
-    replaceS3GetSignedUrlApi(j, source, v2Options);
+
+    if (v2ClientName === S3) {
+      replaceS3GetSignedUrlApi(j, source, clientIdentifiers);
+    }
+
     replaceWaiterApi(j, source, v2Options);
 
     replaceClientCreation(j, source, v2Options);

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -67,6 +67,7 @@ const transformer = async (file: FileInfo, api: API) => {
   }
 
   for (const [v2ClientName, v3ClientMetadata] of Object.entries(clientMetadataRecord)) {
+    const clientIdentifiers = clientIdentifiersRecord[v2ClientName];
     const { v2ClientLocalName, v3ClientName, v3ClientPackageName } = v3ClientMetadata;
 
     const v2Options = { v2ClientName, v2ClientLocalName, v2GlobalName };
@@ -76,7 +77,7 @@ const transformer = async (file: FileInfo, api: API) => {
     replaceTSTypeReference(j, source, { ...v2Options, v3ClientName });
     removeClientModule(j, source, v2Options);
     replaceS3UploadApi(j, source, v2Options);
-    removePromiseCalls(j, source, v2Options);
+    removePromiseCalls(j, source, clientIdentifiers);
     replaceS3GetSignedUrlApi(j, source, v2Options);
     replaceWaiterApi(j, source, v2Options);
 

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -15,6 +15,7 @@ import {
   getClientNamesFromGlobal,
   getClientNamesRecord,
 } from "./client-names";
+import { S3 } from "./config";
 import {
   addClientModules,
   getGlobalNameFromModule,
@@ -70,7 +71,12 @@ const transformer = async (file: FileInfo, api: API) => {
     addClientModules(j, source, { ...v2Options, ...v3Options, clientIdentifiers });
     replaceTSTypeReference(j, source, { ...v2Options, v3ClientName });
     removeClientModule(j, source, v2Options);
-    replaceS3UploadApi(j, source, v2Options);
+
+    if (v2ClientName === S3) {
+      // Needs to be called before removing promise calls, as replacement has `.done()` call.
+      replaceS3UploadApi(j, source, clientIdentifiers);
+    }
+
     removePromiseCalls(j, source, clientIdentifiers);
     replaceS3GetSignedUrlApi(j, source, v2Options);
     replaceWaiterApi(j, source, v2Options);

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -7,8 +7,8 @@ import {
   replaceWaiterApi,
   replaceS3UploadApi,
   replaceS3GetSignedUrlApi,
+  getClientIdentifiersRecord,
 } from "./apis";
-import { getClientIdentifiersRecord } from "./apis/getClientIdentifiersRecord";
 import { replaceClientCreation, replaceDocClientCreation } from "./client-instances";
 import {
   getClientMetadataRecord,

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -51,15 +51,9 @@ const transformer = async (file: FileInfo, api: API) => {
     v2ClientNamesRecord,
   });
 
-  for (const [v2ClientName, v3ClientMetadata] of Object.entries(clientMetadataRecord)) {
-    const { v2ClientLocalName } = v3ClientMetadata;
+  for (const v2ClientName of Object.keys(clientMetadataRecord)) {
     const clientIdentifiers = clientIdentifiersRecord[v2ClientName];
-    addNotSupportedClientComments(j, source, {
-      clientIdentifiers,
-      v2ClientName,
-      v2ClientLocalName,
-      v2GlobalName,
-    });
+    addNotSupportedClientComments(j, source, { v2ClientName, clientIdentifiers });
   }
 
   if (source.toSource() !== file.source) {
@@ -73,7 +67,7 @@ const transformer = async (file: FileInfo, api: API) => {
     const v2Options = { v2ClientName, v2ClientLocalName, v2GlobalName };
     const v3Options = { v3ClientName, v3ClientPackageName };
 
-    addClientModules(j, source, { ...v2Options, ...v3Options });
+    addClientModules(j, source, { ...v2Options, ...v3Options, clientIdentifiers });
     replaceTSTypeReference(j, source, { ...v2Options, v3ClientName });
     removeClientModule(j, source, v2Options);
     replaceS3UploadApi(j, source, v2Options);

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -8,6 +8,7 @@ import {
   replaceS3UploadApi,
   replaceS3GetSignedUrlApi,
 } from "./apis";
+import { getClientIdentifiersRecord } from "./apis/getClientIdentifiersRecord";
 import { replaceClientCreation, replaceDocClientCreation } from "./client-instances";
 import {
   getClientMetadataRecord,
@@ -45,10 +46,20 @@ const transformer = async (file: FileInfo, api: API) => {
   }
 
   const clientMetadataRecord = getClientMetadataRecord(v2ClientNamesRecord);
+  const clientIdentifiersRecord = getClientIdentifiersRecord(j, source, {
+    v2GlobalName,
+    v2ClientNamesRecord,
+  });
 
   for (const [v2ClientName, v3ClientMetadata] of Object.entries(clientMetadataRecord)) {
     const { v2ClientLocalName } = v3ClientMetadata;
-    addNotSupportedClientComments(j, source, { v2ClientName, v2ClientLocalName, v2GlobalName });
+    const clientIdentifiers = clientIdentifiersRecord[v2ClientName];
+    addNotSupportedClientComments(j, source, {
+      clientIdentifiers,
+      v2ClientName,
+      v2ClientLocalName,
+      v2GlobalName,
+    });
   }
 
   if (source.toSource() !== file.source) {

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -83,7 +83,7 @@ const transformer = async (file: FileInfo, api: API) => {
       replaceS3GetSignedUrlApi(j, source, clientIdentifiers);
     }
 
-    replaceWaiterApi(j, source, v2Options);
+    replaceWaiterApi(j, source, clientIdentifiers);
 
     replaceClientCreation(j, source, v2Options);
     replaceDocClientCreation(j, source, v2Options);

--- a/src/transforms/v2-to-v3/types.ts
+++ b/src/transforms/v2-to-v3/types.ts
@@ -1,3 +1,5 @@
+import { Identifier, ThisExpression } from "jscodeshift";
+
 export type ClientMetadataRecord = Record<string, ClientMetadata>;
 
 export interface ClientMetadata {
@@ -5,3 +7,12 @@ export interface ClientMetadata {
   v3ClientName: string;
   v3ClientPackageName: string;
 }
+
+export interface ThisMemberExpression {
+  type: "MemberExpression";
+  object: ThisExpression;
+  property: Identifier;
+}
+
+export type ClientIdentifier = Identifier | ThisMemberExpression;
+export type ClientIdentifiersRecord = Record<string, ClientIdentifier[]>;


### PR DESCRIPTION
### Issue

Alternative to https://github.com/awslabs/aws-sdk-js-codemod/pull/551
Required for https://github.com/awslabs/aws-sdk-js-codemod/pull/550

### Description

Stores clientIdentifiersRecord at transformer level, and passes it wherever required.

This improves the performance of the codemod, and ensures if there's any unstable intermediate state of the code does not impact the output.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
