### PR TITLE
Remove trailing comma from ObjectProperty require

### DIFF
--- a/.changeset/pretty-tips-cry.md
+++ b/.changeset/pretty-tips-cry.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Remove trailing comma from ObjectProperty require

--- a/src/transforms/v2-to-v3/__fixtures__/misc/trailing-comma.require.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/trailing-comma.require.input.js
@@ -1,0 +1,5 @@
+const AWS = require("aws-sdk");
+
+const client = new AWS.DynamoDB({
+  region: "us-west-2",
+});

--- a/src/transforms/v2-to-v3/__fixtures__/misc/trailing-comma.require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/trailing-comma.require.output.js
@@ -1,0 +1,5 @@
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+
+const client = new DynamoDB({
+  region: "us-west-2",
+});

--- a/src/transforms/v2-to-v3/utils/getFormattedSourceString.ts
+++ b/src/transforms/v2-to-v3/utils/getFormattedSourceString.ts
@@ -7,7 +7,11 @@ export const getFormattedSourceString = (source: string) =>
     .replace(
       /\{\n {2}([\w,\n ]+)\n\} = require\((['"])@aws-sdk/g,
       (_, identifiers, quote) =>
-        `{ ${identifiers.split(",\n  ").join(", ")} } = require(${quote}@aws-sdk`
+        `{ ${identifiers
+          .split(",")
+          .map((str: string) => str.trimLeft())
+          .filter((str: string) => str !== "")
+          .join(", ")} } = require(${quote}@aws-sdk`
     )
     // Remove extra newlines between require declarations.
     .replace(


### PR DESCRIPTION
### Issue

Missed in https://github.com/awslabs/aws-sdk-js-codemod/pull/717

### Description

Remove trailing comma from ObjectProperty require

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
