### PR TITLE
Store whether code uses require/import/importEquals in importType

### DIFF
--- a/.changeset/poor-shirts-travel.md
+++ b/.changeset/poor-shirts-travel.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Store whether code uses require/import/importEquals in importType

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -1,7 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 import { getClientNamesFromDeepImport } from "../client-names";
 import { DYNAMODB } from "../config";
-import { ImportType } from "../modules/types";
+import { ImportType } from "../modules";
 import { getNodesWithDocClientNamedImportFromDeepPath } from "./getNodesWithDocClientNamedImportFromDeepPath";
 
 export const addNotSupportedComments = (

--- a/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
+++ b/src/transforms/v2-to-v3/apis/addNotSupportedComments.ts
@@ -1,9 +1,14 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 import { getClientNamesFromDeepImport } from "../client-names";
 import { DYNAMODB } from "../config";
+import { ImportType } from "../modules/types";
 import { getNodesWithDocClientNamedImportFromDeepPath } from "./getNodesWithDocClientNamedImportFromDeepPath";
 
-export const addNotSupportedComments = (j: JSCodeshift, source: Collection<unknown>) => {
+export const addNotSupportedComments = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  importType: ImportType
+) => {
   const clientNamesFromDeepImport = getClientNamesFromDeepImport(source.toSource());
 
   if (clientNamesFromDeepImport.includes(DYNAMODB)) {
@@ -14,7 +19,7 @@ export const addNotSupportedComments = (j: JSCodeshift, source: Collection<unkno
       j.commentLine(" Please convert to a default import, and re-run aws-sdk-js-codemod."),
     ];
 
-    getNodesWithDocClientNamedImportFromDeepPath(j, source).forEach((node) => {
+    getNodesWithDocClientNamedImportFromDeepPath(j, source, importType).forEach((node) => {
       const comments = node.value.comments || [];
       node.value.comments = [...comments, ...documentClientDeepNamedImportUnsupportedComments];
     });

--- a/src/transforms/v2-to-v3/apis/getNodesWithDocClientNamedImportFromDeepPath.ts
+++ b/src/transforms/v2-to-v3/apis/getNodesWithDocClientNamedImportFromDeepPath.ts
@@ -6,7 +6,7 @@ import {
   VariableDeclaration,
 } from "jscodeshift";
 import { DOCUMENT_CLIENT, DYNAMODB, OBJECT_PROPERTY_TYPE_LIST } from "../config";
-import { ImportType } from "../modules/types";
+import { ImportType } from "../modules";
 import { getClientDeepImportPath } from "../utils";
 
 export const getNodesWithDocClientNamedImportFromDeepPath = (

--- a/src/transforms/v2-to-v3/apis/getNodesWithDocClientNamedImportFromDeepPath.ts
+++ b/src/transforms/v2-to-v3/apis/getNodesWithDocClientNamedImportFromDeepPath.ts
@@ -6,15 +6,17 @@ import {
   VariableDeclaration,
 } from "jscodeshift";
 import { DOCUMENT_CLIENT, DYNAMODB, OBJECT_PROPERTY_TYPE_LIST } from "../config";
-import { hasRequire } from "../modules";
+import { ImportType } from "../modules/types";
 import { getClientDeepImportPath } from "../utils";
 
 export const getNodesWithDocClientNamedImportFromDeepPath = (
   j: JSCodeshift,
-  source: Collection<unknown>
+  source: Collection<unknown>,
+  importType: ImportType
 ) => {
   const deepImportPath = getClientDeepImportPath(DYNAMODB);
-  if (hasRequire(j, source)) {
+
+  if (importType === ImportType.REQUIRE) {
     return source
       .find(j.VariableDeclarator, {
         init: {
@@ -37,18 +39,18 @@ export const getNodesWithDocClientNamedImportFromDeepPath = (
       .map(
         (variableDeclarator) => variableDeclarator.parentPath.parentPath
       ) as Collection<VariableDeclaration>;
-  } else {
-    return source
-      .find(j.ImportDeclaration, {
-        type: "ImportDeclaration",
-        source: { value: deepImportPath },
-      })
-      .filter((importDeclaration) =>
-        (importDeclaration.value.specifiers || []).some(
-          (importDeclaration) =>
-            importDeclaration.type === "ImportSpecifier" &&
-            importDeclaration.imported.name === DOCUMENT_CLIENT
-        )
-      );
   }
+
+  return source
+    .find(j.ImportDeclaration, {
+      type: "ImportDeclaration",
+      source: { value: deepImportPath },
+    })
+    .filter((importDeclaration) =>
+      (importDeclaration.value.specifiers || []).some(
+        (importDeclaration) =>
+          importDeclaration.type === "ImportSpecifier" &&
+          importDeclaration.imported.name === DOCUMENT_CLIENT
+      )
+    );
 };

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { ImportType } from "../modules/types";
+import { ImportType } from "../modules";
 import { getClientNamesFromDeepImport } from "./getClientNamesFromDeepImport";
 import { getClientNamesRecordFromImport } from "./getClientNamesRecordFromImport";
 import { getClientNamesRecordFromRequire } from "./getClientNamesRecordFromRequire";

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecord.ts
@@ -1,13 +1,17 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { hasRequire } from "../modules";
+import { ImportType } from "../modules/types";
 import { getClientNamesFromDeepImport } from "./getClientNamesFromDeepImport";
 import { getClientNamesRecordFromImport } from "./getClientNamesRecordFromImport";
 import { getClientNamesRecordFromRequire } from "./getClientNamesRecordFromRequire";
 
-export const getClientNamesRecord = (j: JSCodeshift, source: Collection<unknown>) => {
+export const getClientNamesRecord = (
+  j: JSCodeshift,
+  source: Collection<unknown>,
+  importType: ImportType
+) => {
   const clientNamesFromDeepImport = getClientNamesFromDeepImport(source.toSource());
-  return hasRequire(j, source)
+  return importType === ImportType.REQUIRE
     ? getClientNamesRecordFromRequire(j, source, clientNamesFromDeepImport)
     : getClientNamesRecordFromImport(j, source, clientNamesFromDeepImport);
 };

--- a/src/transforms/v2-to-v3/modules/addClientModules.ts
+++ b/src/transforms/v2-to-v3/modules/addClientModules.ts
@@ -18,26 +18,25 @@ import {
 import { getV3ClientTypesCount } from "../ts-type";
 import { getClientTSTypeRefCount } from "./getClientTSTypeRefCount";
 import { getNewExpressionCount } from "./getNewExpressionCount";
-import { hasImportEquals } from "./hasImportEquals";
-import { hasRequire } from "./hasRequire";
 
 import * as importEqualsModule from "./importEqualsModule";
 import * as importModule from "./importModule";
 import * as requireModule from "./requireModule";
-import { ClientModulesOptions } from "./types";
+import { ClientModulesOptions, ImportType } from "./types";
 
 export const addClientModules = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: ClientModulesOptions
 ): void => {
-  const { clientIdentifiers, v2ClientName, v3ClientName, v2ClientLocalName } = options;
+  const { clientIdentifiers, v2ClientName, v3ClientName, v2ClientLocalName, importType } = options;
 
-  const { addClientDefaultModule, addClientNamedModule } = hasRequire(j, source)
-    ? requireModule
-    : hasImportEquals(j, source)
-    ? importEqualsModule
-    : importModule;
+  const { addClientDefaultModule, addClientNamedModule } =
+    importType === ImportType.REQUIRE
+      ? requireModule
+      : importType === ImportType.IMPORT_EQUALS
+      ? importEqualsModule
+      : importModule;
 
   const v3ClientTypesCount = getV3ClientTypesCount(j, source, options);
   const newExpressionCount = getNewExpressionCount(j, source, options);

--- a/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
+++ b/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
@@ -3,13 +3,14 @@ import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 import { PACKAGE_NAME } from "../config";
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 import { getImportSpecifiers } from "./getImportSpecifiers";
-import { hasRequire } from "./hasRequire";
+import { ImportType } from "./types";
 
 export const getGlobalNameFromModule = (
   j: JSCodeshift,
-  source: Collection<unknown>
+  source: Collection<unknown>,
+  importType: ImportType
 ): string | undefined => {
-  if (hasRequire(j, source)) {
+  if (importType === ImportType.REQUIRE) {
     const requireIdentifiers = source
       .find(j.VariableDeclarator, {
         id: { type: "Identifier" },

--- a/src/transforms/v2-to-v3/modules/getImportType.ts
+++ b/src/transforms/v2-to-v3/modules/getImportType.ts
@@ -1,0 +1,11 @@
+import { Collection, JSCodeshift } from "jscodeshift";
+import { hasImportEquals } from "./hasImportEquals";
+import { hasRequire } from "./hasRequire";
+import { ImportType } from "./types";
+
+export const getImportType = (j: JSCodeshift, source: Collection<unknown>) =>
+  hasRequire(j, source)
+    ? ImportType.REQUIRE
+    : hasImportEquals(j, source)
+    ? ImportType.IMPORT_EQUALS
+    : ImportType.IMPORT;

--- a/src/transforms/v2-to-v3/modules/index.ts
+++ b/src/transforms/v2-to-v3/modules/index.ts
@@ -4,6 +4,5 @@ export * from "./getImportEqualsDeclarationType";
 export * from "./getImportSpecifiers";
 export * from "./getImportType";
 export * from "./getRequireDeclaratorsWithProperty";
-export * from "./hasRequire";
 export * from "./removeClientModule";
 export * from "./removeGlobalModule";

--- a/src/transforms/v2-to-v3/modules/index.ts
+++ b/src/transforms/v2-to-v3/modules/index.ts
@@ -6,3 +6,4 @@ export * from "./getImportType";
 export * from "./getRequireDeclaratorsWithProperty";
 export * from "./removeClientModule";
 export * from "./removeGlobalModule";
+export * from "./types";

--- a/src/transforms/v2-to-v3/modules/index.ts
+++ b/src/transforms/v2-to-v3/modules/index.ts
@@ -2,6 +2,7 @@ export * from "./addClientModules";
 export * from "./getGlobalNameFromModule";
 export * from "./getImportEqualsDeclarationType";
 export * from "./getImportSpecifiers";
+export * from "./getImportType";
 export * from "./getRequireDeclaratorsWithProperty";
 export * from "./hasRequire";
 export * from "./removeClientModule";

--- a/src/transforms/v2-to-v3/modules/removeClientModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeClientModule.ts
@@ -3,16 +3,16 @@ import { Collection, JSCodeshift } from "jscodeshift";
 import { PACKAGE_NAME } from "../config";
 import { getClientTypeNames } from "../ts-type";
 import { getClientDeepImportPath } from "../utils";
-import { hasImportEquals } from "./hasImportEquals";
-import { hasRequire } from "./hasRequire";
 import { removeImportDefault } from "./removeImportDefault";
 import { removeImportEquals } from "./removeImportEquals";
 import { removeImportNamed } from "./removeImportNamed";
 import { removeRequireIdentifier } from "./removeRequireIdentifier";
 import { removeRequireObjectProperty } from "./removeRequireObjectProperty";
 import { removeRequireProperty } from "./removeRequireProperty";
+import { ImportType } from "./types";
 
 export interface RemoveClientModuleOptions {
+  importType: ImportType;
   v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;
@@ -23,17 +23,17 @@ export const removeClientModule = (
   source: Collection<unknown>,
   options: RemoveClientModuleOptions
 ) => {
-  const { v2ClientName, v2ClientLocalName } = options;
+  const { importType, v2ClientName, v2ClientLocalName } = options;
   const deepImportPath = getClientDeepImportPath(v2ClientName);
 
   const defaultOptions = { localName: v2ClientLocalName, sourceValue: deepImportPath };
   const namedOptions = { localName: v2ClientLocalName, sourceValue: PACKAGE_NAME };
 
-  if (hasRequire(j, source)) {
+  if (importType === ImportType.REQUIRE) {
     removeRequireIdentifier(j, source, defaultOptions);
     removeRequireObjectProperty(j, source, namedOptions);
     removeRequireProperty(j, source, { ...namedOptions, propertyName: v2ClientName });
-  } else if (hasImportEquals(j, source)) {
+  } else if (importType === ImportType.IMPORT_EQUALS) {
     removeImportEquals(j, source, defaultOptions);
   } else {
     removeImportDefault(j, source, defaultOptions);

--- a/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
@@ -1,17 +1,21 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { PACKAGE_NAME } from "../config";
-import { hasImportEquals } from "./hasImportEquals";
-import { hasRequire } from "./hasRequire";
 import { removeImportDefault } from "./removeImportDefault";
 import { removeImportEquals } from "./removeImportEquals";
 import { removeRequireIdentifier } from "./removeRequireIdentifier";
+import { ImportType } from "./types";
+
+export interface RemoveGlobalModuleOptions {
+  importType: ImportType;
+  v2GlobalName?: string;
+}
 
 // Removes the import of "aws-sdk" if it's not used.
 export const removeGlobalModule = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  v2GlobalName?: string
+  { importType, v2GlobalName }: RemoveGlobalModuleOptions
 ) => {
   if (!v2GlobalName) return;
 
@@ -20,9 +24,9 @@ export const removeGlobalModule = (
   // Only usage is import/require.
   if (identifierUsages.size() === 1) {
     const defaultOptions = { localName: v2GlobalName, sourceValue: PACKAGE_NAME };
-    if (hasRequire(j, source)) {
+    if (importType === ImportType.REQUIRE) {
       removeRequireIdentifier(j, source, defaultOptions);
-    } else if (hasImportEquals(j, source)) {
+    } else if (importType === ImportType.IMPORT_EQUALS) {
       removeImportEquals(j, source, defaultOptions);
     } else {
       removeImportDefault(j, source, defaultOptions);

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -7,6 +7,7 @@ export interface ClientModulesOptions {
   v3ClientName: string;
   v3ClientPackageName: string;
   clientIdentifiers: ClientIdentifier[];
+  importType: ImportType;
 }
 
 export interface ImportSpecifierOptions {

--- a/src/transforms/v2-to-v3/modules/types.ts
+++ b/src/transforms/v2-to-v3/modules/types.ts
@@ -13,3 +13,9 @@ export interface ImportSpecifierOptions {
   importedName: string;
   localName?: string;
 }
+
+export enum ImportType {
+  REQUIRE = "require",
+  IMPORT = "import",
+  IMPORT_EQUALS = "import-equals",
+}

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -92,7 +92,7 @@ const transformer = async (file: FileInfo, api: API) => {
     replaceDocClientCreation(j, source, v2Options);
   }
   replaceAwsUtilFunctions(j, source, v2GlobalName);
-  removeGlobalModule(j, source, v2GlobalName);
+  removeGlobalModule(j, source, { v2GlobalName, importType });
 
   return source.toSource();
 };

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -34,7 +34,7 @@ const transformer = async (file: FileInfo, api: API) => {
 
   addNotSupportedComments(j, source, importType);
 
-  const v2GlobalName = getGlobalNameFromModule(j, source);
+  const v2GlobalName = getGlobalNameFromModule(j, source, importType);
   const v2ClientNamesRecord = getClientNamesRecord(j, source);
 
   if (!v2GlobalName && Object.keys(v2ClientNamesRecord).length === 0) {

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -30,8 +30,9 @@ import { isTypeScriptFile } from "./utils";
 const transformer = async (file: FileInfo, api: API) => {
   const j = isTypeScriptFile(file.path) ? api.jscodeshift.withParser("ts") : api.jscodeshift;
   const source = j(file.source);
+  const importType = getImportType(j, source);
 
-  addNotSupportedComments(j, source);
+  addNotSupportedComments(j, source, importType);
 
   const v2GlobalName = getGlobalNameFromModule(j, source);
   const v2ClientNamesRecord = getClientNamesRecord(j, source);
@@ -63,7 +64,6 @@ const transformer = async (file: FileInfo, api: API) => {
     return source.toSource();
   }
 
-  const importType = getImportType(j, source);
   for (const [v2ClientName, v3ClientMetadata] of Object.entries(clientMetadataRecord)) {
     const clientIdentifiers = clientIdentifiersRecord[v2ClientName];
     const { v2ClientLocalName, v3ClientName, v3ClientPackageName } = v3ClientMetadata;

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -35,7 +35,7 @@ const transformer = async (file: FileInfo, api: API) => {
   addNotSupportedComments(j, source, importType);
 
   const v2GlobalName = getGlobalNameFromModule(j, source, importType);
-  const v2ClientNamesRecord = getClientNamesRecord(j, source);
+  const v2ClientNamesRecord = getClientNamesRecord(j, source, importType);
 
   if (!v2GlobalName && Object.keys(v2ClientNamesRecord).length === 0) {
     return source.toSource();

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -20,6 +20,7 @@ import { S3 } from "./config";
 import {
   addClientModules,
   getGlobalNameFromModule,
+  getImportType,
   removeClientModule,
   removeGlobalModule,
 } from "./modules";
@@ -62,6 +63,7 @@ const transformer = async (file: FileInfo, api: API) => {
     return source.toSource();
   }
 
+  const importType = getImportType(j, source);
   for (const [v2ClientName, v3ClientMetadata] of Object.entries(clientMetadataRecord)) {
     const clientIdentifiers = clientIdentifiersRecord[v2ClientName];
     const { v2ClientLocalName, v3ClientName, v3ClientPackageName } = v3ClientMetadata;
@@ -69,7 +71,7 @@ const transformer = async (file: FileInfo, api: API) => {
     const v2Options = { v2ClientName, v2ClientLocalName, v2GlobalName };
     const v3Options = { v3ClientName, v3ClientPackageName };
 
-    addClientModules(j, source, { ...v2Options, ...v3Options, clientIdentifiers });
+    addClientModules(j, source, { ...v2Options, ...v3Options, clientIdentifiers, importType });
     replaceTSQualifiedName(j, source, { ...v2Options, v3ClientName });
     removeClientModule(j, source, v2Options);
 

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -73,7 +73,7 @@ const transformer = async (file: FileInfo, api: API) => {
 
     addClientModules(j, source, { ...v2Options, ...v3Options, clientIdentifiers, importType });
     replaceTSQualifiedName(j, source, { ...v2Options, v3ClientName });
-    removeClientModule(j, source, v2Options);
+    removeClientModule(j, source, { ...v2Options, importType });
 
     if (v2ClientName === S3) {
       // Needs to be called before removing promise calls, as replacement has `.done()` call.


### PR DESCRIPTION
### Issue

Required for differentiating behavior of require/import vs import-equals in https://github.com/awslabs/aws-sdk-js-codemod/issues/601

### Description

Store whether code uses require/import/importEquals in importType.

This will improve performance of codemod too, as we don't check for import types in all functions.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
