### PR TITLE
Transform config credential keys

### DIFF
--- a/.changeset/itchy-pets-remain.md
+++ b/.changeset/itchy-pets-remain.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Transform config credential keys

--- a/src/transforms/v2-to-v3/__fixtures__/config/accessKeyId.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/config/accessKeyId.input.js
@@ -1,0 +1,6 @@
+import AWS from "aws-sdk";
+
+const client = new AWS.DynamoDB({
+  accessKeyId: "KEY",
+  secretAccessKey: "SECRET"
+});

--- a/src/transforms/v2-to-v3/__fixtures__/config/accessKeyId.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/config/accessKeyId.output.js
@@ -1,0 +1,8 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+
+const client = new DynamoDB({
+  credentials: {
+    accessKeyId: "KEY",
+    secretAccessKey: "SECRET"
+  }
+});

--- a/src/transforms/v2-to-v3/client-instances/replaceAwsConfig.ts
+++ b/src/transforms/v2-to-v3/client-instances/replaceAwsConfig.ts
@@ -12,14 +12,8 @@ export const replaceAwsConfig = (
     .find(j.NewExpression, {
       callee: {
         type: "MemberExpression",
-        object: {
-          type: "Identifier",
-          name: v2GlobalName,
-        },
-        property: {
-          type: "Identifier",
-          name: "Config",
-        },
+        object: { type: "Identifier", name: v2GlobalName },
+        property: { type: "Identifier", name: "Config" },
       },
     })
     .filter(


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/499

### Description

Transform config accessKeyId and secretAccessKey into credentials

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
