### PR TITLE
Check for StringLiteral type to handle requires in TypeScript code

### DIFF
--- a/.changeset/breezy-rice-stare.md
+++ b/.changeset/breezy-rice-stare.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Check for StringLiteral type to handle requires in TypeScript code

--- a/src/transforms/v2-to-v3/__fixtures__/misc/require.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/require.input.ts
@@ -1,0 +1,3 @@
+const AWS = require("aws-sdk");
+
+const client = new AWS.DynamoDB();

--- a/src/transforms/v2-to-v3/__fixtures__/misc/require.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/require.output.ts
@@ -1,0 +1,5 @@
+const {
+  DynamoDB
+} = require("@aws-sdk/client-dynamodb");
+
+const client = new DynamoDB();

--- a/src/transforms/v2-to-v3/config/constants.ts
+++ b/src/transforms/v2-to-v3/config/constants.ts
@@ -12,3 +12,4 @@ export const FUNCTION_TYPE_LIST = [
   "FunctionExpression",
   "ArrowFunctionExpression",
 ];
+export const STRING_LITERAL_TYPE_LIST = ["Literal", "StringLiteral"];

--- a/src/transforms/v2-to-v3/modules/hasRequire.ts
+++ b/src/transforms/v2-to-v3/modules/hasRequire.ts
@@ -1,4 +1,5 @@
-import { Collection, JSCodeshift } from "jscodeshift";
+import { Collection, JSCodeshift, Literal } from "jscodeshift";
+import { PACKAGE_NAME, STRING_LITERAL_TYPE_LIST } from "../config";
 
 export const hasRequire = (j: JSCodeshift, source: Collection<unknown>) =>
   source
@@ -7,11 +8,11 @@ export const hasRequire = (j: JSCodeshift, source: Collection<unknown>) =>
     })
     .filter((callExpression) => {
       const { arguments: args } = callExpression.value;
-      return (
-        args.length > 0 &&
-        (args[0].type === "Literal" || args[0].type === "StringLiteral") &&
-        typeof args[0].value === "string" &&
-        args[0].value.startsWith("aws-sdk")
-      );
+
+      if (args.length === 0) return false;
+      if (!STRING_LITERAL_TYPE_LIST.includes(args[0].type)) return false;
+
+      const value = (args[0] as Literal).value;
+      return typeof value === "string" && value.startsWith(PACKAGE_NAME);
     })
     .size() > 0;

--- a/src/transforms/v2-to-v3/modules/removeRequireIdentifier.ts
+++ b/src/transforms/v2-to-v3/modules/removeRequireIdentifier.ts
@@ -1,5 +1,6 @@
-import { Collection, Identifier, JSCodeshift, VariableDeclarator } from "jscodeshift";
+import { Collection, Identifier, JSCodeshift, Literal, VariableDeclarator } from "jscodeshift";
 
+import { STRING_LITERAL_TYPE_LIST } from "../config";
 import { getRequireDeclaratorsWithIdentifier } from "./getRequireDeclaratorsWithIdentifier";
 import { removeDeclaration } from "./removeDeclaration";
 
@@ -42,8 +43,8 @@ export const removeRequireIdentifier = (
         const args = init.arguments;
         if (!args) return true;
         if (args.length !== 1) return true;
-        if (args[0].type !== "Literal") return true;
-        if (args[0].value !== sourceValue) return true;
+        if (!STRING_LITERAL_TYPE_LIST.includes(args[0].type)) return true;
+        if ((args[0] as Literal).value !== sourceValue) return true;
 
         return false;
       }

--- a/src/transforms/v2-to-v3/modules/removeRequireProperty.ts
+++ b/src/transforms/v2-to-v3/modules/removeRequireProperty.ts
@@ -1,5 +1,6 @@
-import { Collection, Identifier, JSCodeshift, VariableDeclarator } from "jscodeshift";
+import { Collection, Identifier, JSCodeshift, Literal, VariableDeclarator } from "jscodeshift";
 
+import { STRING_LITERAL_TYPE_LIST } from "../config";
 import { getRequireDeclaratorsWithProperty } from "./getRequireDeclaratorsWithProperty";
 import { removeDeclaration } from "./removeDeclaration";
 
@@ -45,8 +46,8 @@ export const removeRequireProperty = (
 
         const args = object.arguments;
         if (args.length !== 1) return true;
-        if (args[0].type !== "Literal") return true;
-        if (args[0].value !== sourceValue) return true;
+        if (!STRING_LITERAL_TYPE_LIST.includes(args[0].type)) return true;
+        if ((args[0] as Literal).value !== sourceValue) return true;
 
         const property = init.property;
         if (property.type !== "Identifier") return true;

--- a/src/transforms/v2-to-v3/modules/requireModule/addNamedModule.ts
+++ b/src/transforms/v2-to-v3/modules/requireModule/addNamedModule.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift, ObjectPattern, ObjectProperty, Property } from "jscodeshift";
 
-import { OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME } from "../../config";
+import { OBJECT_PROPERTY_TYPE_LIST, PACKAGE_NAME, STRING_LITERAL_TYPE_LIST } from "../../config";
 import { getRequireDeclarators } from "../getRequireDeclarators";
 import { getRequireProperty } from "../getRequireProperty";
 import { objectPatternPropertyCompareFn } from "../objectPatternPropertyCompareFn";
@@ -75,7 +75,7 @@ export const addNamedModule = (
           const args = init.arguments;
           if (!args) return false;
           if (args.length !== 1) return false;
-          if (args[0].type !== "Literal") return false;
+          if (!STRING_LITERAL_TYPE_LIST.includes(args[0].type)) return true;
           if (typeof args[0].value !== "string") return false;
           if (!args[0].value.startsWith(PACKAGE_NAME)) return false;
 
@@ -93,7 +93,7 @@ export const addNamedModule = (
 
           const args = object.arguments;
           if (args.length !== 1) return false;
-          if (args[0].type !== "Literal") return false;
+          if (!STRING_LITERAL_TYPE_LIST.includes(args[0].type)) return true;
           if (args[0].value !== PACKAGE_NAME) return false;
 
           return true;


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/654

### Description

Add check for StringLiteral to handle requires in TypeScript code

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
