### PR TITLE
Remove promise calls when parentPath is CallExpression

### DIFF
--- a/.changeset/warm-flowers-sell.md
+++ b/.changeset/warm-flowers-sell.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove promise calls when parentPath is CallExpression

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/call-expression.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/call-expression.input.js
@@ -1,0 +1,6 @@
+import AWS from "aws-sdk";
+
+const client = new AWS.DynamoDB();
+
+const promiseArray = [];
+promiseArray.push(client.listTables().promise());

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/call-expression.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/call-expression.output.js
@@ -1,0 +1,6 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+
+const client = new DynamoDB();
+
+const promiseArray = [];
+promiseArray.push(client.listTables());

--- a/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
+++ b/src/transforms/v2-to-v3/apis/removePromiseForCallExpression.ts
@@ -5,7 +5,10 @@ export const removePromiseForCallExpression = (
   j: JSCodeshift,
   callExpression: ASTPath<CallExpression>
 ) => {
-  switch (callExpression.parentPath.value.type) {
+  const parentPathValue = Array.isArray(callExpression.parentPath.value)
+    ? callExpression.parentPath.value[0]
+    : callExpression.parentPath.value;
+  switch (parentPathValue.type) {
     case "MemberExpression": {
       callExpression.parentPath.value.object = (
         callExpression.value.callee as MemberExpression
@@ -34,6 +37,7 @@ export const removePromiseForCallExpression = (
     // eslint-disable-next-line no-fallthrough
     case "ArrowFunctionExpression":
     case "AwaitExpression":
+    case "CallExpression":
     case "ExpressionStatement":
     case "ObjectProperty":
     case "ReturnStatement":


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/572

### Description

Removes promise calls when parentPath is CallExpression

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
