### PR TITLE
Use formatting conventions of tabs or spaces from input code

### DIFF
--- a/.changeset/wicked-lions-happen.md
+++ b/.changeset/wicked-lions-happen.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Use formatting conventions of tabs or spaces from input code

--- a/src/transforms/v2-to-v3/__fixtures__/misc/tabs.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/tabs.input.js
@@ -1,0 +1,7 @@
+import AWS from "aws-sdk";
+
+// Client creation with tabs instead of spaces for indentation.
+const client = new AWS.DynamoDB({
+	accessKeyId: "KEY",
+	secretAccessKey: "SECRET"
+});

--- a/src/transforms/v2-to-v3/__fixtures__/misc/tabs.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/tabs.output.js
@@ -1,0 +1,9 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+
+// Client creation with tabs instead of spaces for indentation.
+const client = new DynamoDB({
+	credentials: {
+		accessKeyId: "KEY",
+		secretAccessKey: "SECRET"
+	}
+});

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -31,7 +31,12 @@ import {
   removeGlobalModule,
 } from "./modules";
 import { replaceTSTypeReference } from "./ts-type";
-import { getMostUsedStringLiteralQuote, isTypeScriptFile } from "./utils";
+import {
+  IndentationType,
+  getMostUsedIndentationType,
+  getMostUsedStringLiteralQuote,
+  isTypeScriptFile,
+} from "./utils";
 
 const transformer = async (file: FileInfo, api: API) => {
   const j = isTypeScriptFile(file.path) ? api.jscodeshift.withParser("ts") : api.jscodeshift;
@@ -72,6 +77,7 @@ const transformer = async (file: FileInfo, api: API) => {
 
   // Compute recast options before doing transformations
   const quote = getMostUsedStringLiteralQuote(j, source);
+  const useTabs = getMostUsedIndentationType(file.source) === IndentationType.TAB;
 
   const awsGlobalConfig = getAwsGlobalConfig(j, source, v2GlobalName);
   for (const [v2ClientName, v3ClientMetadata] of Object.entries(clientMetadataRecord)) {
@@ -106,7 +112,7 @@ const transformer = async (file: FileInfo, api: API) => {
   replaceAwsUtilFunctions(j, source, v2GlobalName);
   removeGlobalModule(j, source, v2GlobalName);
 
-  return source.toSource({ quote });
+  return source.toSource({ quote, useTabs });
 };
 
 export default transformer;

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -112,7 +112,14 @@ const transformer = async (file: FileInfo, api: API) => {
   replaceAwsUtilFunctions(j, source, v2GlobalName);
   removeGlobalModule(j, source, v2GlobalName);
 
-  return source.toSource({ quote, useTabs });
+  const sourceString = source.toSource({ quote, useTabs });
+
+  if (useTabs) {
+    // Refs: https://github.com/benjamn/recast/issues/315
+    return sourceString.replace(/ {4,}/g, "\t");
+  }
+
+  return sourceString;
 };
 
 export default transformer;

--- a/src/transforms/v2-to-v3/utils/getMostUsedIndentationType.ts
+++ b/src/transforms/v2-to-v3/utils/getMostUsedIndentationType.ts
@@ -1,0 +1,15 @@
+export enum IndentationType {
+  TAB = "tab",
+  SPACE = "space",
+}
+
+export const getMostUsedIndentationType = (source: string) => {
+  const tabCount = (source.match(/\t/g) || []).length;
+  const spaceCount = (source.match(/ {2}/g) || []).length;
+  console.log({ tabCount, spaceCount });
+
+  if (tabCount > spaceCount) {
+    return IndentationType.TAB;
+  }
+  return IndentationType.SPACE;
+};

--- a/src/transforms/v2-to-v3/utils/index.ts
+++ b/src/transforms/v2-to-v3/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./getClientDeepImportPath";
 export * from "./getClientNewExpression";
 export * from "./getMostUsedStringLiteralQuote";
+export * from "./getMostUsedIndentationType";
 export * from "./isTypeScriptFile";


### PR DESCRIPTION
### Issue

Fixes: https://github.com/awslabs/aws-sdk-js-codemod/issues/708

### Description

Use formatting conventions of tabs or spaces from input code

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
