### PR TITLE
Replace only spaces starting after newline to tabs

### DIFF
--- a/src/transforms/v2-to-v3/__fixtures__/misc/tabs.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/tabs.input.js
@@ -6,4 +6,5 @@ const client = new AWS.DynamoDB({
 	secretAccessKey: "SECRET"
 });
 
+// Spaces inside string should not be replaced.
 const stringWithFourSpaces = "    ";

--- a/src/transforms/v2-to-v3/__fixtures__/misc/tabs.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/tabs.input.js
@@ -5,3 +5,5 @@ const client = new AWS.DynamoDB({
 	accessKeyId: "KEY",
 	secretAccessKey: "SECRET"
 });
+
+const stringWithFourSpaces = "    ";

--- a/src/transforms/v2-to-v3/__fixtures__/misc/tabs.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/tabs.output.js
@@ -7,3 +7,5 @@ const client = new DynamoDB({
 		secretAccessKey: "SECRET"
 	}
 });
+
+const stringWithFourSpaces = "    ";

--- a/src/transforms/v2-to-v3/__fixtures__/misc/tabs.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/tabs.output.js
@@ -8,4 +8,5 @@ const client = new DynamoDB({
 	}
 });
 
+// Spaces inside string should not be replaced.
 const stringWithFourSpaces = "    ";

--- a/src/transforms/v2-to-v3/transformer.ts
+++ b/src/transforms/v2-to-v3/transformer.ts
@@ -35,6 +35,7 @@ import {
   IndentationType,
   getMostUsedIndentationType,
   getMostUsedStringLiteralQuote,
+  getValueIndentedWithTabs,
   isTypeScriptFile,
 } from "./utils";
 
@@ -116,7 +117,7 @@ const transformer = async (file: FileInfo, api: API) => {
 
   if (useTabs) {
     // Refs: https://github.com/benjamn/recast/issues/315
-    return sourceString.replace(/ {4,}/g, "\t");
+    return getValueIndentedWithTabs(sourceString);
   }
 
   return sourceString;

--- a/src/transforms/v2-to-v3/utils/getMostUsedIndentationType.ts
+++ b/src/transforms/v2-to-v3/utils/getMostUsedIndentationType.ts
@@ -4,9 +4,8 @@ export enum IndentationType {
 }
 
 export const getMostUsedIndentationType = (source: string) => {
-  const tabCount = (source.match(/\t/g) || []).length;
-  const spaceCount = (source.match(/ {2}/g) || []).length;
-  console.log({ tabCount, spaceCount });
+  const tabCount = (source.match(/\n\t/g) || []).length;
+  const spaceCount = (source.match(/\n {2}/g) || []).length;
 
   if (tabCount > spaceCount) {
     return IndentationType.TAB;

--- a/src/transforms/v2-to-v3/utils/getMostUsedIndentationType.ts
+++ b/src/transforms/v2-to-v3/utils/getMostUsedIndentationType.ts
@@ -1,11 +1,21 @@
+import { EOL } from "os";
+
 export enum IndentationType {
   TAB = "tab",
   SPACE = "space",
 }
 
 export const getMostUsedIndentationType = (source: string) => {
-  const tabCount = (source.match(/\n\t/g) || []).length;
-  const spaceCount = (source.match(/\n {2}/g) || []).length;
+  let tabCount = 0;
+  let spaceCount = 0;
+
+  for (const line of source.split(EOL)) {
+    if (line.startsWith(" ")) {
+      spaceCount++;
+    } else if (line.startsWith("\t")) {
+      tabCount++;
+    }
+  }
 
   if (tabCount > spaceCount) {
     return IndentationType.TAB;

--- a/src/transforms/v2-to-v3/utils/getValueIndentedWithTabs.ts
+++ b/src/transforms/v2-to-v3/utils/getValueIndentedWithTabs.ts
@@ -1,0 +1,21 @@
+import { EOL } from "os";
+
+const INDENTATION_REGEX = /^(\t*)( {4})/;
+
+export const getValueIndentedWithTabs = (value: string) => {
+  const lines: string[] = [];
+
+  for (const line of value.split(EOL)) {
+    const match = line.match(INDENTATION_REGEX);
+    if (match) {
+      const numberOfTabs = match[1].length;
+      const numberOfSpaces = match[2].length;
+      const numberOfIndents = numberOfTabs + numberOfSpaces / 4;
+      lines.push("\t".repeat(numberOfIndents) + line.trimLeft());
+    } else {
+      lines.push(line);
+    }
+  }
+
+  return lines.join(EOL);
+};

--- a/src/transforms/v2-to-v3/utils/index.ts
+++ b/src/transforms/v2-to-v3/utils/index.ts
@@ -2,4 +2,5 @@ export * from "./getClientDeepImportPath";
 export * from "./getClientNewExpression";
 export * from "./getMostUsedStringLiteralQuote";
 export * from "./getMostUsedIndentationType";
+export * from "./getValueIndentedWithTabs";
 export * from "./isTypeScriptFile";


### PR DESCRIPTION
### Issue

Edge cases for https://github.com/awslabs/aws-sdk-js-codemod/pull/710

### Description

Replaces only spaces starting after newline to tabs

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
