### PR TITLE
Rename constant PACKAGE_NAME to PACKAGE_NAME_V2

### DIFF
--- a/src/transforms/v2-to-v3/client-names/getClientNamesFromDeepImport.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesFromDeepImport.ts
@@ -1,6 +1,6 @@
-import { CLIENT_NAMES, PACKAGE_NAME } from "../config";
+import { CLIENT_NAMES, PACKAGE_NAME_V2 } from "../config";
 
-const DEEP_IMPORT_PATH_REGEXP = new RegExp(`${PACKAGE_NAME}/clients/([\\w]*)`, "g");
+const DEEP_IMPORT_PATH_REGEXP = new RegExp(`${PACKAGE_NAME_V2}/clients/([\\w]*)`, "g");
 
 export const getClientNamesFromDeepImport = (fileSource: string) => {
   const clientsFromDeepImportPath = new Set(

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromImport.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromImport.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, ImportSpecifier, JSCodeshift } from "jscodeshift";
 
-import { CLIENT_NAMES, PACKAGE_NAME } from "../config";
+import { CLIENT_NAMES, PACKAGE_NAME_V2 } from "../config";
 import { getImportEqualsDeclarationType, getImportSpecifiers } from "../modules";
 import { getClientDeepImportPath } from "../utils";
 
@@ -11,7 +11,7 @@ export const getClientNamesRecordFromImport = (
 ) => {
   const clientNamesRecord: Record<string, string> = {};
 
-  const specifiersFromNamedImport = getImportSpecifiers(j, source, PACKAGE_NAME).filter(
+  const specifiersFromNamedImport = getImportSpecifiers(j, source, PACKAGE_NAME_V2).filter(
     (specifier) => specifier?.type === "ImportSpecifier"
   ) as ImportSpecifier[];
 

--- a/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
+++ b/src/transforms/v2-to-v3/client-names/getClientNamesRecordFromRequire.ts
@@ -7,7 +7,7 @@ import {
   Property,
 } from "jscodeshift";
 
-import { CLIENT_NAMES, OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME } from "../config";
+import { CLIENT_NAMES, OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME_V2 } from "../config";
 import { getRequireDeclaratorsWithProperty } from "../modules";
 import { getClientDeepImportPath } from "../utils";
 import { getRequireIds } from "./getRequireIds";
@@ -19,7 +19,7 @@ export const getClientNamesRecordFromRequire = (
 ) => {
   const clientNamesRecord: Record<string, string> = {};
 
-  const idPropertiesFromObjectPattern = getRequireIds(j, source, PACKAGE_NAME)
+  const idPropertiesFromObjectPattern = getRequireIds(j, source, PACKAGE_NAME_V2)
     .filter((id) => id.type === "ObjectPattern")
     .map((objectPattern) => (objectPattern as ObjectPattern).properties)
     .flat();
@@ -39,7 +39,7 @@ export const getClientNamesRecordFromRequire = (
   }
 
   const declaratorsWithProperty = getRequireDeclaratorsWithProperty(j, source, {
-    sourceValue: PACKAGE_NAME,
+    sourceValue: PACKAGE_NAME_V2,
   }).nodes();
 
   for (const declaratorWithProperty of declaratorsWithProperty) {

--- a/src/transforms/v2-to-v3/config/constants.ts
+++ b/src/transforms/v2-to-v3/config/constants.ts
@@ -1,4 +1,4 @@
-export const PACKAGE_NAME = "aws-sdk";
+export const PACKAGE_NAME_V2 = "aws-sdk";
 
 export const S3 = "S3";
 export const DYNAMODB = "DynamoDB";

--- a/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
+++ b/src/transforms/v2-to-v3/modules/getGlobalNameFromModule.ts
@@ -1,6 +1,6 @@
 import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
+import { PACKAGE_NAME_V2 } from "../config";
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 import { getImportSpecifiers } from "./getImportSpecifiers";
 import { ImportType } from "./types";
@@ -17,7 +17,7 @@ export const getGlobalNameFromModule = (
         init: {
           type: "CallExpression",
           callee: { type: "Identifier", name: "require" },
-          arguments: [{ value: PACKAGE_NAME }],
+          arguments: [{ value: PACKAGE_NAME_V2 }],
         },
       })
       .nodes();
@@ -27,8 +27,9 @@ export const getGlobalNameFromModule = (
     }
   }
 
-  const importDefaultSpecifiers = getImportSpecifiers(j, source, PACKAGE_NAME).filter((specifier) =>
-    ["ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(specifier?.type as string)
+  const importDefaultSpecifiers = getImportSpecifiers(j, source, PACKAGE_NAME_V2).filter(
+    (specifier) =>
+      ["ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(specifier?.type as string)
   );
 
   if (importDefaultSpecifiers.length > 0) {
@@ -37,7 +38,7 @@ export const getGlobalNameFromModule = (
 
   const importEqualsDeclarations = source.find(
     j.TSImportEqualsDeclaration,
-    getImportEqualsDeclarationType(PACKAGE_NAME)
+    getImportEqualsDeclarationType(PACKAGE_NAME_V2)
   );
 
   if (importEqualsDeclarations.length > 0) {

--- a/src/transforms/v2-to-v3/modules/getImportDeclaration.ts
+++ b/src/transforms/v2-to-v3/modules/getImportDeclaration.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
+import { PACKAGE_NAME_V2 } from "../config";
 import { getClientDeepImportPath } from "../utils";
 
 export interface GetImportDeclarationOptions {
@@ -21,7 +21,7 @@ export const getImportDeclaration = (
     const sourceValue = importDeclaration.value.source.value as string;
 
     if (
-      sourceValue === PACKAGE_NAME &&
+      sourceValue === PACKAGE_NAME_V2 &&
       importDeclaration.value.specifiers?.some(
         (specifier) =>
           ["ImportNamespaceSpecifier", "ImportDefaultSpecifier"].includes(specifier.type) ||

--- a/src/transforms/v2-to-v3/modules/getImportEqualsDeclaration.ts
+++ b/src/transforms/v2-to-v3/modules/getImportEqualsDeclaration.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift, TSExternalModuleReference } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
+import { PACKAGE_NAME_V2 } from "../config";
 import { getClientDeepImportPath } from "../utils";
 import { getImportEqualsDeclarationType } from "./getImportEqualsDeclarationType";
 
@@ -27,7 +27,7 @@ export const getImportEqualsDeclaration = (
         .moduleReference as TSExternalModuleReference;
       const expressionValue = importEqualsModuleRef.expression.value;
 
-      if (expressionValue === PACKAGE_NAME && identifierName === options.v2GlobalName) {
+      if (expressionValue === PACKAGE_NAME_V2 && identifierName === options.v2GlobalName) {
         return true;
       }
 

--- a/src/transforms/v2-to-v3/modules/getRequireDeclarator.ts
+++ b/src/transforms/v2-to-v3/modules/getRequireDeclarator.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
+import { PACKAGE_NAME_V2 } from "../config";
 import { getClientDeepImportPath } from "../utils";
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";
 import { getRequireDeclaratorsWithObjectPattern } from "./getRequireDeclaratorsWithObjectPattern";
@@ -25,7 +25,7 @@ export const getRequireDeclarator = (
   if (v2GlobalName) {
     const requireDeclaratorsWithIdentifier = getRequireDeclaratorsWithIdentifier(j, source, {
       identifierName: v2GlobalName,
-      sourceValue: PACKAGE_NAME,
+      sourceValue: PACKAGE_NAME_V2,
     });
 
     if (requireDeclaratorsWithIdentifier.size() > 0) {
@@ -35,7 +35,7 @@ export const getRequireDeclarator = (
 
   const requireDeclaratorsWithObjectPattern = getRequireDeclaratorsWithObjectPattern(j, source, {
     identifierName: v2ClientLocalName,
-    sourceValue: PACKAGE_NAME,
+    sourceValue: PACKAGE_NAME_V2,
   });
 
   if (requireDeclaratorsWithObjectPattern.size() > 0) {
@@ -44,7 +44,7 @@ export const getRequireDeclarator = (
 
   const requireDeclaratorsWithProperty = getRequireDeclaratorsWithProperty(j, source, {
     identifierName: v2ClientName,
-    sourceValue: PACKAGE_NAME,
+    sourceValue: PACKAGE_NAME_V2,
   });
 
   if (requireDeclaratorsWithProperty.size() > 0) {

--- a/src/transforms/v2-to-v3/modules/removeClientModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeClientModule.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
+import { PACKAGE_NAME_V2 } from "../config";
 import { getClientTypeNames } from "../ts-type";
 import { getClientDeepImportPath } from "../utils";
 import { removeImportDefault } from "./removeImportDefault";
@@ -27,7 +27,7 @@ export const removeClientModule = (
   const deepImportPath = getClientDeepImportPath(v2ClientName);
 
   const defaultOptions = { localName: v2ClientLocalName, sourceValue: deepImportPath };
-  const namedOptions = { localName: v2ClientLocalName, sourceValue: PACKAGE_NAME };
+  const namedOptions = { localName: v2ClientLocalName, sourceValue: PACKAGE_NAME_V2 };
 
   if (importType === ImportType.REQUIRE) {
     removeRequireIdentifier(j, source, defaultOptions);

--- a/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
+++ b/src/transforms/v2-to-v3/modules/removeGlobalModule.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-import { PACKAGE_NAME } from "../config";
+import { PACKAGE_NAME_V2 } from "../config";
 import { removeImportDefault } from "./removeImportDefault";
 import { removeImportEquals } from "./removeImportEquals";
 import { removeRequireIdentifier } from "./removeRequireIdentifier";
@@ -23,7 +23,7 @@ export const removeGlobalModule = (
 
   // Only usage is import/require.
   if (identifierUsages.size() === 1) {
-    const defaultOptions = { localName: v2GlobalName, sourceValue: PACKAGE_NAME };
+    const defaultOptions = { localName: v2GlobalName, sourceValue: PACKAGE_NAME_V2 };
     if (importType === ImportType.REQUIRE) {
       removeRequireIdentifier(j, source, defaultOptions);
     } else if (importType === ImportType.IMPORT_EQUALS) {

--- a/src/transforms/v2-to-v3/utils/getClientDeepImportPath.ts
+++ b/src/transforms/v2-to-v3/utils/getClientDeepImportPath.ts
@@ -1,4 +1,4 @@
-import { PACKAGE_NAME } from "../config";
+import { PACKAGE_NAME_V2 } from "../config";
 
 export const getClientDeepImportPath = (v2ClientName: string) =>
-  `${PACKAGE_NAME}/clients/${v2ClientName.toLowerCase()}`;
+  `${PACKAGE_NAME_V2}/clients/${v2ClientName.toLowerCase()}`;


### PR DESCRIPTION
### Issue

Noticed in https://github.com/awslabs/aws-sdk-js-codemod/pull/622

### Description

Renames constant PACKAGE_NAME to PACKAGE_NAME_V2, to avoid confusion with generic packageName being introduced in https://github.com/awslabs/aws-sdk-js-codemod/pull/622

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
