### PR TITLE
Remove extra newlines between v3 require declarations

### DIFF
--- a/.changeset/empty-beers-appear.md
+++ b/.changeset/empty-beers-appear.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove extra newlines between v3 require declarations

--- a/scripts/generateNewClientTests/getGlobalRequireOutput.ts
+++ b/scripts/generateNewClientTests/getGlobalRequireOutput.ts
@@ -7,6 +7,7 @@ export const getGlobalRequireOutput = () => {
   let content = `\n\n`;
 
   content += getV3PackageRequiresCode(getClientNamesSortedByPackageName(CLIENTS_TO_TEST));
+  content += `\n`;
   content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
   return content;

--- a/scripts/generateNewClientTests/getServiceRequireDeepOutput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireDeepOutput.ts
@@ -7,6 +7,7 @@ export const getServiceRequireDeepOutput = () => {
   let content = `\n\n`;
 
   content += getV3PackageRequiresCode(getClientNamesSortedByPackageName(CLIENTS_TO_TEST));
+  content += `\n`;
   content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST);
 
   return content;

--- a/scripts/generateNewClientTests/getServiceRequireDeepWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireDeepWithNameOutput.ts
@@ -10,6 +10,7 @@ export const getServiceRequireDeepWithNameOutput = () => {
   content += getV3PackageRequiresCode(getClientNamesSortedByPackageName(CLIENTS_TO_TEST), {
     useLocalSuffix: true,
   });
+  content += `\n`;
   content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
 
   return content;

--- a/scripts/generateNewClientTests/getServiceRequireWithNameOutput.ts
+++ b/scripts/generateNewClientTests/getServiceRequireWithNameOutput.ts
@@ -10,6 +10,7 @@ export const getServiceRequireWithNameOutput = () => {
   content += getV3PackageRequiresCode(getClientNamesSortedByPackageName(CLIENTS_TO_TEST), {
     useLocalSuffix: true,
   });
+  content += `\n`;
   content += getV3ClientsNewExpressionCode(CLIENTS_TO_TEST.map(getClientNameWithLocalSuffix));
 
   return content;

--- a/scripts/generateNewClientTests/getV3PackageRequiresCode.ts
+++ b/scripts/generateNewClientTests/getV3PackageRequiresCode.ts
@@ -27,7 +27,7 @@ export const getV3PackageRequiresCode = (
       v2ClientName === v2ClientLocalName
         ? ` ${v3ClientName} `
         : `\n  ${v3ClientName}: ${v2ClientLocalName}\n`;
-    content += `const {${v3RequireKeyValuePair}} = require("${v3ClientPackageName}");\n\n`;
+    content += `const {${v3RequireKeyValuePair}} = require("${v3ClientPackageName}");\n`;
   }
 
   return content;

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/global-require.output.js
@@ -1,5 +1,4 @@
 const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
-
 const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 
 const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep-with-name.output.js
@@ -1,5 +1,4 @@
 const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
-
 const {
   DynamoDB: DynamoDBClient
 } = require("@aws-sdk/client-dynamodb");

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-deep.output.js
@@ -1,5 +1,4 @@
 const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
-
 const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 
 const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require-with-name.output.js
@@ -1,5 +1,4 @@
 const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
-
 const {
   DynamoDB: DynamoDBClient
 } = require("@aws-sdk/client-dynamodb");

--- a/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/ddb-doc-client/service-require.output.js
@@ -1,5 +1,4 @@
 const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
-
 const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 
 const documentClient = DynamoDBDocument.from(new DynamoDB({ region: "us-west-2" }));

--- a/src/transforms/v2-to-v3/__fixtures__/misc/multiple-declarators.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/multiple-declarators.output.js
@@ -1,5 +1,4 @@
 const { ApplicationDiscoveryService } = require("@aws-sdk/client-application-discovery-service");
-
 const { DynamoDB } = require("@aws-sdk/client-dynamodb");
 
 const ddbClient = new DynamoDB(),

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/global-require-property-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/global-require-property-with-name.output.js
@@ -5,11 +5,9 @@
 const {
   AccessAnalyzer: AccessAnalyzerClient
 } = require("@aws-sdk/client-accessanalyzer");
-
 const {
   ACM: ACMClient
 } = require("@aws-sdk/client-acm");
-
 const {
   ApplicationDiscoveryService: DiscoveryClient
 } = require("@aws-sdk/client-application-discovery-service");

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/global-require-property.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/global-require-property.output.js
@@ -3,9 +3,7 @@
 
 
 const { AccessAnalyzer } = require("@aws-sdk/client-accessanalyzer");
-
 const { ACM } = require("@aws-sdk/client-acm");
-
 const { ApplicationDiscoveryService } = require("@aws-sdk/client-application-discovery-service");
 
 new AccessAnalyzer();

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/global-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/global-require.output.js
@@ -3,9 +3,7 @@
 
 
 const { AccessAnalyzer } = require("@aws-sdk/client-accessanalyzer");
-
 const { ACM } = require("@aws-sdk/client-acm");
-
 const { ApplicationDiscoveryService } = require("@aws-sdk/client-application-discovery-service");
 
 new AccessAnalyzer();

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/service-require-deep-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/service-require-deep-with-name.output.js
@@ -5,11 +5,9 @@
 const {
   AccessAnalyzer: AccessAnalyzerClient
 } = require("@aws-sdk/client-accessanalyzer");
-
 const {
   ACM: ACMClient
 } = require("@aws-sdk/client-acm");
-
 const {
   ApplicationDiscoveryService: DiscoveryClient
 } = require("@aws-sdk/client-application-discovery-service");

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/service-require-deep.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/service-require-deep.output.js
@@ -3,9 +3,7 @@
 
 
 const { AccessAnalyzer } = require("@aws-sdk/client-accessanalyzer");
-
 const { ACM } = require("@aws-sdk/client-acm");
-
 const { ApplicationDiscoveryService } = require("@aws-sdk/client-application-discovery-service");
 
 new AccessAnalyzer();

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/service-require-with-name.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/service-require-with-name.output.js
@@ -5,11 +5,9 @@
 const {
   AccessAnalyzer: AccessAnalyzerClient
 } = require("@aws-sdk/client-accessanalyzer");
-
 const {
   ACM: ACMClient
 } = require("@aws-sdk/client-acm");
-
 const {
   ApplicationDiscoveryService: DiscoveryClient
 } = require("@aws-sdk/client-application-discovery-service");

--- a/src/transforms/v2-to-v3/__fixtures__/new-client/service-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/new-client/service-require.output.js
@@ -3,9 +3,7 @@
 
 
 const { AccessAnalyzer } = require("@aws-sdk/client-accessanalyzer");
-
 const { ACM } = require("@aws-sdk/client-acm");
-
 const { ApplicationDiscoveryService } = require("@aws-sdk/client-application-discovery-service");
 
 new AccessAnalyzer();

--- a/src/transforms/v2-to-v3/__fixtures__/s3-get-signed-url/getObject.require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-get-signed-url/getObject.require.output.js
@@ -1,5 +1,4 @@
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
-
 const { GetObjectCommand, S3 } = require("@aws-sdk/client-s3");
 
 const s3 = new S3();

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/global-require-property.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/global-require-property.output.js
@@ -1,5 +1,4 @@
 const { Upload } = require("@aws-sdk/lib-storage");
-
 const { S3 } = require("@aws-sdk/client-s3");
 
 const client = new S3();

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/global-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/global-require.output.js
@@ -1,5 +1,4 @@
 const { Upload } = require("@aws-sdk/lib-storage");
-
 const { S3 } = require("@aws-sdk/client-s3");
 
 const client = new S3();

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/service-require-deep.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/service-require-deep.output.js
@@ -1,5 +1,4 @@
 const { Upload } = require("@aws-sdk/lib-storage");
-
 const { S3 } = require("@aws-sdk/client-s3");
 
 const client = new S3();

--- a/src/transforms/v2-to-v3/__fixtures__/s3-upload/service-require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/s3-upload/service-require.output.js
@@ -1,5 +1,4 @@
 const { Upload } = require("@aws-sdk/lib-storage");
-
 const { S3 } = require("@aws-sdk/client-s3");
 
 const client = new S3();

--- a/src/transforms/v2-to-v3/utils/getFormattedSourceString.ts
+++ b/src/transforms/v2-to-v3/utils/getFormattedSourceString.ts
@@ -3,9 +3,14 @@
  */
 export const getFormattedSourceString = (source: string) =>
   source
-    // Remove newlines from ObjectPattern requires.
+    // Remove newlines from ObjectPattern require declarations.
     .replace(
       /\{\n {2}([\w,\n ]+)\n\} = require\((['"])@aws-sdk/g,
       (_, identifiers, quote) =>
         `{ ${identifiers.split(",\n  ").join(", ")} } = require(${quote}@aws-sdk`
+    )
+    // Remove extra newlines between require declarations.
+    .replace(
+      /@aws-sdk\/([\w-]+)(['"])\);\n\nconst \{/g,
+      (_, packageName, quote) => `@aws-sdk/${packageName}${quote});\nconst {`
     );


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/awslabs/aws-sdk-js-codemod/pull/717

### Description

Remove extra newlines between v3 require declarations

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
