### PR TITLE
Replace TSTypeReference inside NewExpression

### DIFF
--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/new-expression.input.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/new-expression.input.ts
@@ -1,0 +1,3 @@
+import AWS from "aws-sdk";
+
+const arr = new Array<AWS.CloudFormation.StackResourceSummary>();

--- a/src/transforms/v2-to-v3/__fixtures__/api-basic-type/new-expression.output.ts
+++ b/src/transforms/v2-to-v3/__fixtures__/api-basic-type/new-expression.output.ts
@@ -1,0 +1,3 @@
+import { StackResourceSummary } from "@aws-sdk/client-cloudformation";
+
+const arr = new Array<StackResourceSummary>();


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/657

### Description

Replace TSTypeReference inside NewExpression

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
