### PR TITLE
fix(ci): pass --trust-local-git-config to trufflehog

### DIFF
--- a/.github/workflows/secrets_scan.yml
+++ b/.github/workflows/secrets_scan.yml
@@ -13,4 +13,5 @@ jobs:
           fetch-depth: 0
       - uses: trufflesecurity/trufflehog@main
         with:
+          extra_args: --trust-local-git-config
           base: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
### Issue

https://github.com/trufflesecurity/trufflehog/issues/4540#issuecomment-3542996600

### Description

Pass --trust-local-git-config to trufflehog to fix "error preparing repo"

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
