### PR TITLE
Remove transformation for types with type annotation

### DIFF
--- a/.changeset/strange-foxes-yawn.md
+++ b/.changeset/strange-foxes-yawn.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove transformation for types with type annotation

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -24,7 +24,7 @@ import {
   removeClientModule,
   removeGlobalModule,
 } from "./modules";
-import { replaceTSQualifiedName } from "./ts-type";
+import { replaceTSTypeReference } from "./ts-type";
 import { isTypeScriptFile } from "./utils";
 
 const transformer = async (file: FileInfo, api: API) => {
@@ -72,7 +72,7 @@ const transformer = async (file: FileInfo, api: API) => {
     const v3Options = { v3ClientName, v3ClientPackageName };
 
     addClientModules(j, source, { ...v2Options, ...v3Options, clientIdentifiers, importType });
-    replaceTSQualifiedName(j, source, { ...v2Options, v3ClientName });
+    replaceTSTypeReference(j, source, { ...v2Options, v3ClientName });
     removeClientModule(j, source, { ...v2Options, importType });
 
     if (v2ClientName === S3) {

--- a/src/transforms/v2-to-v3/ts-type/index.ts
+++ b/src/transforms/v2-to-v3/ts-type/index.ts
@@ -1,4 +1,4 @@
 export * from "./getClientTypeNames";
 export * from "./getV3ClientType";
 export * from "./getV3ClientTypes";
-export * from "./replaceTSQualifiedName";
+export * from "./replaceTSTypeReference";

--- a/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
@@ -18,8 +18,6 @@ const isRightSectionIdentifier = (node: TSTypeReference) =>
 const getRightIdentifierName = (node: TSTypeReference) =>
   ((node.typeName as TSQualifiedName).right as Identifier).name;
 
-const getIdentifierName = (node: TSTypeReference) => (node.typeName as Identifier).name;
-
 // Replace v2 client type reference with v3 client type reference.
 export const replaceTSTypeReference = (
   j: JSCodeshift,
@@ -85,7 +83,7 @@ export const replaceTSTypeReference = (
     source
       .find(j.TSTypeReference, { typeName: { type: "Identifier", name: clientTypeName } })
       .replaceWith((v2ClientType) => {
-        const v2ClientTypeName = getIdentifierName(v2ClientType.node);
+        const v2ClientTypeName = (v2ClientType.node.typeName as Identifier).name;
         return getV3ClientType(j, { ...clientTypeOptions, v2ClientTypeName });
       });
   }

--- a/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
+++ b/src/transforms/v2-to-v3/ts-type/replaceTSTypeReference.ts
@@ -1,29 +1,30 @@
-import { ASTPath, Collection, Identifier, JSCodeshift, TSQualifiedName } from "jscodeshift";
+import { Collection, Identifier, JSCodeshift, TSQualifiedName, TSTypeReference } from "jscodeshift";
 
 import { DOCUMENT_CLIENT, DYNAMODB, DYNAMODB_DOCUMENT_CLIENT } from "../config";
 import { getClientTypeNames } from "./getClientTypeNames";
 import { getTSQualifiedNameFromClientName } from "./getTSQualifiedNameFromClientName";
 import { getV3ClientType } from "./getV3ClientType";
 
-export interface ReplaceTSQualifiedNameOptions {
+export interface ReplaceTSTypeReferenceOptions {
   v2ClientName: string;
   v2ClientLocalName: string;
   v2GlobalName?: string;
   v3ClientName: string;
 }
 
-const isRightSectionIdentifier = (node: TSQualifiedName) => node.right.type === "Identifier";
+const isRightSectionIdentifier = (node: TSTypeReference) =>
+  (node.typeName as TSQualifiedName).right.type === "Identifier";
 
-const getRightIdentifierName = (node: TSQualifiedName) => (node.right as Identifier).name;
+const getRightIdentifierName = (node: TSTypeReference) =>
+  ((node.typeName as TSQualifiedName).right as Identifier).name;
 
-const isParentTSQualifiedName = (node: ASTPath<TSQualifiedName>) =>
-  node.parentPath?.value.type === "TSQualifiedName";
+const getIdentifierName = (node: TSTypeReference) => (node.typeName as Identifier).name;
 
 // Replace v2 client type reference with v3 client type reference.
-export const replaceTSQualifiedName = (
+export const replaceTSTypeReference = (
   j: JSCodeshift,
   source: Collection<unknown>,
-  options: ReplaceTSQualifiedNameOptions
+  options: ReplaceTSTypeReferenceOptions
 ): void => {
   const { v2ClientName, v2ClientLocalName, v2GlobalName, v3ClientName } = options;
   const clientTypeOptions = { v2ClientName, v2ClientLocalName };
@@ -31,19 +32,21 @@ export const replaceTSQualifiedName = (
   if (v2GlobalName) {
     // Replace type reference to client created with global name.
     source
-      .find(j.TSQualifiedName, getTSQualifiedNameFromClientName(v2GlobalName, v2ClientName))
-      .filter((v2ClientType) => !isParentTSQualifiedName(v2ClientType))
-      .replaceWith(() => j.tsTypeReference(j.identifier(v3ClientName)));
+      .find(j.TSTypeReference, {
+        typeName: getTSQualifiedNameFromClientName(v2GlobalName, v2ClientName),
+      })
+      .replaceWith((v2ClientType) =>
+        j.tsTypeReference(j.identifier(v3ClientName), v2ClientType.node.typeParameters)
+      );
 
     // Replace reference to client types created with global name.
     source
-      .find(j.TSQualifiedName, {
-        left: getTSQualifiedNameFromClientName(v2GlobalName, v2ClientName),
+      .find(j.TSTypeReference, {
+        typeName: {
+          left: getTSQualifiedNameFromClientName(v2GlobalName, v2ClientName),
+        },
       })
-      .filter(
-        (v2ClientType) =>
-          isRightSectionIdentifier(v2ClientType.node) && !isParentTSQualifiedName(v2ClientType)
-      )
+      .filter((v2ClientType) => isRightSectionIdentifier(v2ClientType.node))
       .replaceWith((v2ClientType) => {
         const v2ClientTypeName = getRightIdentifierName(v2ClientType.node);
         return getV3ClientType(j, { ...clientTypeOptions, v2ClientTypeName });
@@ -53,20 +56,19 @@ export const replaceTSQualifiedName = (
   const [clientNamePrefix, clientNameSuffix] = v2ClientLocalName.split(".");
   // Replace reference to client types created with client module.
   source
-    .find(j.TSQualifiedName, {
-      ...(clientNameSuffix
-        ? {
-            left: {
-              left: { type: "Identifier", name: clientNamePrefix },
-              right: { type: "Identifier", name: clientNameSuffix },
-            },
-          }
-        : { left: { type: "Identifier", name: clientNamePrefix } }),
+    .find(j.TSTypeReference, {
+      typeName: {
+        ...(clientNameSuffix
+          ? {
+              left: {
+                left: { type: "Identifier", name: clientNamePrefix },
+                right: { type: "Identifier", name: clientNameSuffix },
+              },
+            }
+          : { left: { type: "Identifier", name: clientNamePrefix } }),
+      },
     })
-    .filter(
-      (v2ClientType) =>
-        isRightSectionIdentifier(v2ClientType.node) && !isParentTSQualifiedName(v2ClientType)
-    )
+    .filter((v2ClientType) => isRightSectionIdentifier(v2ClientType.node))
     .replaceWith((v2ClientType) => {
       const v2ClientTypeName = getRightIdentifierName(v2ClientType.node);
       return getV3ClientType(j, { ...clientTypeOptions, v2ClientTypeName });
@@ -81,19 +83,15 @@ export const replaceTSQualifiedName = (
 
   for (const clientTypeName of clientTypeNames) {
     source
-      .find(j.Identifier, { name: clientTypeName })
-      .filter(
-        (v2ClientType) =>
-          !["TSQualifiedName", "ImportSpecifier"].includes(v2ClientType.parentPath?.value.type)
-      )
+      .find(j.TSTypeReference, { typeName: { type: "Identifier", name: clientTypeName } })
       .replaceWith((v2ClientType) => {
-        const v2ClientTypeName = v2ClientType.node.name;
+        const v2ClientTypeName = getIdentifierName(v2ClientType.node);
         return getV3ClientType(j, { ...clientTypeOptions, v2ClientTypeName });
       });
   }
 
   if (v2ClientName === DYNAMODB) {
-    replaceTSQualifiedName(j, source, {
+    replaceTSTypeReference(j, source, {
       ...options,
       v2ClientName: DYNAMODB_DOCUMENT_CLIENT,
       v2ClientLocalName: `${v2ClientLocalName}.${DOCUMENT_CLIENT}`,


### PR DESCRIPTION
### Issue

Reverts: https://github.com/awslabs/aws-sdk-js-codemod/pull/550
Not needed, as the invalid tests were removed in https://github.com/awslabs/aws-sdk-js-codemod/pull/607

### Description

Remove transformation for types with type annotation

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
