### PR TITLE
Mark Config apiVersion as deprecated

### DIFF
--- a/.changeset/five-peas-whisper.md
+++ b/.changeset/five-peas-whisper.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Mark Config apiVersion as deprecated

--- a/src/transforms/v2-to-v3/__fixtures__/config/apiVersion.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/config/apiVersion.input.js
@@ -1,0 +1,5 @@
+import AWS from "aws-sdk";
+
+const config = new AWS.Config({
+  apiVersion: "2012-08-10"
+});

--- a/src/transforms/v2-to-v3/__fixtures__/config/apiVersion.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/config/apiVersion.output.js
@@ -1,0 +1,5 @@
+const config = {
+  // The key apiVersion is no longer supported in v3, and can be removed.
+  // @deprecated The client uses the "latest" apiVersion.
+  apiVersion: "2012-08-10"
+};

--- a/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
+++ b/src/transforms/v2-to-v3/config/AWS_CONFIG_KEY_MAP.ts
@@ -8,6 +8,9 @@ export interface AwsConfigKeyStatus {
  * Maps the AWS config keys with their equivalent replacement in v3.
  */
 export const AWS_CONFIG_KEY_MAP: Record<string, AwsConfigKeyStatus> = {
+  apiVersion: {
+    deprecationMessage: `The client uses the "latest" apiVersion.`,
+  },
   computeChecksums: {
     deprecationMessage: "Applicable commands of S3 will automatically compute the MD5 checksums.",
   },


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/685

### Description

Mark Config apiVersion as deprecated

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
