### PR TITLE
Use only default import while transforming import equals

### DIFF
--- a/.changeset/tall-roses-hunt.md
+++ b/.changeset/tall-roses-hunt.md
@@ -2,4 +2,4 @@
 "aws-sdk-js-codemod": minor
 ---
 
-Use only default import in case of import equals
+Use only default import while transforming import equals

--- a/.changeset/tall-roses-hunt.md
+++ b/.changeset/tall-roses-hunt.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": minor
+---
+
+Use only default import in case of import equals

--- a/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalImportEqualsOutput.ts
@@ -1,3 +1,5 @@
+import { CLIENT_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
+import { getDefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
 import { CLIENTS_TO_TEST } from "./config";
 import { getClientNamesSortedByPackageName } from "./getClientNamesSortedByPackageName";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
@@ -7,7 +9,12 @@ export const getGlobalImportEqualsOutput = () => {
   let content = ``;
 
   content += getV3PackageImportEqualsCode(getClientNamesSortedByPackageName(CLIENTS_TO_TEST));
-  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += "\n";
+  content += getV3ClientsNewExpressionCode(
+    CLIENTS_TO_TEST.map((clientName) =>
+      [getDefaultLocalName(clientName), CLIENT_NAMES_MAP[clientName]].join(".")
+    )
+  );
 
   return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportEqualsInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportEqualsInput.ts
@@ -8,6 +8,7 @@ export const getServiceImportEqualsInput = () => {
   for (const clientName of CLIENTS_TO_TEST) {
     content += `import ${clientName} = require("${getClientDeepImportPath(clientName)}");\n`;
   }
+  content += `\n`;
   content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
   return content;

--- a/scripts/generateNewClientTests/getServiceImportEqualsOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportEqualsOutput.ts
@@ -1,3 +1,5 @@
+import { CLIENT_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
+import { getDefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
 import { CLIENTS_TO_TEST } from "./config";
 import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
 import { getV3PackageImportEqualsCode } from "./getV3PackageImportEqualsCode";
@@ -6,7 +8,12 @@ export const getServiceImportEqualsOutput = () => {
   let content = ``;
 
   content += getV3PackageImportEqualsCode(CLIENTS_TO_TEST);
-  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
+  content += "\n";
+  content += getV3ClientsNewExpressionCode(
+    CLIENTS_TO_TEST.map((clientName) =>
+      [getDefaultLocalName(clientName), CLIENT_NAMES_MAP[clientName]].join(".")
+    )
+  );
 
   return content;
 };

--- a/scripts/generateNewClientTests/getServiceImportEqualsWithNameInput.ts
+++ b/scripts/generateNewClientTests/getServiceImportEqualsWithNameInput.ts
@@ -10,6 +10,7 @@ export const getServiceImportEqualsWithNameInput = () => {
     const importName = getClientNameWithLocalSuffix(clientName);
     content += `import ${importName} = require("${getClientDeepImportPath(clientName)}");\n`;
   }
+  content += `\n`;
   content += getV2ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
 
   return content;

--- a/scripts/generateNewClientTests/getServiceImportEqualsWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceImportEqualsWithNameOutput.ts
@@ -1,13 +1,3 @@
-import { CLIENTS_TO_TEST } from "./config";
-import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
-import { getV3ClientsNewExpressionCode } from "./getV3ClientsNewExpressionCode";
-import { getV3PackageImportEqualsCode } from "./getV3PackageImportEqualsCode";
+import { getServiceImportEqualsOutput } from "./getServiceImportEqualsOutput";
 
-export const getServiceImportEqualsWithNameOutput = () => {
-  let content = ``;
-
-  content += getV3PackageImportEqualsCode(CLIENTS_TO_TEST, { useLocalSuffix: true });
-  content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
-
-  return content;
-};
+export const getServiceImportEqualsWithNameOutput = getServiceImportEqualsOutput;

--- a/scripts/generateNewClientTests/getV3PackageImportEqualsCode.ts
+++ b/scripts/generateNewClientTests/getV3PackageImportEqualsCode.ts
@@ -1,37 +1,13 @@
-import {
-  CLIENT_NAMES,
-  CLIENT_NAMES_MAP,
-  CLIENT_PACKAGE_NAMES_MAP,
-} from "../../src/transforms/v2-to-v3/config";
+import { CLIENT_NAMES, CLIENT_PACKAGE_NAMES_MAP } from "../../src/transforms/v2-to-v3/config";
 import { getDefaultLocalName } from "../../src/transforms/v2-to-v3/utils";
-import { getClientNameWithLocalSuffix } from "./getClientNameWithLocalSuffix";
 
-export interface V3PackageImportEqualsCodeOptions {
-  useLocalSuffix?: boolean;
-}
-
-export const getV3PackageImportEqualsCode = (
-  clientsToTest: typeof CLIENT_NAMES,
-  options?: V3PackageImportEqualsCodeOptions
-) => {
+export const getV3PackageImportEqualsCode = (clientsToTest: typeof CLIENT_NAMES) => {
   let content = ``;
-  const { useLocalSuffix = false } = options || {};
 
   for (const v2ClientName of clientsToTest) {
     const v3ClientDefaultLocalName = getDefaultLocalName(v2ClientName);
     const v3ClientPackageName = `@aws-sdk/${CLIENT_PACKAGE_NAMES_MAP[v2ClientName]}`;
-    content += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n\n`;
-
-    const v3ClientName = CLIENT_NAMES_MAP[v2ClientName];
-    const v2ClientLocalName = useLocalSuffix
-      ? getClientNameWithLocalSuffix(v2ClientName)
-      : v2ClientName;
-
-    const v3ObjectPattern =
-      v2ClientName === v2ClientLocalName ? v3ClientName : `${v3ClientName}: ${v2ClientLocalName}`;
-
-    content +=
-      `const {\n` + `  ${v3ObjectPattern}\n` + `} = ${getDefaultLocalName(v2ClientName)};\n\n`;
+    content += `import ${v3ClientDefaultLocalName} = require("${v3ClientPackageName}");\n`;
   }
 
   return content;

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/global-import-equals.output.ts
@@ -1,32 +1,18 @@
 import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
-
-const {
-  DynamoDB
-} = AWS_DynamoDB;
-
 import AWS_Lambda = require("@aws-sdk/client-lambda");
-
-const {
-  Lambda
-} = AWS_Lambda;
-
 import AWS_STS = require("@aws-sdk/client-sts");
 
-const {
-  STS
-} = AWS_STS;
-
-const ddbClient = new DynamoDB({ region: "us-west-2" });
+const ddbClient = new AWS_DynamoDB.DynamoDB({ region: "us-west-2" });
 const listTablesInput: AWS_DynamoDB.ListTablesCommandInput = { Limit: 10 };
 const listTablesOutput: AWS_DynamoDB.ListTablesCommandOutput = await ddbClient
   .listTables(listTablesInput);
 
-const stsClient = new STS({ region: "us-west-2" });
+const stsClient = new AWS_STS.STS({ region: "us-west-2" });
 const getCallerIdentityInput: AWS_STS.GetCallerIdentityCommandInput = {};
 const getCallerIdentityOutput: AWS_STS.GetCallerIdentityCommandOutput = await stsClient
   .getCallerIdentity(getCallerIdentityInput);
 
-const lambdaClient = new Lambda({ region: "us-west-2" });
+const lambdaClient = new AWS_Lambda.Lambda({ region: "us-west-2" });
 const invokeInput: AWS_Lambda.InvokeCommandInput = { FunctionName: "my-function" };
 const invokeOutput: AWS_Lambda.InvokeCommandOutput = await lambdaClient
   .invoke(invokeInput);

--- a/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-input-output-type/service-import-equals.output.ts
@@ -1,32 +1,18 @@
 import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
-
-const {
-  DynamoDB
-} = AWS_DynamoDB;
-
 import AWS_Lambda = require("@aws-sdk/client-lambda");
-
-const {
-  Lambda
-} = AWS_Lambda;
-
 import AWS_STS = require("@aws-sdk/client-sts");
 
-const {
-  STS
-} = AWS_STS;
-
-const ddbClient = new DynamoDB({ region: "us-west-2" });
+const ddbClient = new AWS_DynamoDB.DynamoDB({ region: "us-west-2" });
 const listTablesInput: AWS_DynamoDB.ListTablesCommandInput = { Limit: 10 };
 const listTablesOutput: AWS_DynamoDB.ListTablesCommandOutput = await ddbClient
   .listTables(listTablesInput);
 
-const stsClient = new STS({ region: "us-west-2" });
+const stsClient = new AWS_STS.STS({ region: "us-west-2" });
 const getCallerIdentityInput: AWS_STS.GetCallerIdentityCommandInput = {};
 const getCallerIdentityOutput: AWS_STS.GetCallerIdentityCommandOutput = await stsClient
   .getCallerIdentity(getCallerIdentityInput);
 
-const lambdaClient = new Lambda({ region: "us-west-2" });
+const lambdaClient = new AWS_Lambda.Lambda({ region: "us-west-2" });
 const invokeInput: AWS_Lambda.InvokeCommandInput = { FunctionName: "my-function" };
 const invokeOutput: AWS_Lambda.InvokeCommandOutput = await lambdaClient
   .invoke(invokeInput);

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/global-import-equals.output.ts
@@ -1,8 +1,4 @@
 import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
 
-const {
-  DynamoDB
-} = AWS_DynamoDB;
-
-const client = new DynamoDB();
+const client = new AWS_DynamoDB.DynamoDB();
 const data = await client.listTables();

--- a/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-promise/service-import-equals.output.ts
@@ -1,8 +1,4 @@
 import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
 
-const {
-  DynamoDB
-} = AWS_DynamoDB;
-
-const client = new DynamoDB();
+const client = new AWS_DynamoDB.DynamoDB();
 const data = await client.listTables();

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/global-import-equals.output.ts
@@ -1,20 +1,11 @@
 import AWS_lib_dynamodb = require("@aws-sdk/lib-dynamodb");
-
-const {
-  DynamoDBDocument
-} = AWS_lib_dynamodb;
-
 import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
 
-const {
-  DynamoDB
-} = AWS_DynamoDB;
+const docClient = AWS_lib_dynamodb.DynamoDBDocument.from(new AWS_DynamoDB.DynamoDB({ region: "us-west-2" }));
 
-const docClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
-
-const docClientScanInput: AWS_DynamoDBDocumentClient.ScanCommandInput = {
+const docClientScanInput: AWS_lib_dynamodb.ScanCommandInput = {
   TableName: "TableName"
 };
 
-const docClientScanOutput: AWS_DynamoDBDocumentClient.ScanCommandOutput = await docClient
+const docClientScanOutput: AWS_lib_dynamodb.ScanCommandOutput = await docClient
   .scan(docClientScanInput);

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/global-import.output.ts
@@ -1,16 +1,11 @@
-import * as AWS_DynamoDBDocumentClient from "@aws-sdk/lib-dynamodb";
-
-const {
-  DynamoDBDocument
-} = AWS_DynamoDBDocumentClient;
-
+import { DynamoDBDocument, ScanCommandInput, ScanCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
 const docClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
 
-const docClientScanInput: AWS_DynamoDBDocumentClient.ScanCommandInput = {
+const docClientScanInput: ScanCommandInput = {
   TableName: "TableName"
 };
 
-const docClientScanOutput: AWS_DynamoDBDocumentClient.ScanCommandOutput = await docClient
+const docClientScanOutput: ScanCommandOutput = await docClient
   .scan(docClientScanInput);

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/global-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/global-import.output.ts
@@ -1,11 +1,16 @@
-import { DynamoDBDocument, ScanCommandInput, ScanCommandOutput } from "@aws-sdk/lib-dynamodb";
+import * as AWS_DynamoDBDocumentClient from "@aws-sdk/lib-dynamodb";
+
+const {
+  DynamoDBDocument
+} = AWS_DynamoDBDocumentClient;
+
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
 const docClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
 
-const docClientScanInput: ScanCommandInput = {
+const docClientScanInput: AWS_DynamoDBDocumentClient.ScanCommandInput = {
   TableName: "TableName"
 };
 
-const docClientScanOutput: ScanCommandOutput = await docClient
+const docClientScanOutput: AWS_DynamoDBDocumentClient.ScanCommandOutput = await docClient
   .scan(docClientScanInput);

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/service-import-deep.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/service-import-deep.output.ts
@@ -1,11 +1,16 @@
-import { DynamoDBDocument, ScanCommandInput, ScanCommandOutput } from "@aws-sdk/lib-dynamodb";
+import * as AWS_DynDBDocumentClient from "@aws-sdk/lib-dynamodb";
+
+const {
+  DynamoDBDocument
+} = AWS_DynDBDocumentClient;
+
 import { DynamoDB as DynDB } from "@aws-sdk/client-dynamodb";
 
 const docClient = DynamoDBDocument.from(new DynDB({ region: "us-west-2" }));
 
-const docClientScanInput: ScanCommandInput = {
+const docClientScanInput: AWS_DynDBDocumentClient.ScanCommandInput = {
   TableName: "TableName"
 };
 
-const docClientScanOutput: ScanCommandOutput = await docClient
+const docClientScanOutput: AWS_DynDBDocumentClient.ScanCommandOutput = await docClient
   .scan(docClientScanInput);

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/service-import-deep.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/service-import-deep.output.ts
@@ -1,16 +1,11 @@
-import * as AWS_DynDBDocumentClient from "@aws-sdk/lib-dynamodb";
-
-const {
-  DynamoDBDocument
-} = AWS_DynDBDocumentClient;
-
+import { DynamoDBDocument, ScanCommandInput, ScanCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { DynamoDB as DynDB } from "@aws-sdk/client-dynamodb";
 
 const docClient = DynamoDBDocument.from(new DynDB({ region: "us-west-2" }));
 
-const docClientScanInput: AWS_DynDBDocumentClient.ScanCommandInput = {
+const docClientScanInput: ScanCommandInput = {
   TableName: "TableName"
 };
 
-const docClientScanOutput: AWS_DynDBDocumentClient.ScanCommandOutput = await docClient
+const docClientScanOutput: ScanCommandOutput = await docClient
   .scan(docClientScanInput);

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/service-import-equals.output.ts
@@ -1,20 +1,11 @@
 import AWS_lib_dynamodb = require("@aws-sdk/lib-dynamodb");
-
-const {
-  DynamoDBDocument
-} = AWS_lib_dynamodb;
-
 import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
 
-const {
-  DynamoDB: DynDB
-} = AWS_DynamoDB;
+const docClient = AWS_lib_dynamodb.DynamoDBDocument.from(new AWS_DynamoDB.DynamoDB({ region: "us-west-2" }));
 
-const docClient = DynamoDBDocument.from(new DynDB({ region: "us-west-2" }));
-
-const docClientScanInput: AWS_DynDBDocumentClient.ScanCommandInput = {
+const docClientScanInput: AWS_lib_dynamodb.ScanCommandInput = {
   TableName: "TableName"
 };
 
-const docClientScanOutput: AWS_DynDBDocumentClient.ScanCommandOutput = await docClient
+const docClientScanOutput: AWS_lib_dynamodb.ScanCommandOutput = await docClient
   .scan(docClientScanInput);

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/service-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/service-import.output.ts
@@ -1,11 +1,16 @@
-import { DynamoDBDocument, ScanCommandInput, ScanCommandOutput } from "@aws-sdk/lib-dynamodb";
+import * as AWS_DynDBDocumentClient from "@aws-sdk/lib-dynamodb";
+
+const {
+  DynamoDBDocument
+} = AWS_DynDBDocumentClient;
+
 import { DynamoDB as DynDB } from "@aws-sdk/client-dynamodb";
 
 const docClient = DynamoDBDocument.from(new DynDB({ region: "us-west-2" }));
 
-const docClientScanInput: ScanCommandInput = {
+const docClientScanInput: AWS_DynDBDocumentClient.ScanCommandInput = {
   TableName: "TableName"
 };
 
-const docClientScanOutput: ScanCommandOutput = await docClient
+const docClientScanOutput: AWS_DynDBDocumentClient.ScanCommandOutput = await docClient
   .scan(docClientScanInput);

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/service-import.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client-input-output-type/service-import.output.ts
@@ -1,16 +1,11 @@
-import * as AWS_DynDBDocumentClient from "@aws-sdk/lib-dynamodb";
-
-const {
-  DynamoDBDocument
-} = AWS_DynDBDocumentClient;
-
+import { DynamoDBDocument, ScanCommandInput, ScanCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { DynamoDB as DynDB } from "@aws-sdk/client-dynamodb";
 
 const docClient = DynamoDBDocument.from(new DynDB({ region: "us-west-2" }));
 
-const docClientScanInput: AWS_DynDBDocumentClient.ScanCommandInput = {
+const docClientScanInput: ScanCommandInput = {
   TableName: "TableName"
 };
 
-const docClientScanOutput: AWS_DynDBDocumentClient.ScanCommandOutput = await docClient
+const docClientScanOutput: ScanCommandOutput = await docClient
   .scan(docClientScanInput);

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-import-equals.output.ts
@@ -1,14 +1,5 @@
 import AWS_lib_dynamodb = require("@aws-sdk/lib-dynamodb");
-
-const {
-  DynamoDBDocument
-} = AWS_lib_dynamodb;
-
 import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
 
-const {
-  DynamoDB
-} = AWS_DynamoDB;
-
-const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const documentClient = AWS_lib_dynamodb.DynamoDBDocument.from(new AWS_DynamoDB.DynamoDB({ region: "us-west-2" }));
 const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals-with-name.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals-with-name.output.ts
@@ -1,5 +1,5 @@
 import AWS_lib_dynamodb = require("@aws-sdk/lib-dynamodb");
 import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
 
-const documentClient = AWS_lib_dynamodb.DynamoDBDocument.from(new AWS_DynamoDB.DynamoDBClient({ region: "us-west-2" }));
+const documentClient = AWS_lib_dynamodb.DynamoDBDocument.from(new AWS_DynamoDB.DynamoDB({ region: "us-west-2" }));
 const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals-with-name.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals-with-name.output.ts
@@ -1,14 +1,5 @@
 import AWS_lib_dynamodb = require("@aws-sdk/lib-dynamodb");
-
-const {
-  DynamoDBDocument
-} = AWS_lib_dynamodb;
-
 import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
 
-const {
-  DynamoDB: DynamoDBClient
-} = AWS_DynamoDB;
-
-const documentClient = DynamoDBDocument.from(new DynamoDBClient({ region: "us-west-2" }));
+const documentClient = AWS_lib_dynamodb.DynamoDBDocument.from(new AWS_DynamoDB.DynamoDBClient({ region: "us-west-2" }));
 const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-import-equals.output.ts
@@ -1,14 +1,5 @@
 import AWS_lib_dynamodb = require("@aws-sdk/lib-dynamodb");
-
-const {
-  DynamoDBDocument
-} = AWS_lib_dynamodb;
-
 import AWS_DynamoDB = require("@aws-sdk/client-dynamodb");
 
-const {
-  DynamoDB
-} = AWS_DynamoDB;
-
-const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));
+const documentClient = AWS_lib_dynamodb.DynamoDBDocument.from(new AWS_DynamoDB.DynamoDB({ region: "us-west-2" }));
 const response = await documentClient.scan({ TableName: "TABLE_NAME" });

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/global-import-equals.output.ts
@@ -3,23 +3,9 @@
 
 
 import AWS_AccessAnalyzer = require("@aws-sdk/client-accessanalyzer");
-
-const {
-  AccessAnalyzer
-} = AWS_AccessAnalyzer;
-
 import AWS_ACM = require("@aws-sdk/client-acm");
-
-const {
-  ACM
-} = AWS_ACM;
-
 import AWS_Discovery = require("@aws-sdk/client-application-discovery-service");
 
-const {
-  ApplicationDiscoveryService
-} = AWS_Discovery;
-
-new ACM();
-new AccessAnalyzer();
-new ApplicationDiscoveryService();
+new AWS_ACM.ACM();
+new AWS_AccessAnalyzer.AccessAnalyzer();
+new AWS_Discovery.ApplicationDiscoveryService();

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/service-import-equals-with-name.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/service-import-equals-with-name.input.ts
@@ -3,6 +3,7 @@
 import ACMClient = require("aws-sdk/clients/acm");
 import AccessAnalyzerClient = require("aws-sdk/clients/accessanalyzer");
 import DiscoveryClient = require("aws-sdk/clients/discovery");
+
 new ACMClient();
 new AccessAnalyzerClient();
 new DiscoveryClient();

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/service-import-equals-with-name.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/service-import-equals-with-name.output.ts
@@ -3,23 +3,9 @@
 
 
 import AWS_ACM = require("@aws-sdk/client-acm");
-
-const {
-  ACM: ACMClient
-} = AWS_ACM;
-
 import AWS_AccessAnalyzer = require("@aws-sdk/client-accessanalyzer");
-
-const {
-  AccessAnalyzer: AccessAnalyzerClient
-} = AWS_AccessAnalyzer;
-
 import AWS_Discovery = require("@aws-sdk/client-application-discovery-service");
 
-const {
-  ApplicationDiscoveryService: DiscoveryClient
-} = AWS_Discovery;
-
-new ACMClient();
-new AccessAnalyzerClient();
-new DiscoveryClient();
+new AWS_ACM.ACM();
+new AWS_AccessAnalyzer.AccessAnalyzer();
+new AWS_Discovery.ApplicationDiscoveryService();

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/service-import-equals.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/service-import-equals.input.ts
@@ -3,6 +3,7 @@
 import ACM = require("aws-sdk/clients/acm");
 import AccessAnalyzer = require("aws-sdk/clients/accessanalyzer");
 import Discovery = require("aws-sdk/clients/discovery");
+
 new ACM();
 new AccessAnalyzer();
 new Discovery();

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/service-import-equals.output.ts
@@ -3,23 +3,9 @@
 
 
 import AWS_ACM = require("@aws-sdk/client-acm");
-
-const {
-  ACM
-} = AWS_ACM;
-
 import AWS_AccessAnalyzer = require("@aws-sdk/client-accessanalyzer");
-
-const {
-  AccessAnalyzer
-} = AWS_AccessAnalyzer;
-
 import AWS_Discovery = require("@aws-sdk/client-application-discovery-service");
 
-const {
-  ApplicationDiscoveryService
-} = AWS_Discovery;
-
-new ACM();
-new AccessAnalyzer();
-new ApplicationDiscoveryService();
+new AWS_ACM.ACM();
+new AWS_AccessAnalyzer.AccessAnalyzer();
+new AWS_Discovery.ApplicationDiscoveryService();

--- a/src/transforms/v2-to-v3/__fixtures__/s3-get-signed-url/getObject.import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-get-signed-url/getObject.import-equals.output.ts
@@ -1,20 +1,10 @@
 import AWS_s3_request_presigner = require("@aws-sdk/s3-request-presigner");
-
-const {
-  getSignedUrl
-} = AWS_s3_request_presigner;
-
 import AWS_S3 = require("@aws-sdk/client-s3");
 
-const {
-  GetObjectCommand,
-  S3
-} = AWS_S3;
+const s3 = new AWS_S3.S3();
 
-const s3 = new S3();
-
-url = await getSignedUrl(s3, new GetObjectCommand({ Bucket: "bucket", Key: "key" }));
-url = await getSignedUrl(s3, new GetObjectCommand({
+url = await AWS_s3_request_presigner.getSignedUrl(s3, new AWS_S3.GetObjectCommand({ Bucket: "bucket", Key: "key" }));
+url = await AWS_s3_request_presigner.getSignedUrl(s3, new AWS_S3.GetObjectCommand({
   Bucket: "bucket",
   Key: "key"
 }), {

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/global-import-equals.output.ts
@@ -1,17 +1,8 @@
 import AWS_lib_storage = require("@aws-sdk/lib-storage");
-
-const {
-  Upload
-} = AWS_lib_storage;
-
 import AWS_S3 = require("@aws-sdk/client-s3");
 
-const {
-  S3
-} = AWS_S3;
-
-const client = new S3({ region: "REGION" });
-await new Upload({
+const client = new AWS_S3.S3({ region: "REGION" });
+await new AWS_lib_storage.Upload({
   client,
 
   params: {

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/service-import-equals.output.ts
@@ -1,17 +1,8 @@
 import AWS_lib_storage = require("@aws-sdk/lib-storage");
-
-const {
-  Upload
-} = AWS_lib_storage;
-
 import AWS_S3 = require("@aws-sdk/client-s3");
 
-const {
-  S3
-} = AWS_S3;
-
-const client = new S3({ region: "REGION" });
-await new Upload({
+const client = new AWS_S3.S3({ region: "REGION" });
+await new AWS_lib_storage.Upload({
   client,
 
   params: {

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/global-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/global-import-equals.output.ts
@@ -1,16 +1,11 @@
 import AWS_S3 = require("@aws-sdk/client-s3");
 
-const {
-  S3,
-  waitUntilBucketExists
-} = AWS_S3;
-
 const Bucket = "BUCKET_NAME";
-const client = new S3({ region: "REGION" });
+const client = new AWS_S3.S3({ region: "REGION" });
 
 await client.createBucket({ Bucket });
 
-await waitUntilBucketExists({
+await AWS_S3.waitUntilBucketExists({
   client,
   maxWaitTime: 200
 }, { Bucket });

--- a/src/transforms/v2-to-v3/__fixtures__/waiters/service-import-equals.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/waiters/service-import-equals.output.ts
@@ -1,16 +1,11 @@
 import AWS_S3 = require("@aws-sdk/client-s3");
 
-const {
-  S3,
-  waitUntilBucketExists
-} = AWS_S3;
-
 const Bucket = "BUCKET_NAME";
-const client = new S3({ region: "REGION" });
+const client = new AWS_S3.S3({ region: "REGION" });
 
 await client.createBucket({ Bucket });
 
-await waitUntilBucketExists({
+await AWS_S3.waitUntilBucketExists({
   client,
   maxWaitTime: 200
 }, { Bucket });

--- a/src/transforms/v2-to-v3/client-instances/getDynamoDBDocClientArgs.ts
+++ b/src/transforms/v2-to-v3/client-instances/getDynamoDBDocClientArgs.ts
@@ -1,9 +1,12 @@
 import { ASTPath, JSCodeshift, NewExpression, ObjectProperty, Property } from "jscodeshift";
 import { OBJECT_PROPERTY_TYPE_LIST } from "../config";
+import { ImportType } from "../modules";
 import { getDynamoDBForDocClient } from "./getDynamoDBForDocClient";
 
 export interface GetDynamoDBDocClientArgsOptions {
+  v2ClientName: string;
   v2ClientLocalName?: string;
+  importType: ImportType;
 }
 
 export const getDynamoDBDocClientArgs = (

--- a/src/transforms/v2-to-v3/client-instances/getDynamoDBForDocClient.ts
+++ b/src/transforms/v2-to-v3/client-instances/getDynamoDBForDocClient.ts
@@ -1,15 +1,19 @@
 import { ASTPath, JSCodeshift, NewExpression, ObjectProperty, Property } from "jscodeshift";
 
 import { DYNAMODB, OBJECT_PROPERTY_TYPE_LIST } from "../config";
+import { ImportType } from "../modules";
+import { getV3ClientTypeName } from "../ts-type";
 
 export interface GetDynamoDBForDocClientOptions {
+  v2ClientName: string;
   v2ClientLocalName?: string;
+  importType: ImportType;
 }
 
 export const getDynamoDBForDocClient = (
   j: JSCodeshift,
   v2DocClientNewExpression: ASTPath<NewExpression>,
-  { v2ClientLocalName }: GetDynamoDBForDocClientOptions
+  { v2ClientName, v2ClientLocalName, importType }: GetDynamoDBForDocClientOptions
 ) => {
   const v2DocClientArgs = v2DocClientNewExpression.node.arguments || [];
 
@@ -64,7 +68,7 @@ export const getDynamoDBForDocClient = (
   }
 
   return j.newExpression(
-    v2ClientLocalName ? j.identifier(v2ClientLocalName) : j.identifier(DYNAMODB),
+    j.identifier(getV3ClientTypeName(v2ClientLocalName ?? DYNAMODB, v2ClientName, importType)),
     v3DocClientNewExpressionArgs
   );
 };

--- a/src/transforms/v2-to-v3/client-instances/getDynamoDBForDocClient.ts
+++ b/src/transforms/v2-to-v3/client-instances/getDynamoDBForDocClient.ts
@@ -67,8 +67,10 @@ export const getDynamoDBForDocClient = (
     }
   }
 
+  const typeName =
+    importType === ImportType.IMPORT_EQUALS ? DYNAMODB : v2ClientLocalName ?? DYNAMODB;
   return j.newExpression(
-    j.identifier(getV3ClientTypeName(v2ClientLocalName ?? DYNAMODB, v2ClientName, importType)),
+    j.identifier(getV3ClientTypeName(typeName, v2ClientName, importType)),
     v3DocClientNewExpressionArgs
   );
 };

--- a/src/transforms/v2-to-v3/client-instances/replaceClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceClientCreation.ts
@@ -24,8 +24,13 @@ export const replaceClientCreation = (
     importType,
   }: ReplaceClientCreationOptions
 ): void => {
-  const clientName = v2ClientName === v2ClientLocalName ? v3ClientName : v2ClientLocalName;
-  const v3ClientConstructor = getV3ClientTypeName(clientName, v2ClientLocalName, importType);
+  const clientName =
+    importType === ImportType.IMPORT_EQUALS || v2ClientName === v2ClientLocalName
+      ? v3ClientName
+      : v2ClientLocalName;
+  const clientLocalName =
+    importType === ImportType.IMPORT_EQUALS ? v2ClientName : v2ClientLocalName;
+  const v3ClientConstructor = getV3ClientTypeName(clientName, clientLocalName, importType);
 
   if (v2GlobalName) {
     source

--- a/src/transforms/v2-to-v3/client-instances/replaceClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceClientCreation.ts
@@ -1,5 +1,7 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
+import { ImportType } from "../modules";
+import { getV3ClientTypeName } from "../ts-type";
 import { getClientNewExpression } from "../utils";
 
 export interface ReplaceClientCreationOptions {
@@ -7,27 +9,35 @@ export interface ReplaceClientCreationOptions {
   v2ClientLocalName: string;
   v2GlobalName?: string;
   v3ClientName: string;
+  importType: ImportType;
 }
 
 // Replace v2 client creation with v3 client creation.
 export const replaceClientCreation = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientName, v2ClientLocalName, v2GlobalName, v3ClientName }: ReplaceClientCreationOptions
+  {
+    v2ClientName,
+    v2ClientLocalName,
+    v2GlobalName,
+    v3ClientName,
+    importType,
+  }: ReplaceClientCreationOptions
 ): void => {
   const clientName = v2ClientName === v2ClientLocalName ? v3ClientName : v2ClientLocalName;
+  const v3ClientConstructor = getV3ClientTypeName(clientName, v2ClientLocalName, importType);
 
   if (v2GlobalName) {
     source
       .find(j.NewExpression, getClientNewExpression({ v2GlobalName, v2ClientName }))
       .replaceWith((v2ClientNewExpression) =>
-        j.newExpression(j.identifier(clientName), v2ClientNewExpression.node.arguments)
+        j.newExpression(j.identifier(v3ClientConstructor), v2ClientNewExpression.node.arguments)
       );
   }
 
   source
     .find(j.NewExpression, getClientNewExpression({ v2ClientName, v2ClientLocalName }))
     .replaceWith((v2ClientNewExpression) =>
-      j.newExpression(j.identifier(clientName), v2ClientNewExpression.node.arguments)
+      j.newExpression(j.identifier(v3ClientConstructor), v2ClientNewExpression.node.arguments)
     );
 };

--- a/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceDocClientCreation.ts
@@ -1,6 +1,8 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
 import { DOCUMENT_CLIENT, DYNAMODB, DYNAMODB_DOCUMENT, DYNAMODB_DOCUMENT_CLIENT } from "../config";
+import { ImportType, getImportEqualsLocalNameSuffix } from "../modules";
+import { getV3ClientTypeName } from "../ts-type";
 import { getClientNewExpression } from "../utils";
 import { getDynamoDBDocClientArgs } from "./getDynamoDBDocClientArgs";
 
@@ -8,14 +10,22 @@ export interface ReplaceDocClientCreationOptions {
   v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;
+  importType: ImportType;
 }
 
 export const replaceDocClientCreation = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  { v2ClientName, v2ClientLocalName, v2GlobalName }: ReplaceDocClientCreationOptions
+  { v2ClientName, v2ClientLocalName, v2GlobalName, importType }: ReplaceDocClientCreationOptions
 ): void => {
   if (v2ClientName !== DYNAMODB) return;
+
+  const v3DocClientName = getV3ClientTypeName(
+    DYNAMODB_DOCUMENT,
+    getImportEqualsLocalNameSuffix(v2ClientName, "@aws-sdk/lib-dynamodb"),
+    importType
+  );
+  const ddbDocClientOptions = { v2ClientName, v2ClientLocalName, importType };
 
   if (v2GlobalName) {
     source
@@ -25,8 +35,8 @@ export const replaceDocClientCreation = (
       )
       .replaceWith((v2DocClientNewExpression) =>
         j.callExpression(
-          j.memberExpression(j.identifier(DYNAMODB_DOCUMENT), j.identifier("from")),
-          getDynamoDBDocClientArgs(j, v2DocClientNewExpression, { v2ClientLocalName })
+          j.memberExpression(j.identifier(v3DocClientName), j.identifier("from")),
+          getDynamoDBDocClientArgs(j, v2DocClientNewExpression, ddbDocClientOptions)
         )
       );
   }
@@ -38,8 +48,8 @@ export const replaceDocClientCreation = (
     )
     .replaceWith((v2DocClientNewExpression) =>
       j.callExpression(
-        j.memberExpression(j.identifier(DYNAMODB_DOCUMENT), j.identifier("from")),
-        getDynamoDBDocClientArgs(j, v2DocClientNewExpression, { v2ClientLocalName })
+        j.memberExpression(j.identifier(v3DocClientName), j.identifier("from")),
+        getDynamoDBDocClientArgs(j, v2DocClientNewExpression, ddbDocClientOptions)
       )
     );
 };

--- a/src/transforms/v2-to-v3/modules/importEqualsModule/addClientNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/importEqualsModule/addClientNamedModule.ts
@@ -1,63 +1,16 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { getDefaultLocalName } from "../../utils";
-import { getImportEqualsDeclarationType } from "../getImportEqualsDeclarationType";
-import { getImportEqualsLocalNameSuffix } from "../getImportEqualsLocalNameSuffix";
-import { getRequireProperty } from "../getRequireProperty";
-import { objectPatternPropertyCompareFn } from "../objectPatternPropertyCompareFn";
 import { ClientModulesOptions, ImportSpecifierOptions } from "../types";
 import { addClientDefaultModule } from "./addClientDefaultModule";
 
+/**
+ * Import Equals does not support named import.
+ * We just add a default import for the package.
+ */
 export const addClientNamedModule = (
   j: JSCodeshift,
   source: Collection<unknown>,
   options: ClientModulesOptions & ImportSpecifierOptions
 ) => {
-  const { importedName, localName, ...v3ClientModulesOptions } = options;
-  const { v2ClientName, v3ClientPackageName } = v3ClientModulesOptions;
-
-  const localNameSuffix = getImportEqualsLocalNameSuffix(v2ClientName, v3ClientPackageName);
-  const defaultLocalName = getDefaultLocalName(localNameSuffix);
-  const namedImportObjectProperty = getRequireProperty(j, { importedName, localName });
-
-  const existingVarDeclarator = source.find(j.VariableDeclarator, {
-    type: "VariableDeclarator",
-    init: { type: "Identifier", name: defaultLocalName },
-  });
-
-  if (existingVarDeclarator.size()) {
-    const firstDeclaratorProperties = existingVarDeclarator.get(0).node.id.properties;
-    firstDeclaratorProperties.push(namedImportObjectProperty);
-    firstDeclaratorProperties.sort(objectPatternPropertyCompareFn);
-    return;
-  }
-
-  const importEqualsDeclaration = getImportEqualsDeclarationType(v3ClientPackageName);
-  if (source.find(j.TSImportEqualsDeclaration, importEqualsDeclaration).size() === 0) {
-    addClientDefaultModule(j, source, v3ClientModulesOptions);
-  }
-
-  const varDeclaration = j.variableDeclaration("const", [
-    j.variableDeclarator(
-      j.objectPattern([namedImportObjectProperty]),
-      j.identifier(defaultLocalName)
-    ),
-  ]);
-
-  const v3ClientImportEquals = source
-    .find(j.TSImportEqualsDeclaration, importEqualsDeclaration)
-    .filter(
-      (importEqualsDeclaration) => importEqualsDeclaration.value.id.name === defaultLocalName
-    );
-
-  if (v3ClientImportEquals.size() > 0) {
-    v3ClientImportEquals.at(0).insertAfter(varDeclaration);
-    return;
-  }
-
-  // Unreachable code, throw error
-  throw new Error(
-    "The named import equals can't exist on it's own.\n" +
-      "Please report your use case on https://github.com/awslabs/aws-sdk-js-codemod"
-  );
+  addClientDefaultModule(j, source, options);
 };

--- a/src/transforms/v2-to-v3/modules/index.ts
+++ b/src/transforms/v2-to-v3/modules/index.ts
@@ -1,6 +1,7 @@
 export * from "./addClientModules";
 export * from "./getGlobalNameFromModule";
 export * from "./getImportEqualsDeclarationType";
+export * from "./getImportEqualsLocalNameSuffix";
 export * from "./getImportSpecifiers";
 export * from "./getImportType";
 export * from "./getRequireDeclaratorsWithProperty";

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -86,7 +86,7 @@ const transformer = async (file: FileInfo, api: API) => {
       replaceS3GetSignedUrlApi(j, source, { clientIdentifiers, importType });
     }
 
-    replaceWaiterApi(j, source, clientIdentifiers);
+    replaceWaiterApi(j, source, { clientIdentifiers, v2ClientName, importType });
 
     replaceClientCreation(j, source, { ...v2Options, v3ClientName, importType });
     replaceDocClientCreation(j, source, { ...v2Options, importType });

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -77,7 +77,7 @@ const transformer = async (file: FileInfo, api: API) => {
 
     if (v2ClientName === S3) {
       // Needs to be called before removing promise calls, as replacement has `.done()` call.
-      replaceS3UploadApi(j, source, clientIdentifiers);
+      replaceS3UploadApi(j, source, { clientIdentifiers, importType });
     }
 
     removePromiseCalls(j, source, clientIdentifiers);

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -72,7 +72,7 @@ const transformer = async (file: FileInfo, api: API) => {
     const v3Options = { v3ClientName, v3ClientPackageName };
 
     addClientModules(j, source, { ...v2Options, ...v3Options, clientIdentifiers, importType });
-    replaceTSQualifiedName(j, source, { ...v2Options, v3ClientName });
+    replaceTSQualifiedName(j, source, { ...v2Options, v3ClientName, importType });
     removeClientModule(j, source, { ...v2Options, importType });
 
     if (v2ClientName === S3) {

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -83,7 +83,7 @@ const transformer = async (file: FileInfo, api: API) => {
     removePromiseCalls(j, source, clientIdentifiers);
 
     if (v2ClientName === S3) {
-      replaceS3GetSignedUrlApi(j, source, clientIdentifiers);
+      replaceS3GetSignedUrlApi(j, source, { clientIdentifiers, importType });
     }
 
     replaceWaiterApi(j, source, clientIdentifiers);

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -88,7 +88,7 @@ const transformer = async (file: FileInfo, api: API) => {
 
     replaceWaiterApi(j, source, clientIdentifiers);
 
-    replaceClientCreation(j, source, { ...v2Options, v3ClientName });
+    replaceClientCreation(j, source, { ...v2Options, v3ClientName, importType });
     replaceDocClientCreation(j, source, v2Options);
   }
   replaceAwsUtilFunctions(j, source, v2GlobalName);

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -89,7 +89,7 @@ const transformer = async (file: FileInfo, api: API) => {
     replaceWaiterApi(j, source, clientIdentifiers);
 
     replaceClientCreation(j, source, { ...v2Options, v3ClientName, importType });
-    replaceDocClientCreation(j, source, v2Options);
+    replaceDocClientCreation(j, source, { ...v2Options, importType });
   }
   replaceAwsUtilFunctions(j, source, v2GlobalName);
   removeGlobalModule(j, source, { v2GlobalName, importType });

--- a/src/transforms/v2-to-v3/ts-type/getV3ClientTypeName.ts
+++ b/src/transforms/v2-to-v3/ts-type/getV3ClientTypeName.ts
@@ -1,0 +1,14 @@
+import { ImportType } from "../modules";
+import { getDefaultLocalName } from "../utils";
+
+export const getV3ClientTypeName = (
+  typeName: string,
+  localName: string,
+  importType: ImportType
+) => {
+  const v3ClientTypeNameSections = [typeName];
+  if (importType === ImportType.IMPORT_EQUALS) {
+    v3ClientTypeNameSections.unshift(getDefaultLocalName(localName));
+  }
+  return v3ClientTypeNameSections.join(".");
+};

--- a/src/transforms/v2-to-v3/ts-type/index.ts
+++ b/src/transforms/v2-to-v3/ts-type/index.ts
@@ -1,4 +1,5 @@
 export * from "./getClientTypeNames";
 export * from "./getV3ClientType";
+export * from "./getV3ClientTypeName";
 export * from "./getV3ClientTypesCount";
 export * from "./replaceTSQualifiedName";

--- a/src/transforms/v2-to-v3/ts-type/replaceTSQualifiedName.ts
+++ b/src/transforms/v2-to-v3/ts-type/replaceTSQualifiedName.ts
@@ -96,7 +96,10 @@ export const replaceTSQualifiedName = (
     replaceTSQualifiedName(j, source, {
       ...options,
       v2ClientName: DYNAMODB_DOCUMENT_CLIENT,
-      v2ClientLocalName: `${v2ClientLocalName}.${DOCUMENT_CLIENT}`,
+      v2ClientLocalName:
+        importType === ImportType.IMPORT_EQUALS
+          ? `lib_dynamodb`
+          : `${v2ClientLocalName}.${DOCUMENT_CLIENT}`,
     });
   }
 };

--- a/src/transforms/v2-to-v3/ts-type/updateV2ClientType.ts
+++ b/src/transforms/v2-to-v3/ts-type/updateV2ClientType.ts
@@ -1,4 +1,6 @@
 import { ASTPath, Identifier, JSCodeshift, TSQualifiedName, TSTypeReference } from "jscodeshift";
+import { DOCUMENT_CLIENT } from "../config";
+import { ImportType } from "../modules";
 import { addTsTypeQueryToRefType } from "./addTsTypeQueryToRefType";
 import { getV3ClientType } from "./getV3ClientType";
 
@@ -10,13 +12,21 @@ interface UpdateV2ClientTypeOptions {
   v2ClientName: string;
   v2ClientTypeName: string;
   v2ClientLocalName: string;
+  importType: ImportType;
 }
 
 export const updateV2ClientType = (
   j: JSCodeshift,
   v2ClientType: ASTPath<TSQualifiedName>,
-  { v2ClientName, v2ClientTypeName, v2ClientLocalName }: UpdateV2ClientTypeOptions
+  options: UpdateV2ClientTypeOptions
 ) => {
+  const { v2ClientName, v2ClientTypeName, importType } = options;
+  const v2ClientLocalName =
+    importType === ImportType.IMPORT_EQUALS &&
+    options.v2ClientLocalName.endsWith(`.${DOCUMENT_CLIENT}`)
+      ? "lib_dynamodb"
+      : options.v2ClientLocalName;
+
   const v3ClientType = getV3ClientType(j, { v2ClientName, v2ClientTypeName, v2ClientLocalName });
 
   if (v2ClientType.parentPath?.value.type === "TSTypeQuery") {


### PR DESCRIPTION
### Issue

Refs: https://github.com/awslabs/aws-sdk-js-codemod/issues/601

### Description

Since import equals does not support named imports, we switched to using default imports for simplicity.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
