### PR TITLE
Add disclaimer in README and process warning

### DIFF
--- a/.changeset/two-oranges-bow.md
+++ b/.changeset/two-oranges-bow.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Add disclaimer in README and process warning

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ You can provide names of the custom transforms instead of a local path or url:
      v2-to-v3  Converts AWS SDK for JavaScript APIs in a Javascript/TypeScript
                codebase from version 2 (v2) to version 3 (v3).
 
+Please review the code change thoroughly for required functionality before deploying it to production.
+If the transformation is not complete or is incorrect, please report the issue on GitHub.
+
 ## Prerequisites
 
 To use aws-sdk-js-codemod, please install [Node.js][install-nodejs].

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,8 +63,13 @@ const { transform } = options;
 if (transforms.map(({ name }) => name).includes(transform)) {
   // ToDo: Move this warning only after files are transformed.
   console.warn(
-    `\nPlease review the code change thoroughly for required\nfunctionality before deploying it to production.\n\n` +
-      `If the transformation is not complete or is incorrect,\nplease report the issue on GitHub.\n`
+    `\n╔════════════════════════════════════════════════════════╗` +
+      `\n║ Please review the code change thoroughly for required  ║` +
+      `\n║ functionality before deploying it to production.       ║` +
+      `\n║                                                        ║` +
+      `\n║ If the transformation is not complete or is incorrect, ║` +
+      `\n║ please report the issue on GitHub.                     ║` +
+      `\n╚════════════════════════════════════════════════════════╝\n`
   );
   options.transform = getUpdatedTransformFile(transform);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,11 @@ try {
 
 const { transform } = options;
 if (transforms.map(({ name }) => name).includes(transform)) {
+  // ToDo: Move this warning only after files are transformed.
+  console.warn(
+    `\nPlease review the code change thoroughly for required\nfunctionality before deploying it to production.\n\n` +
+      `If the transformation is not complete or is incorrect,\nplease report the issue on GitHub.\n`
+  );
   options.transform = getUpdatedTransformFile(transform);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,10 @@ try {
 
 const { transform } = options;
 if (transforms.map(({ name }) => name).includes(transform)) {
-  console.warn(disclaimerLines.map((line) => `\n${line}`).join(""));
+  const supressDisclaimer = process.env.AWS_SDK_JS_CODEMOD_SUPRESS_WARNING;
+  if (!supressDisclaimer || !supressDisclaimer === "1") {
+    console.warn(disclaimerLines.map((line) => `\n${line}`).join(""));
+  }
   options.transform = getUpdatedTransformFile(transform);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,17 @@ if (args[2] === "--help" || args[2] === "-h") {
   process.stdout.write(getHelpParagraph(transforms));
 }
 
+const disclaimerLines = [
+  `╔════════════════════════════════════════════════════════╗`,
+  `║ Please review the code change thoroughly for required  ║`,
+  `║ functionality before deploying it to production.       ║`,
+  `║                                                        ║`,
+  `║ If the transformation is not complete or is incorrect, ║`,
+  `║ please report the issue on GitHub.                     ║`,
+  `╚════════════════════════════════════════════════════════╝`,
+  ``,
+];
+
 const parser = getJsCodeshiftParser();
 
 let options, positionalArguments;
@@ -61,16 +72,7 @@ try {
 
 const { transform } = options;
 if (transforms.map(({ name }) => name).includes(transform)) {
-  // ToDo: Move this warning only after files are transformed.
-  console.warn(
-    `\n╔════════════════════════════════════════════════════════╗` +
-      `\n║ Please review the code change thoroughly for required  ║` +
-      `\n║ functionality before deploying it to production.       ║` +
-      `\n║                                                        ║` +
-      `\n║ If the transformation is not complete or is incorrect, ║` +
-      `\n║ please report the issue on GitHub.                     ║` +
-      `\n╚════════════════════════════════════════════════════════╝\n`
-  );
+  console.warn(disclaimerLines.map((line) => `\n${line}`).join(""));
   options.transform = getUpdatedTransformFile(transform);
 }
 


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/676

### Description

Adds disclaimer in README and process warning

### Testing

The disclaimer is emitted at when codemod is run:
```console
$ ./bin/aws-sdk-js-codemod -t v2-to-v3 ../test/example.ts 

╔════════════════════════════════════════════════════════╗
║ Please review the code change thoroughly for required  ║
║ functionality before deploying it to production.       ║
║                                                        ║
║ If the transformation is not complete or is incorrect, ║
║ please report the issue on GitHub.                     ║
╚════════════════════════════════════════════════════════╝

Processing 1 files... 
Spawning 1 workers...
Sending 1 files to free worker...
All done. 
Results: 
0 errors
1 unmodified
0 skipped
0 ok
Time elapsed: 0.229seconds
```

Warning is suppressed if `AWS_SDK_JS_CODEMOD_SUPRESS_WARNING` is set.

```console
$ AWS_SDK_JS_CODEMOD_SUPRESS_WARNING=1 ./bin/aws-sdk-js-codemod -t v2-to-v3 ../test/example.ts
Processing 1 files... 
Spawning 1 workers...
Sending 1 files to free worker...
All done. 
Results: 
0 errors
1 unmodified
0 skipped
0 ok
Time elapsed: 0.203seconds
```

Skipping the following as the option is not available in JSCodeShift:
* move disclaimer at the end of the transformation
* emit disclaimer only if there are transformations


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
