### PR TITLE
chore(deps-dev): bump yarn to 4.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "devEngines": {
     "packageManager": {
       "name": "yarn",
-      "version": "4.8.0",
+      "version": "4.9.2",
       "onFail": "download"
     }
   },


### PR DESCRIPTION
### Issue

https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.9.2

### Description

Bumps yarn to 4.9.2

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
