### PR TITLE
Yarn use default value for enableGlobalCache

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,3 @@
-enableGlobalCache: false
-
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.0.0.cjs

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-sdk-js-codemod",
   "version": "0.24.0",
-  "description": "Collection of codemod scripts that help update AWS SDK for JavaScript APIs",
+  "description": "Test Collection of codemod scripts that help update AWS SDK for JavaScript APIs",
   "keywords": [
     "jscodeshift",
     "transform",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-sdk-js-codemod",
   "version": "0.24.0",
-  "description": "Test Collection of codemod scripts that help update AWS SDK for JavaScript APIs",
+  "description": "Collection of codemod scripts that help update AWS SDK for JavaScript APIs",
   "keywords": [
     "jscodeshift",
     "transform",


### PR DESCRIPTION
### Issue

The global cache was disabled while upgrading to yarn@4.0.0 https://github.com/awslabs/aws-sdk-js-codemod/pull/632, as it was the default in 3.x

### Description

Yarn use default value for enableGlobalCache

### Testing

#### Before

```console
$ yarn config cacheFolder
└─ cacheFolder
   ├─ Description: Folder where the cache files must be written
   ├─ Source: <default>
   └─ Value: '/Users/trivikram/workspace/aws-sdk-js-codemod/.yarn/cache'
```

#### After

```console
$ yarn config cacheFolder 
└─ cacheFolder
   ├─ Description: Folder where the cache files must be written
   ├─ Source: <internal>
   └─ Value: '/Users/trivikram/.yarn/berry/cache'
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
