### PR TITLE
chore(deps-dev): bump prettier to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^8.48.0",
     "eslint-plugin-import": "^2.28.1",
     "lint-staged": "^13.0.3",
-    "prettier": "3.0.0",
+    "prettier": "3.0.3",
     "simple-git-hooks": "^2.8.1",
     "tsx": "^3.12.1",
     "typescript": "~5.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1898,7 +1898,7 @@ __metadata:
     eslint-plugin-import: ^2.28.1
     jscodeshift: 0.15.0
     lint-staged: ^13.0.3
-    prettier: 3.0.0
+    prettier: 3.0.3
     simple-git-hooks: ^2.8.1
     tsx: ^3.12.1
     typescript: ~5.2.2
@@ -5191,12 +5191,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.0.0":
-  version: 3.0.0
-  resolution: "prettier@npm:3.0.0"
+"prettier@npm:3.0.3":
+  version: 3.0.3
+  resolution: "prettier@npm:3.0.3"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 6a832876a1552dc58330d2467874e5a0b46b9ccbfc5d3531eb69d15684743e7f83dc9fbd202db6270446deba9c82b79d24383d09924c462b457136a759425e33
+  checksum: e10b9af02b281f6c617362ebd2571b1d7fc9fb8a3bd17e371754428cda992e5e8d8b7a046e8f7d3e2da1dcd21aa001e2e3c797402ebb6111b5cd19609dd228e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Adds support for Typescript 5.2 https://github.com/prettier/prettier/blob/main/CHANGELOG.md#303

### Description

Bump prettier to 3.0.3

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
