### PR TITLE
Enable secrets scanning with TruffleHog in CI

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,17 @@
+name: scan
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  scan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Issue

* Internal V1146711610
* Instructions https://github.com/trufflesecurity/trufflehog#octocat-trufflehog-github-action

### Description

Enable secrets scanning with TruffleHog in CI

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
