### PR TITLE
Rename scan to secrets_scan

### DIFF
--- a/.github/workflows/secrets_scan.yml
+++ b/.github/workflows/secrets_scan.yml
@@ -1,11 +1,11 @@
-name: scan
+name: secrets_scan
 
 on:
   pull_request:
     branches: [main]
 
 jobs:
-  scan:
+  trufflehog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Issue

We now have security scan in https://github.com/awslabs/aws-sdk-js-codemod/pull/744

### Description

Rename scan to secrets_scan

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
