### PR TITLE
Check for raw string in extra.raw when searching for quotes

### DIFF
--- a/.changeset/happy-seahorses-buy.md
+++ b/.changeset/happy-seahorses-buy.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Check for raw string in extra.raw when searching for quotes

--- a/src/transforms/v2-to-v3/__fixtures__/misc/single-quote.require.input.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/single-quote.require.input.js
@@ -1,0 +1,3 @@
+const AWS = require('aws-sdk');
+
+const client = new AWS.DynamoDB();

--- a/src/transforms/v2-to-v3/__fixtures__/misc/single-quote.require.output.js
+++ b/src/transforms/v2-to-v3/__fixtures__/misc/single-quote.require.output.js
@@ -1,0 +1,3 @@
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
+const client = new DynamoDB();

--- a/src/transforms/v2-to-v3/utils/getMostUsedStringLiteralQuote.ts
+++ b/src/transforms/v2-to-v3/utils/getMostUsedStringLiteralQuote.ts
@@ -21,7 +21,7 @@ export const getMostUsedStringLiteralQuote = (
     if (typeof value === "string") {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore Property 'raw' does not exist on type 'Literal'.
-      const rawValue = path.node.raw || "";
+      const rawValue = path.node.raw || path.node.extra?.raw || "";
       if (rawValue.startsWith("'")) {
         quoteCount[StringLiteralQuoteType.SINGLE]++;
       } else if (rawValue.startsWith('"')) {


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/awslabs/aws-sdk-js-codemod/pull/705

I couldn't create a repro, but discovered raw value in `extra.raw` when testing single quotes in
https://github.com/handlebars-lang/handlebars.js/pull/2020

### Description

Check for raw string in extra.raw when searching for quotes

### Testing

Verified in https://github.com/handlebars-lang/handlebars.js/pull/2020

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
