### PR TITLE
chore(deps-dev): bump TypeScript to 5.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prettier": "3.0.3",
     "simple-git-hooks": "^2.8.1",
     "tsx": "^3.12.1",
-    "typescript": "~5.2.2",
+    "typescript": "~5.3.2",
     "vitest": "~0.34.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,7 +1929,7 @@ __metadata:
     prettier: "npm:3.0.3"
     simple-git-hooks: "npm:^2.8.1"
     tsx: "npm:^3.12.1"
-    typescript: "npm:~5.2.2"
+    typescript: "npm:~5.3.2"
     vitest: "npm:~0.34.1"
   bin:
     aws-sdk-js-codemod: bin/aws-sdk-js-codemod
@@ -6238,23 +6238,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.2.2":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
+"typescript@npm:~5.3.2":
+  version: 5.3.2
+  resolution: "typescript@npm:5.3.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 91ae3e6193d0ddb8656d4c418a033f0f75dec5e077ebbc2bd6d76439b93f35683936ee1bdc0e9cf94ec76863aa49f27159b5788219b50e1cd0cd6d110aa34b07
+  checksum: d7dbe1fbe19039e36a65468ea64b5d338c976550394ba576b7af9c68ed40c0bc5d12ecce390e4b94b287a09a71bd3229f19c2d5680611f35b7c53a3898791159
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.2.2#optional!builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#optional!builtin<compat/typescript>::version=5.2.2&hash=f3b441"
+"typescript@patch:typescript@npm%3A~5.3.2#optional!builtin<compat/typescript>":
+  version: 5.3.2
+  resolution: "typescript@patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 062c1cee1990e6b9419ce8a55162b8dc917eb87f807e4de0327dbc1c2fa4e5f61bc0dd4e034d38ff541d1ed0479b53bcee8e4de3a4075c51a1724eb6216cb6f5
+  checksum: 73c8bad74e732d93211c9d77f28b03307e2f5fc6a0afc73f4b783261ab567686a16d6ae958bdaef383a00be1b0b8c8b6741dd6ca3d13af4963fa7e47456d49c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Refs: https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/

### Description

Bump TypeScript to 5.3.x

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
