### PR TITLE
Transform Input/Output types without operation name prefix

### DIFF
--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-import.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-import.input.ts
@@ -11,3 +11,9 @@ const getCallerIdentityInput: AWS.STS.GetCallerIdentityRequest = {};
 const getCallerIdentityOutput: AWS.STS.GetCallerIdentityResponse = await stsClient
   .getCallerIdentity(getCallerIdentityInput)
   .promise();
+
+const lambdaClient = new AWS.Lambda({ region: "us-west-2" });
+const invokeInput: AWS.Lambda.InvocationRequest = { FunctionName: "my-function" };
+const invokeOutput: AWS.Lambda.InvocationResponse = await lambdaClient
+  .invoke(invokeInput)
+  .promise();

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-import.output.ts
@@ -10,6 +10,12 @@ const {
   STS
 } = AWS_STS;
 
+import * as AWS_Lambda from "@aws-sdk/client-lambda";
+
+const {
+  Lambda
+} = AWS_Lambda;
+
 const ddbClient = new DynamoDB({ region: "us-west-2" });
 const listTablesInput: AWS_DynamoDB.ListTablesCommandInput = { Limit: 10 };
 const listTablesOutput: AWS_DynamoDB.ListTablesCommandOutput = await ddbClient
@@ -19,3 +25,8 @@ const stsClient = new STS({ region: "us-west-2" });
 const getCallerIdentityInput: AWS_STS.GetCallerIdentityCommandInput = {};
 const getCallerIdentityOutput: AWS_STS.GetCallerIdentityCommandOutput = await stsClient
   .getCallerIdentity(getCallerIdentityInput);
+
+const lambdaClient = new Lambda({ region: "us-west-2" });
+const invokeInput: AWS_Lambda.InvokeCommandInput = { FunctionName: "my-function" };
+const invokeOutput: AWS_Lambda.InvokeCommandOutput = await lambdaClient
+  .invoke(invokeInput);


### PR DESCRIPTION
### Issue

Fixes https://github.com/awslabs/aws-sdk-js-codemod/issues/560

### Description

Transforms Input/Output types without operation name prefix

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
