### PR TITLE
chore(deps-dev): bump typescript to 5.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prettier": "3.0.0",
     "simple-git-hooks": "^2.8.1",
     "tsx": "^3.12.1",
-    "typescript": "~5.1.6",
+    "typescript": "~5.2.2",
     "vitest": "~0.34.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1901,7 +1901,7 @@ __metadata:
     prettier: 3.0.0
     simple-git-hooks: ^2.8.1
     tsx: ^3.12.1
-    typescript: ~5.1.6
+    typescript: ~5.2.2
     vitest: ~0.34.1
   bin:
     aws-sdk-js-codemod: bin/aws-sdk-js-codemod
@@ -6293,23 +6293,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.1.6":
-  version: 5.1.6
-  resolution: "typescript@npm:5.1.6"
+"typescript@npm:~5.2.2":
+  version: 5.2.2
+  resolution: "typescript@npm:5.2.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
+  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~5.1.6#~builtin<compat/typescript>":
-  version: 5.1.6
-  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"
+"typescript@patch:typescript@~5.2.2#~builtin<compat/typescript>":
+  version: 5.2.2
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f53bfe97f7c8b2b6d23cf572750d4e7d1e0c5fff1c36d859d0ec84556a827b8785077bc27676bf7e71fae538e517c3ecc0f37e7f593be913d884805d931bc8be
+  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/

### Description

Bumps typescript to 5.2.x

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
