### PR TITLE
Update GitHub build workflow actions to use node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
         node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

Update build workflow actions to use node 20
* https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400
* https://github.com/actions/setup-node/releases/tag/v4.0.0

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
